### PR TITLE
Introduce enumerators and iterators of digraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Markus Pfeiffer as new authors.
 * The operation `ChromaticNumber` is introduced. [[James D. Mitchell](http://goo.gl/ZtViV6) and [Wilf A. Wilson](https://wilf.me)]
 * The operations `IsDirectedTree` and `IsUndirectedTree` are introduced. [Luke Elliott]
 * The operation `IsEulerianDigraph`is introduced. [Luke Elliott]
+* The functions `EnumeratorOfDigraphs` and `IteratorOfDigraphs` are
+  introduced, along with helper functions `DigraphNumber` and
+  `NumberDigraph`. [[Michael Torpey](http://www-circa.mcs.st-and.ac.uk/~mct25)]
 	
 ## Version 0.5.2 (released 20/06/2016)
 This is a minor release containing one bugfix and several other minor changes.

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -1152,3 +1152,38 @@ gap> NumberDigraph(gr:v);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="EnumeratorOfDigraphs">
+<ManSection>
+  <Func Name="EnumeratorOfDigraphs" Arg="[nr_vertices]"/>
+  <Returns>An enumerator.</Returns>
+  <Description>
+    This function returns an enumerator containing all digraphs without multiple
+    edges.  This enumerator can be used in exactly the same way as a list of
+    digraphs; the only difference is that the entries are not stored in memory,
+    but are created on demand using <Ref Oper="DigraphNumber"/>
+    and <Ref Oper="NumberDigraph" Label="for a digraph"/>. <P/>
+
+    If the optional argument <A>nr_vertices</A> is specified and is a
+    non-negative integer, then the enumerator will only contain digraphs with
+    this number of vertices. <P/>
+
+    See also <Ref Func="IteratorOfDigraphs"/>. <P/>
+
+    <Example><![CDATA[
+gap> digraphs := EnumeratorOfDigraphs();
+<enumerator of digraphs>
+gap> digraphs[30];
+<digraph with 3 vertices, 2 edges>
+gap> Position(digraphs, Digraph([[1], [1, 2]]));
+17
+gap> digraphs := EnumeratorOfDigraphs(42);
+<enumerator of digraphs with 42 vertices>
+gap> digraphs[1];
+<digraph with 42 vertices, 0 edges>
+gap> digraphs[200];
+<digraph with 42 vertices, 5 edges>
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -1083,3 +1083,72 @@ gap> JohnsonDigraph(1,0);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="DigraphNumber">
+<ManSection>
+  <Oper Name="DigraphNumber" Arg="nr[, v]"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    This operation defines a bijection between the positive integers and the set
+    of all digraphs without multiple edges.  If <A>nr</A> is a positive integer,
+    then this operation returns the unique digraph which corresponds to that
+    number.  This result will be consistent across sessions and systems. <P/>
+
+    If the optional argument <A>v</A> is specified and is a non-negative
+    integer, then this operation will use a different mapping which only assigns
+    numbers to digraphs with <A>v</A> vertices (with no multiple edges).  If
+    <A>nr</A> is higher than <C>2 ^ (<A>v</A> ^ 2)</C> then <C>fail</C> will be
+    returned. <P/>
+
+    See also <Ref Oper="NumberDigraph" Label="for a digraph"/>. <P/>
+
+    <Example><![CDATA[
+gap> gr := DigraphNumber(23);
+<digraph with 3 vertices, 2 edges>
+gap> gr := DigraphNumber(7 ^ 7);
+<digraph with 5 vertices, 12 edges>
+gap> gr := DigraphNumber(123456789, 200);
+<digraph with 200 vertices, 15 edges>
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="NumberDigraph">
+<ManSection>
+  <Oper Name="NumberDigraph" Arg="digraph"
+        Label="for a digraph"/>
+  <Oper Name="NumberDigraph" Arg="digraph:v"
+        Label="for a digraph, with the &quot;v&quot; option"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    This operation defines a bijection between the positive integers and the set
+    of all digraphs without multiple edges.  If <A>digraph</A> is a digraph
+    without multiple edges, then this operation returns the unique positive
+    integer which corresponds to that digraph.  This result will be consistent
+    across sessions and systems. <P/>
+
+    If the option <A>v</A> is specified, then this operation will use a
+    different mapping which only assigns numbers to digraphs with the same
+    number of vertices as <A>digraph</A>.  See <Ref Oper="DigraphNumber"/> for
+    more information. <P/>
+
+    <Example><![CDATA[
+gap> gr := Digraph([[1,2], [3], []]);
+<digraph with 3 vertices, 3 edges>
+gap> NumberDigraph(gr);
+55
+gap> NumberDigraph(gr:v);
+36
+gap> gr := DigraphNumber(104);
+<digraph with 3 vertices, 3 edges>
+gap> NumberDigraph(gr);
+104
+gap> gr := DigraphNumber(42, 12);
+<digraph with 12 vertices, 3 edges>
+gap> NumberDigraph(gr:v);
+42
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -1092,12 +1092,13 @@ gap> JohnsonDigraph(1,0);
     This operation defines a bijection between the positive integers and the set
     of all digraphs without multiple edges.  If <A>nr</A> is a positive integer,
     then this operation returns the unique digraph which corresponds to that
-    number.  This result will be consistent across sessions and systems. <P/>
+    number.  This result will be consistent across sessions and systems.  The
+    digraphs will ordered by increasing number of vertices. <P/>
 
     If the optional argument <A>v</A> is specified and is a non-negative
     integer, then this operation will use a different mapping which only assigns
     numbers to digraphs with <A>v</A> vertices (with no multiple edges).  If
-    <A>nr</A> is higher than <C>2 ^ (<A>v</A> ^ 2)</C> then <C>fail</C> will be
+    <A>nr</A> is higher than <C>2 ^ (<A>v</A> ^ 2)</C> then <K>fail</K> will be
     returned. <P/>
 
     See also <Ref Oper="NumberDigraph" Label="for a digraph"/>. <P/>
@@ -1120,18 +1121,22 @@ gap> gr := DigraphNumber(123456789, 200);
         Label="for a digraph"/>
   <Oper Name="NumberDigraph" Arg="digraph:v"
         Label="for a digraph, with the &quot;v&quot; option"/>
-  <Returns>A digraph.</Returns>
+  <Returns>A digraph, or <K>fail</K>.</Returns>
   <Description>
-    This operation defines a bijection between the positive integers and the set
+    The operation <C>NumberDigraph(<A>digraph</A>)</C> defines a bijection
+    between the positive integers and the set
     of all digraphs without multiple edges.  If <A>digraph</A> is a digraph
-    without multiple edges, then this operation returns the unique positive
+    without multiple edges, then this operation returns the
     integer which corresponds to that digraph.  This result will be consistent
     across sessions and systems. <P/>
 
     If the option <A>v</A> is specified, then this operation will use a
     different mapping which only assigns numbers to digraphs with the same
-    number of vertices as <A>digraph</A>.  See <Ref Oper="DigraphNumber"/> for
-    more information. <P/>
+    number of vertices as <A>digraph</A>.  In this way, <C>NumberDigraph</C>
+    with the &quot;<A>v</A>&quot; option is the inverse of the two-argument
+    version of <Ref Oper="DigraphNumber"/>; and <C>NumberDigraph</C> without
+    &quot;<A>v</A>&quot; is the inverse of the one-argument version of <Ref
+    Oper="DigraphNumber"/>. <P/>
 
     <Example><![CDATA[
 gap> gr := Digraph([[1,2], [3], []]);
@@ -1162,7 +1167,8 @@ gap> NumberDigraph(gr:v);
     edges.  This enumerator can be used in exactly the same way as a list of
     digraphs; the only difference is that the entries are not stored in memory,
     but are created on demand using <Ref Oper="DigraphNumber"/>
-    and <Ref Oper="NumberDigraph" Label="for a digraph"/>. <P/>
+    and <Ref Oper="NumberDigraph" Label="for a digraph"/>.
+    The digraphs are therefore ordered by increasing number of vertices. <P/>
 
     If the optional argument <A>nr_vertices</A> is specified and is a
     non-negative integer, then the enumerator will only contain digraphs with
@@ -1196,7 +1202,8 @@ gap> digraphs[200];
     This function returns an iterator for all digraphs without multiple edges.
     If the optional argument <A>nr_vertices</A> is specified and is a
     non-negative integer, then the iterator will only contain digraphs with this
-    number of vertices. <P/>
+    number of vertices; otherwise, the iterator will produce digraphs in order
+    of their number of vertices, starting at 0 and increasing. <P/>
 
     See <Ref Sect="Iterators" BookName="ref"/> for more information about
     iterators. <P/>

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -1187,3 +1187,34 @@ gap> digraphs[200];
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="IteratorOfDigraphs">
+<ManSection>
+  <Func Name="IteratorOfDigraphs" Arg="[nr_vertices]"/>
+  <Returns>An iterator.</Returns>
+  <Description>
+    This function returns an iterator for all digraphs without multiple edges.
+    If the optional argument <A>nr_vertices</A> is specified and is a
+    non-negative integer, then the iterator will only contain digraphs with this
+    number of vertices. <P/>
+
+    See <Ref Sect="Iterators" BookName="ref"/> for more information about
+    iterators. <P/>
+
+    <Example><![CDATA[
+gap> iter := IteratorOfDigraphs();
+<iterator of digraphs>
+gap> NextIterator(iter);
+<digraph with 0 vertices, 0 edges>
+gap> NextIterator(iter);
+<digraph with 1 vertex, 0 edges>
+gap> iter := IteratorOfDigraphs(42);
+<iterator of digraphs with 42 vertices>
+gap> NextIterator(iter);
+<digraph with 42 vertices, 0 edges>
+gap> IsDoneIterator(iter);
+false
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -58,6 +58,7 @@
   </Section>
 
   <Section><Heading>Enumerating digraphs</Heading>
+    <#Include Label="EnumeratorOfDigraphs">
     <#Include Label="DigraphNumber">
     <#Include Label="NumberDigraph">
   </Section>

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -57,6 +57,11 @@
     <#Include Label="DistanceDigraph">
   </Section>
 
+  <Section><Heading>Enumerating digraphs</Heading>
+    <#Include Label="DigraphNumber">
+    <#Include Label="NumberDigraph">
+  </Section>
+
   <Section><Heading>Random digraphs</Heading>
     <#Include Label="RandomDigraph">
     <#Include Label="RandomMultiDigraph">

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -59,6 +59,7 @@
 
   <Section><Heading>Enumerating digraphs</Heading>
     <#Include Label="EnumeratorOfDigraphs">
+    <#Include Label="IteratorOfDigraphs">
     <#Include Label="DigraphNumber">
     <#Include Label="NumberDigraph">
   </Section>

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -109,3 +109,4 @@ DeclareOperation("JohnsonDigraph", [IsInt, IsInt]);
 DeclareOperation("DigraphNumber", [IsPosInt, IsInt]);
 DeclareOperation("DigraphNumber", [IsPosInt]);
 DeclareOperation("NumberDigraph", [IsDigraph]);
+DeclareGlobalFunction("EnumeratorOfDigraphs");

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -110,3 +110,4 @@ DeclareOperation("DigraphNumber", [IsPosInt, IsInt]);
 DeclareOperation("DigraphNumber", [IsPosInt]);
 DeclareOperation("NumberDigraph", [IsDigraph]);
 DeclareGlobalFunction("EnumeratorOfDigraphs");
+DeclareGlobalFunction("IteratorOfDigraphs");

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -105,3 +105,7 @@ DeclareOperation("SetDigraphEdgeLabels", [IsDigraph, IsFunction]);
 DeclareOperation("DigraphAddAllLoops", [IsDigraph]);
 
 DeclareOperation("JohnsonDigraph", [IsInt, IsInt]);
+
+DeclareOperation("DigraphNumber", [IsPosInt, IsInt]);
+DeclareOperation("DigraphNumber", [IsPosInt]);
+DeclareOperation("NumberDigraph", [IsDigraph]);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1647,3 +1647,84 @@ function(sizes)
   SetIsBipartiteDigraph(out, nr_parts = 2);
   return out;
 end);
+
+#
+
+InstallMethod(DigraphNumber,
+"for a positive integer and an integer",
+[IsPosInt, IsInt],
+function(nr, v)
+  local out, i, j, bit;
+  if v < 0 then
+    ErrorNoReturn("Digraphs: DigraphNumber: usage,\n",
+                  "second arg <v> must be a non-negative integer,");
+  fi;
+  # Number of digraphs on <v> vertices
+  if nr > 2 ^ (v ^ 2) then
+    return fail;
+  fi;
+  # Use the bits of <nr> as an adjacency matrix
+  nr := nr - 1;
+  out := [];
+  for i in [1 .. v] do
+    out[i] := [];
+    for j in [1 .. v] do
+      bit := nr mod 2;
+      if bit = 1 then
+        Add(out[i], j);
+      fi;
+      nr := (nr - bit) / 2;
+    od;
+  od;
+  return Digraph(out);;
+end);
+
+#
+
+InstallMethod(DigraphNumber,
+"for a positive integer",
+[IsPosInt],
+function(nr)
+  local v, limit;
+  v := -1;
+  limit := 0;
+  repeat
+    nr := nr - limit;
+    v := v + 1;
+    limit := 2 ^ (v ^ 2);
+  until nr <= limit;
+  return DigraphNumber(nr, v);
+end);
+
+#
+
+InstallMethod(NumberDigraph,
+"for a digraph",
+[IsDigraph],
+function(gr)
+  local nr, out, v, i, j;
+  if IsMultiDigraph(gr) then
+    ErrorNoReturn("Digraphs: NumberDigraph: usage,\n",
+                  "first arg <gr> must not have multiple edges,");
+  fi;
+  nr := 0;
+  out := OutNeighbours(gr);
+  v := DigraphNrVertices(gr);
+  # Flip a bit in <nr> for each active edge
+  for i in [1 .. v] do
+    for j in out[i] do
+      nr := nr + 2 ^ ((i-1)*v + (j-1));
+    od;
+  od;
+  # Initialise at 1 instead of 0
+  nr := nr + 1;
+  # Return if option "v" is specified
+  if ValueOption("v") = true then
+    return nr;
+  fi;
+  # Put <nr> in the right range for <v> vertices
+  for i in [0 .. v-1] do
+    nr := nr + 2 ^ (i ^ 2);
+  od;
+  return nr;
+end);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1728,3 +1728,82 @@ function(gr)
   od;
   return nr;
 end);
+
+#
+
+InstallGlobalFunction(EnumeratorOfDigraphs,
+function(arg)
+  local fam, elm_nr, nr_elm, len, view, print;
+  if Length(arg) >= 2 then
+    ErrorNoReturn("Digraphs: EnumeratorOfDigraphs: usage,\n",
+                  "this function takes no more than 1 argument,");
+  fi;
+
+  fam := CollectionsFamily(DigraphFamily);
+
+  if Length(arg) = 0 then
+
+    elm_nr := function(enum, pos)
+      return DigraphNumber(pos);
+    end;
+
+    nr_elm := function(enum, elm)
+      if not (IsDigraph(elm) and not IsMultiDigraph(elm)) then
+        return fail;
+      fi;
+      return NumberDigraph(elm);
+    end;
+
+    len := enum -> infinity;
+
+    view := function(enum)
+      Print("<enumerator of digraphs>");
+    end;
+
+    print := function(enum)
+      Print("EnumeratorOfDigraphs(  )");
+    end;
+
+  elif Length(arg) = 1 then
+    if not (IsInt(arg[1]) and arg[1] >= 0) then
+      ErrorNoReturn("Digraphs: EnumeratorOfDigraphs: usage,\n",
+                    "<nr_vertices> must be a non-negative integer,");
+    fi;
+
+    elm_nr := function(enum, pos)
+      return DigraphNumber(pos, arg[1]);
+    end;
+
+    nr_elm := function(enum, elm)
+      if not (IsDigraph(elm) and
+              DigraphNrVertices(elm) = arg[1] and
+              not IsMultiDigraph(elm)) then
+        return fail;
+      fi;
+      return NumberDigraph(elm:v);
+    end;
+
+    len := enum -> 2 ^ (arg[1] ^ 2);
+
+    if arg[1] = 1 then
+      view := function(enum)
+        Print("<enumerator of digraphs with 1 vertex>");
+      end;
+    else
+      view := function(enum)
+        Print("<enumerator of digraphs with ", arg[1], " vertices>");
+      end;
+    fi;
+
+    print := function(enum)
+      Print("EnumeratorOfDigraphs( ", arg[1], " )");
+    end;
+
+  fi;
+
+  return EnumeratorByFunctions(fam, rec(ElementNumber := elm_nr,
+                                        NumberElement := nr_elm,
+                                        Length := len,
+                                        ViewObj := view,
+                                        PrintObj := print));
+end);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1676,7 +1676,7 @@ function(nr, v)
       nr := (nr - bit) / 2;
     od;
   od;
-  return Digraph(out);;
+  return Digraph(out);
 end);
 
 #
@@ -1713,7 +1713,7 @@ function(gr)
   # Flip a bit in <nr> for each active edge
   for i in [1 .. v] do
     for j in out[i] do
-      nr := nr + 2 ^ ((i-1)*v + (j-1));
+      nr := nr + 2 ^ ((i - 1) * v + (j - 1));
     od;
   od;
   # Initialise at 1 instead of 0
@@ -1723,7 +1723,7 @@ function(gr)
     return nr;
   fi;
   # Put <nr> in the right range for <v> vertices
-  for i in [0 .. v-1] do
+  for i in [0 .. v - 1] do
     nr := nr + 2 ^ (i ^ 2);
   od;
   return nr;

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1807,3 +1807,41 @@ function(arg)
                                         ViewObj := view,
                                         PrintObj := print));
 end);
+
+#
+
+InstallGlobalFunction(IteratorOfDigraphs,
+function(arg)
+  local iter;
+  if Length(arg) >= 2 then
+    ErrorNoReturn("Digraphs: IteratorOfDigraphs: usage,\n",
+                  "this function takes no more than 1 argument,");
+  elif Length(arg) = 0 then
+    iter := Iterator(EnumeratorOfDigraphs());
+    iter!.ViewObj := function(iter)
+      Print("<iterator of digraphs>");
+    end;
+    iter!.PrintObj := function(iter)
+      Print("IteratorOfDigraphs(  )");
+    end;
+  elif Length(arg) = 1 then
+    if not (IsInt(arg[1]) and arg[1] >= 0) then
+      ErrorNoReturn("Digraphs: IteratorOfDigraphs: usage,\n",
+                    "<nr_vertices> must be a non-negative integer,");
+    fi;
+    iter := Iterator(EnumeratorOfDigraphs(arg[1]));
+    if arg[1] = 1 then
+      iter!.ViewObj := function(iter)
+        Print("<iterator of digraphs with 1 vertex>");
+      end;
+    else
+      iter!.ViewObj := function(iter)
+        Print("<iterator of digraphs with ", arg[1], " vertices>");
+      end;
+    fi;
+    iter!.PrintObj := function(iter)
+      Print("IteratorOfDigraphs( ", arg[1], " )");
+    end;
+  fi;
+  return iter;
+end);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1772,6 +1772,83 @@ gap> DigraphNumber(999, -1);
 Error, Digraphs: DigraphNumber: usage,
 second arg <v> must be a non-negative integer,
 
+#T# EnumeratorOfDigraphs with no arg
+gap> enum := EnumeratorOfDigraphs();
+<enumerator of digraphs>
+gap> enum[1];
+<digraph with 0 vertices, 0 edges>
+gap> enum[30];
+<digraph with 3 vertices, 2 edges>
+gap> enum[20^20];
+<digraph with 10 vertices, 55 edges>
+gap> ForAll([1, 35, 7^100, 10^1000], i -> enum[i] = DigraphNumber(i));
+true
+gap> Position(enum, ChainDigraph(7));
+2276399973398
+gap> ForAll([1, 85, 5^300, 10^999+1], i -> i = Position(enum, enum[i]));
+true
+gap> Position(enum, Digraph([[1,2], [3,4], [], []]));
+727
+gap> Position(enum, Digraph([[1,2,2], [3,4], [], []]));
+fail
+gap> Position(enum, "hello world");
+fail
+gap> Position(enum, [[1,2,2], [], []]);
+fail
+gap> Length(enum);
+infinity
+
+#T# EnumeratorOfDigraphs with nr_vertices
+gap> enum := EnumeratorOfDigraphs(5);
+<enumerator of digraphs with 5 vertices>
+gap> Length(enum);
+33554432
+gap> enum[123];
+<digraph with 5 vertices, 5 edges>
+gap> enum[1];
+<digraph with 5 vertices, 0 edges>
+gap> enum[2 ^ (5 ^ 2)];
+<digraph with 5 vertices, 25 edges>
+gap> enum[2 ^ (5 ^ 2) + 1];
+fail
+gap> ForAll([1, 35, 7^100, 10^1000], i -> enum[i] = DigraphNumber(i, 5));
+true
+gap> Position(enum, CompleteDigraph(5));
+16510911
+gap> ChainDigraph(5) in enum;
+true
+gap> ForAll([1, 85, 2 ^ 25, 3 ^ 10], i -> i = Position(enum, enum[i]));
+true
+gap> Position(enum, CompleteDigraph(4));
+fail
+gap> Position(enum, CompleteDigraph(6));
+fail
+gap> enum := EnumeratorOfDigraphs(0);
+<enumerator of digraphs with 0 vertices>
+gap> Length(enum);
+1
+gap> AsList(enum);
+[ <digraph with 0 vertices, 0 edges> ]
+gap> enum := EnumeratorOfDigraphs(2);
+<enumerator of digraphs with 2 vertices>
+gap> AsList(enum);
+[ <digraph with 2 vertices, 0 edges>, <digraph with 2 vertices, 1 edge>, 
+  <digraph with 2 vertices, 1 edge>, <digraph with 2 vertices, 2 edges>, 
+  <digraph with 2 vertices, 1 edge>, <digraph with 2 vertices, 2 edges>, 
+  <digraph with 2 vertices, 2 edges>, <digraph with 2 vertices, 3 edges>, 
+  <digraph with 2 vertices, 1 edge>, <digraph with 2 vertices, 2 edges>, 
+  <digraph with 2 vertices, 2 edges>, <digraph with 2 vertices, 3 edges>, 
+  <digraph with 2 vertices, 2 edges>, <digraph with 2 vertices, 3 edges>, 
+  <digraph with 2 vertices, 3 edges>, <digraph with 2 vertices, 4 edges> ]
+gap> enum := EnumeratorOfDigraphs(-1);
+Error, Digraphs: EnumeratorOfDigraphs: usage,
+<nr_vertices> must be a non-negative integer,
+gap> enum := EnumeratorOfDigraphs(2, 2);
+Error, Digraphs: EnumeratorOfDigraphs: usage,
+this function takes no more than 1 argument,
+gap> enum := EnumeratorOfDigraphs(1);
+<enumerator of digraphs with 1 vertex>
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(adj);
@@ -1784,6 +1861,7 @@ gap> Unbind(ddigraph);
 gap> Unbind(digraph);
 gap> Unbind(divides);
 gap> Unbind(elms);
+gap> Unbind(enum);
 gap> Unbind(error);
 gap> Unbind(f);
 gap> Unbind(foo);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1695,6 +1695,83 @@ gap> SetDigraphEdgeLabel(gr, 2, 2, "a");
 Error, Digraphs: SetDigraphEdgeLabel:
 [2, 2] is not an edge of <graph>,
 
+#T# NumberDigraph
+gap> NumberDigraph(Digraph([]));
+1
+gap> NumberDigraph(Digraph([[1]]));
+3
+gap> NumberDigraph(Digraph([[], [1]]));
+8
+gap> NumberDigraph(Digraph([[1, 2, 4, 6, 7], [3, 5, 6], [1, 2, 3, 4],
+>                           [4], [3, 6, 7], [1, 2, 3, 7], [5]]));
+72903899274367
+gap> List([0 .. 100], n-> NumberDigraph(EmptyDigraph(n))) =
+>    List([0 .. 100], n-> Sum([0 .. n-1], i-> 2 ^ (i ^ 2)) + 1);
+true
+gap> ForAll([0 .. 100], n-> NumberDigraph(EmptyDigraph(n):v) = 1);
+true
+gap> NumberDigraph(CompleteDigraph(6));
+34122809746
+gap> NumberDigraph(ChainDigraph(6));
+574718742
+gap> NumberDigraph(EmptyDigraph(6));
+33620500
+gap> NumberDigraph(Digraph([[1, 2, 2], []]));
+Error, Digraphs: NumberDigraph: usage,
+first arg <gr> must not have multiple edges,
+gap> gr := Digraph([[1,2], [3], []]);
+<digraph with 3 vertices, 3 edges>
+gap> NumberDigraph(gr);
+55
+gap> NumberDigraph(gr:v);
+36
+gap> gr := DigraphNumber(104);
+<digraph with 3 vertices, 3 edges>
+gap> NumberDigraph(gr);
+104
+gap> gr := DigraphNumber(42, 12);
+<digraph with 12 vertices, 3 edges>
+gap> NumberDigraph(gr:v);
+42
+
+#T# DigraphNumber(nr)
+gap> DigraphNumber(1);
+<digraph with 0 vertices, 0 edges>
+gap> DigraphNumber(3 ^ 30);
+<digraph with 7 vertices, 25 edges>
+gap> DigraphNumber(3 ^ 300);
+<digraph with 22 vertices, 239 edges>
+gap> OutNeighbours(DigraphNumber(113));
+[ [ 1, 3 ], [ 1, 2 ], [ 1 ] ]
+gap> OutNeighbours(DigraphNumber(+ 447800540966));
+[ [ 2, 5 ], [ 2, 4, 5, 6, 7 ], [ 1, 2, 5, 6, 7 ], [ 1, 2, 3 ], [ 3 ], 
+  [ 1, 2, 4 ], [  ] ]
+gap> OutNeighbours(DigraphNumber(10 ^ 10));
+[ [ 3, 4, 6 ], [ 1, 2, 3 ], [ 2, 3, 4, 6 ], [ 2 ], [ 2, 5 ], [ 1, 4 ] ]
+
+#T# DigraphNumber(nr, v)
+gap> DigraphNumber(1, 0);
+<digraph with 0 vertices, 0 edges>
+gap> ForAll([1 .. 10], v-> DigraphNumber(1, v) = EmptyDigraph(v));
+true
+gap> nr := NumberDigraph(EmptyDigraph(22));;
+gap> DigraphNumber(3 ^ 300) = DigraphNumber(3 ^ 300 - nr + 1, 22);
+true
+gap> DigraphNumber(42, 0);
+fail
+gap> DigraphNumber(512, 3);
+<digraph with 3 vertices, 9 edges>
+gap> DigraphNumber(513, 3);
+fail
+gap> DigraphNumber(2, 132);
+<digraph with 132 vertices, 1 edge>
+gap> DigraphNumber(17, -3);
+Error, Digraphs: DigraphNumber: usage,
+second arg <v> must be a non-negative integer,
+gap> DigraphNumber(999, -1);
+Error, Digraphs: DigraphNumber: usage,
+second arg <v> must be a non-negative integer,
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(adj);
@@ -1726,9 +1803,11 @@ gap> Unbind(h);
 gap> Unbind(i);
 gap> Unbind(im);
 gap> Unbind(inn);
+gap> Unbind(l);
 gap> Unbind(mat);
 gap> Unbind(n);
 gap> Unbind(new);
+gap> Unbind(nr);
 gap> Unbind(out);
 gap> Unbind(r);
 gap> Unbind(r1);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1743,7 +1743,7 @@ gap> DigraphNumber(3 ^ 300);
 <digraph with 22 vertices, 239 edges>
 gap> OutNeighbours(DigraphNumber(113));
 [ [ 1, 3 ], [ 1, 2 ], [ 1 ] ]
-gap> OutNeighbours(DigraphNumber(+ 447800540966));
+gap> OutNeighbours(DigraphNumber(447800540966));
 [ [ 2, 5 ], [ 2, 4, 5, 6, 7 ], [ 1, 2, 5, 6, 7 ], [ 1, 2, 3 ], [ 3 ], 
   [ 1, 2, 4 ], [  ] ]
 gap> OutNeighbours(DigraphNumber(10 ^ 10));

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1849,6 +1849,61 @@ this function takes no more than 1 argument,
 gap> enum := EnumeratorOfDigraphs(1);
 <enumerator of digraphs with 1 vertex>
 
+#T# IteratorOfDigraphs
+gap> iter := IteratorOfDigraphs(12);
+<iterator of digraphs with 12 vertices>
+gap> NextIterator(iter);
+<digraph with 12 vertices, 0 edges>
+gap> NextIterator(iter);
+<digraph with 12 vertices, 1 edge>
+gap> NextIterator(iter);
+<digraph with 12 vertices, 1 edge>
+gap> NextIterator(iter);
+<digraph with 12 vertices, 2 edges>
+gap> NextIterator(iter);
+<digraph with 12 vertices, 1 edge>
+gap> iter := IteratorOfDigraphs(2);
+<iterator of digraphs with 2 vertices>
+gap> iter := IteratorOfDigraphs(2);
+<iterator of digraphs with 2 vertices>
+gap> repeat Print(NextIterator(iter), "\n"); until IsDoneIterator(iter);
+Digraph( [ [ ], [ ] ] )
+Digraph( [ [ 1 ], [ ] ] )
+Digraph( [ [ 2 ], [ ] ] )
+Digraph( [ [ 1, 2 ], [ ] ] )
+Digraph( [ [ ], [ 1 ] ] )
+Digraph( [ [ 1 ], [ 1 ] ] )
+Digraph( [ [ 2 ], [ 1 ] ] )
+Digraph( [ [ 1, 2 ], [ 1 ] ] )
+Digraph( [ [ ], [ 2 ] ] )
+Digraph( [ [ 1 ], [ 2 ] ] )
+Digraph( [ [ 2 ], [ 2 ] ] )
+Digraph( [ [ 1, 2 ], [ 2 ] ] )
+Digraph( [ [ ], [ 1, 2 ] ] )
+Digraph( [ [ 1 ], [ 1, 2 ] ] )
+Digraph( [ [ 2 ], [ 1, 2 ] ] )
+Digraph( [ [ 1, 2 ], [ 1, 2 ] ] )
+gap> iter := IteratorOfDigraphs();
+<iterator of digraphs>
+gap> NextIterator(iter);
+<digraph with 0 vertices, 0 edges>
+gap> NextIterator(iter);
+<digraph with 1 vertex, 0 edges>
+gap> NextIterator(iter);
+<digraph with 1 vertex, 1 edge>
+gap> NextIterator(iter);
+<digraph with 2 vertices, 0 edges>
+gap> IsDoneIterator(iter);
+false
+gap> iter := IteratorOfDigraphs(-1);
+Error, Digraphs: IteratorOfDigraphs: usage,
+<nr_vertices> must be a non-negative integer,
+gap> iter := IteratorOfDigraphs(2, 2);
+Error, Digraphs: IteratorOfDigraphs: usage,
+this function takes no more than 1 argument,
+gap> iter := IteratorOfDigraphs(1);
+<iterator of digraphs with 1 vertex>
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(adj);
@@ -1881,6 +1936,7 @@ gap> Unbind(h);
 gap> Unbind(i);
 gap> Unbind(im);
 gap> Unbind(inn);
+gap> Unbind(iter);
 gap> Unbind(l);
 gap> Unbind(mat);
 gap> Unbind(n);


### PR DESCRIPTION
Two global functions now exist to allow us to enumerate and iterate our way through a list of all the digraphs without multiple edges (up to lists of out neighbours).  This is done either with or without a user-specified number of vertices, and the functions used are `DigraphNumber` and `NumberDigraph`.