### PR TITLE
(Out/In)NeighboursMutableCopy

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -344,8 +344,8 @@ gap> DigraphNrEdges(gr);
 <ManSection>
   <Attr Name="OutNeighbours" Arg="digraph"/>
   <Attr Name="OutNeighbors" Arg="digraph"/>
-  <Oper Name="OutNeighboursCopy" Arg="digraph"/>
-  <Oper Name="OutNeighborsCopy" Arg="digraph"/>
+  <Oper Name="OutNeighboursMutableCopy" Arg="digraph"/>
+  <Oper Name="OutNeighborsMutableCopy" Arg="digraph"/>
   <Returns>The adjacencies of a digraph.</Returns>
   <Description>
     This function returns the list <C>out</C> of out-neighbours of each vertex
@@ -354,9 +354,10 @@ gap> DigraphNrEdges(gr);
     there exists an edge with source <C>i</C> and range <C>j</C> in 
     <A>digraph</A>. <P/>
 
-    The function <C>OutNeighbours</C> returns an immutable list of immutable 
-    lists, whereas the function <C>OutNeighboursCopy</C> returns a copy of
-    <C>OutNeighbours</C> which is a mutable list of mutable lists. <P/>
+    The function <C>OutNeighbours</C> returns an immutable list of immutable
+    lists, whereas the function <C>OutNeighboursMutableCopy</C> returns a copy
+    of <C>OutNeighbours</C> which is a mutable list of mutable lists. <P/>
+
     <Example><![CDATA[
 gap> gr := Digraph(["a", "b", "c"],
 > ["a", "b", "b"],
@@ -376,7 +377,7 @@ gap> gr := Digraph(3,
 <multidigraph with 3 vertices, 7 edges>
 gap> OutNeighbours(gr);
 [ [ 1, 2, 3, 2 ], [ 2, 1 ], [ 3 ] ]
-gap> OutNeighboursCopy(gr);
+gap> OutNeighboursMutableCopy(gr);
 [ [ 1, 2, 3, 2 ], [ 2, 1 ], [ 3 ] ]
 ]]></Example>
   </Description>
@@ -387,6 +388,8 @@ gap> OutNeighboursCopy(gr);
 <ManSection>
   <Attr Name="InNeighbours" Arg="digraph"/>
   <Attr Name="InNeighbors" Arg="digraph"/>
+  <Oper Name="InNeighboursMutableCopy" Arg="digraph"/>
+  <Oper Name="InNeighborsMutableCopy" Arg="digraph"/>
   <Returns>A list of lists of vertices.</Returns>
   <Description>
     This function returns the list <C>inn</C> of in-neighbours of each vertex
@@ -394,7 +397,11 @@ gap> OutNeighboursCopy(gr);
     More specifically, a vertex <C>j</C> appears in <C>inn[i]</C> each time
     there exists an edge with source <C>j</C> and range <C>i</C> in
     <A>digraph</A>. <P/>
-    
+
+    The function <C>InNeighbours</C> returns an immutable list of immutable
+    lists, whereas the function <C>InNeighboursMutableCopy</C> returns a copy
+    of <C>InNeighbours</C> which is a mutable list of mutable lists. <P/>
+
     Note that each entry of <C>inn</C> is sorted into ascending order. <P/>
 
     <Example><![CDATA[
@@ -415,6 +422,8 @@ gap> gr := Digraph(3,
 > [1, 2, 3, 2, 3, 1, 2]);
 <multidigraph with 3 vertices, 7 edges>
 gap> InNeighbours(gr);
+[ [ 1, 2 ], [ 1, 1, 2 ], [ 1, 3 ] ]
+gap> InNeighboursMutableCopy(gr);
 [ [ 1, 2 ], [ 1, 1, 2 ], [ 1, 3 ] ]
 ]]></Example>
   </Description>

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -921,7 +921,7 @@ function(digraph)
       and n > 1 then
     verts := [1 .. n]; # We don't want DigraphVertices as that's immutable
     mat := List(verts, x -> verts * 0);
-    new := OutNeighboursCopy(digraph);
+    new := OutNeighboursMutableCopy(digraph);
     for i in verts do
       for j in new[i] do
         if j < i then

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1455,7 +1455,7 @@ function(digraph, edge)
     return digraph;
   fi;
 
-  out := OutNeighboursCopy(digraph);
+  out := OutNeighboursMutableCopy(digraph);
   G   := DigraphGroup(digraph);
   o   := Orbit(G, edge, OnTuples);
 
@@ -1489,7 +1489,7 @@ function(digraph, edge)
     return digraph;
   fi;
 
-  out := OutNeighboursCopy(digraph);
+  out := OutNeighboursMutableCopy(digraph);
   G   := DigraphGroup(digraph);
   o   := Orbit(G, edge, OnTuples);
 

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -75,8 +75,10 @@ DeclareOperation("IsReachable", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("DigraphLongestDistanceFromVertex", [IsDigraph, IsPosInt]);
 DeclareOperation("DigraphRemoveAllMultipleEdges", [IsDigraph]);
 
-DeclareOperation("OutNeighboursCopy", [IsDigraph]);
-DeclareSynonym("OutNeighborsCopy", OutNeighboursCopy);
+DeclareOperation("OutNeighboursMutableCopy", [IsDigraph]);
+DeclareSynonym("OutNeighborsMutableCopy", OutNeighboursMutableCopy);
+DeclareOperation("InNeighboursMutableCopy", [IsDigraph]);
+DeclareSynonym("InNeighborsMutableCopy", InNeighboursMutableCopy);
 DeclareOperation("AdjacencyMatrixMutableCopy", [IsDigraph]);
 
 DeclareOperation("DigraphLayers", [IsDigraph, IsPosInt]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -142,7 +142,7 @@ function(digraph, edges)
   current := 1;
   nredges := Length(edges);
   out := OutNeighbours(digraph);
-  new := OutNeighboursCopy(digraph);
+  new := OutNeighboursMutableCopy(digraph);
   for i in DigraphVertices(digraph) do
     while current <= nredges and edges[current][1] = i do
       Remove(new[i], Position(new[i], edges[current][2]));
@@ -466,7 +466,7 @@ InstallMethod(DigraphAddEdgesNC, "for a digraph and a list",
 function(digraph, edges)
   local gr, new, new_lbl, verts, edge;
 
-  new := OutNeighboursCopy(digraph);
+  new := OutNeighboursMutableCopy(digraph);
   new_lbl := StructuralCopy(DigraphEdgeLabelsNC(digraph));
   verts := DigraphVertices(digraph);
   for edge in edges do
@@ -528,7 +528,7 @@ function(digraph, m, names)
   local n, new, newverts, out, nam, i;
 
   n := DigraphNrVertices(digraph);
-  new := OutNeighboursCopy(digraph);
+  new := OutNeighboursMutableCopy(digraph);
   newverts := [(n + 1) .. (n + m)];
   for i in newverts do
     new[i] := [];
@@ -644,7 +644,7 @@ function(graph, perm)
                   "of the 1st argument <graph>,");
   fi;
 
-  adj := OutNeighboursCopy(graph);
+  adj := OutNeighboursMutableCopy(graph);
   adj := Permuted(adj, perm);
   Apply(adj, x -> OnTuples(x, perm));
 
@@ -1365,10 +1365,16 @@ function(digraph)
   return gr;
 end);
 
-InstallMethod(OutNeighboursCopy, "for a digraph",
+InstallMethod(OutNeighboursMutableCopy, "for a digraph",
 [IsDigraph],
 function(digraph)
   return List(OutNeighbours(digraph), ShallowCopy);
+end);
+
+InstallMethod(InNeighboursMutableCopy, "for a digraph",
+[IsDigraph],
+function(digraph)
+  return List(InNeighbours(digraph), ShallowCopy);
 end);
 
 InstallMethod(AdjacencyMatrixMutableCopy, "for a digraph",

--- a/tst/extreme/oper.tst
+++ b/tst/extreme/oper.tst
@@ -14,13 +14,13 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# OutNeighboursCopy 1
+#T# OutNeighboursMutableCopy 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
 gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                       "/digraphs-lib/extreme.d6.gz"), 1);
 <digraph with 5000 vertices, 4211332 edges>
-gap> out := OutNeighboursCopy(gr);;
-gap> out := OutNeighborsCopy(gr);;
+gap> out := OutNeighboursMutableCopy(gr);;
+gap> out := OutNeighborsMutableCopy(gr);;
 gap> IsMutable(out);
 true
 gap> ForAll(out, IsMutable);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1230,7 +1230,7 @@ gap> DigraphJoin(EmptyDigraph(3), EmptyDigraph(2)) =
 > CompleteBipartiteDigraph(3, 2);
 true
 
-#T# OutNeighboursCopy
+#T# OutNeighboursMutableCopy
 gap> gr := Digraph([[3], [10], [6], [3], [10], [], [6], [3], [], [3]]);
 <digraph with 10 vertices, 8 edges>
 gap> out1 := OutNeighbours(gr);
@@ -1239,17 +1239,42 @@ gap> IsMutable(out1);
 false
 gap> IsMutable(out1[1]);
 false
-gap> out2 := OutNeighboursCopy(gr);
+gap> out2 := OutNeighboursMutableCopy(gr);
 [ [ 3 ], [ 10 ], [ 6 ], [ 3 ], [ 10 ], [  ], [ 6 ], [ 3 ], [  ], [ 3 ] ]
 gap> IsMutable(out2);
 true
 gap> IsMutable(out2[1]);
 true
-gap> out3 := OutNeighborsCopy(gr);
+gap> out3 := OutNeighborsMutableCopy(gr);
 [ [ 3 ], [ 10 ], [ 6 ], [ 3 ], [ 10 ], [  ], [ 6 ], [ 3 ], [  ], [ 3 ] ]
 gap> IsMutable(out3);
 true
 gap> IsMutable(out3[1]);
+true
+
+#T# InNeighboursMutableCopy
+gap> gr := Digraph([[3], [10], [6], [3], [10], [], [6], [3], [], [3]]);
+<digraph with 10 vertices, 8 edges>
+gap> in1 := InNeighbours(gr);
+[ [  ], [  ], [ 1, 4, 8, 10 ], [  ], [  ], [ 3, 7 ], [  ], [  ], [  ], 
+  [ 2, 5 ] ]
+gap> IsMutable(in1);
+false
+gap> IsMutable(in1[1]);
+false
+gap> in2 := InNeighboursMutableCopy(gr);
+[ [  ], [  ], [ 1, 4, 8, 10 ], [  ], [  ], [ 3, 7 ], [  ], [  ], [  ], 
+  [ 2, 5 ] ]
+gap> IsMutable(in2);
+true
+gap> IsMutable(in2[1]);
+true
+gap> in3 := InNeighborsMutableCopy(gr);
+[ [  ], [  ], [ 1, 4, 8, 10 ], [  ], [  ], [ 3, 7 ], [  ], [  ], [  ], 
+  [ 2, 5 ] ]
+gap> IsMutable(in3);
+true
+gap> IsMutable(in3[1]);
 true
 
 #T# DigraphRemoveAllMultipleEdges


### PR DESCRIPTION
`OutNeighboursCopy` is renamed to `OutNeighboursMutableCopy`.
`InNeighboursMutableCopy` is added.

Semigroups has one use of `OutNeighboursCopy`, and I've made a PR to change that too.