### PR TITLE
Updated status

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -159,7 +159,7 @@ Persons := [
     Institution   := "University of St Andrews"
   )],
 
-Status := "dev",
+Status := "deposited",
 
 IssueTrackerURL := Concatenation(~.SourceRepository.URL, "/issues"),
 PackageWWWHome  := Concatenation("https://gap-packages.github.io/",


### PR DESCRIPTION
For packages redistributed with GAP, the status should be one of accepted/submitted/deposited.