### PR TITLE
fix: AsDigraph for a transformation and an integer

### DIFF
--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -650,27 +650,35 @@ gap> gr := DigraphByInNeighbours([[2, 3, 2], [1], [1, 2, 3]]);
 <#GAPDoc Label="AsDigraph">
 <ManSection>
   <Oper Name="AsDigraph" Arg="trans[, n]"/>
-  <Returns>A digraph.</Returns>
+  <Returns>A digraph, or <K>fail</K>.</Returns>
   <Description>
-    If <A>trans</A> is a transformation and <A>n</A> is a non-negative integer,
-    then this function returns the functional digraph with <A>n</A> 
-    vertices defined by <A>trans</A>. See <Ref Prop="IsFunctionalDigraph"/>.
+    If <A>trans</A> is a transformation, and <A>n</A> is a non-negative integer
+    such that the restriction of <A>trans</A> to <C>[1 .. <A>n</A>]</C> defines
+    a transformation of <C>[1 .. <A>n</A>]</C>, then <C>AsDigraph</C>
+    returns the functional digraph with <A>n</A> vertices defined by
+    <A>trans</A>. See <Ref Prop="IsFunctionalDigraph"/>.
+    <P/>
     
-    Specifically, the graph has  <A>n</A> edges: for each vertex <M>x</M>, 
-    there is a unique edge with source <M>x</M>; this edge has range 
-    <M>x</M>^<A>trans</A>.
+    Specifically, the digraph returned by <C>AsDigraph</C> has  <A>n</A> edges:
+    for each vertex <C>x</C> in <C>[1 .. <A>n</A>]</C>, there is a unique edge
+    with source <C>x</C>; this edge has range <C>x^<A>trans</A></C>.
     <P/>
 
-    If the optional second argument <A>n</A> is not supplied, then the degree
-    of the transformation <A>trans</A> is used by default.
+    If the optional second argument <A>n</A> is not supplied, then the degree of
+    the transformation <A>trans</A> is used by default.  If the restriction of
+    <A>trans</A> to <C>[1 .. <A>n</A>]</C> does not define a transformation of
+    <C>[1 .. <A>n</A>]</C>, then <C>AsDigraph(<A>trans</A>, <A>n</A>)</C>
+    returns <K>fail</K>.
     
     <Example><![CDATA[
-gap> f := Transformation([7, 10, 10, 1, 7, 9, 10, 4, 2, 3]);
-Transformation( [ 7, 10, 10, 1, 7, 9, 10, 4, 2, 3 ] )
-gap> AsDigraph(f); 
+gap> f := Transformation([4, 3, 3, 1, 7, 9, 10, 4, 2, 3]);
+Transformation( [ 4, 3, 3, 1, 7, 9, 10, 4, 2, 3 ] )
+gap> AsDigraph(f);
 <digraph with 10 vertices, 10 edges>
-gap> AsDigraph(f, 4); 
+gap> AsDigraph(f, 4);
 <digraph with 4 vertices, 4 edges>
+gap> AsDigraph(f, 5);
+fail
 ]]></Example>
   </Description>
 </ManSection>

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -518,20 +518,23 @@ end);
 
 InstallMethod(AsDigraph, "for a transformation and an integer",
 [IsTransformation, IsInt],
-function(trans, int)
-  local ran, out, gr, i;
+function(f, n)
+  local out, x, gr, i;
 
-  if int < 0 then
+  if n < 0 then
     ErrorNoReturn("Digraphs: AsDigraph: usage,\n",
-                  "the second argument should be a non-negative integer,");
+                  "the second argument <n> should be a non-negative integer,");
   fi;
 
-  ran := ListTransformation(trans, int);
-  out := EmptyPlist(int);
-  for i in [1 .. int] do
-    out[i] := [ran[i]];
+  out := EmptyPlist(n);
+  for i in [1 .. n] do
+    x := i ^ f;
+    if x > n then
+      return fail;
+    fi;
+    out[i] := [x];
   od;
-  gr := DigraphNC(out);
+  gr := DigraphNC(out, n);
   SetIsMultiDigraph(gr, false);
   SetIsFunctionalDigraph(gr, true);
   return gr;

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -576,13 +576,19 @@ gap> AsDigraph(g);
 <digraph with 8 vertices, 8 edges>
 gap> AsDigraph(g, -1);
 Error, Digraphs: AsDigraph: usage,
-the second argument should be a non-negative integer,
+the second argument <n> should be a non-negative integer,
 gap> AsDigraph(g, 10);
 <digraph with 10 vertices, 10 edges>
+gap> AsDigraph(g, 6);
+fail
+gap> AsDigraph(g, 7);
+<digraph with 7 vertices, 7 edges>
 gap> h := Transformation([2, 4, 1, 3, 5]);
 Transformation( [ 2, 4, 1, 3 ] )
 gap> AsDigraph(h);
 <digraph with 4 vertices, 4 edges>
+gap> AsDigraph(h, 2);
+fail
 
 #T# RandomDigraph
 gap> DigraphNrVertices(RandomDigraph(10));

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -263,6 +263,14 @@ gap> OutNeighbours(OnDigraphs(d, PermList([2, 3, 1])));
 gap> OutNeighbours(OnDigraphs(d, Transformation([2, 3, 1])));
 [ [ 2, 2 ], [ 3 ], [ 1 ] ]
 
+#T# Issue 42: Bug in AsDigraph for a transformation and an integer
+gap> f := Transformation([7, 10, 10, 1, 7, 9, 10, 4, 2, 3]);
+Transformation( [ 7, 10, 10, 1, 7, 9, 10, 4, 2, 3 ] )
+gap> AsDigraph(f); 
+<digraph with 10 vertices, 10 edges>
+gap> AsDigraph(f, 4); 
+fail
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);


### PR DESCRIPTION
This resolves issue #42. It fixes the bug that `AsDigraph(f, n)` returns a malformed digraph in the case that the transformation `f` does not actually define a transformation on `[1 .. n]`. After this PR, `AsDigraph(f, n)` returns `fail` in this case.