### PR TITLE
Introduce methods for undirected spanning trees and forests

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1211,3 +1211,58 @@ gap> OutNeighbours(sym);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="UndirectedSpanningTree">
+<ManSection>
+  <Attr Name="UndirectedSpanningTree" Arg="digraph"/>
+  <Attr Name="UndirectedSpanningForest" Arg="digraph"/>
+  <Returns>A digraph, or <K>fail</K>.</Returns>
+  <Description>
+    If <A>digraph</A> is a digraph with at least one vertex, then
+    <C>UndirectedSpanningForest</C> returns an undirected spanning forest of
+    <A>digraph</A>, otherwise this attribute returns <K>fail</K>. See <Ref
+      Oper="IsUndirectedSpanningForest" /> for the definition of an undirected
+    spanning forest. <P/>
+
+    If <A>digraph</A> is a digraph with at least one vertex and whose <Ref
+      Attr="MaximalSymmetricSubdigraph"/> is connected (see <Ref
+      Prop="IsConnectedDigraph" />), then <C>UndirectedSpanningTree</C> returns
+    an undirected spanning tree of <A>digraph</A>, otherwise this attribute
+    returns <K>fail</K>.  See <Ref Oper="IsUndirectedSpanningTree" /> for the
+    definition of an undirected spanning tree. <P/>
+
+    Note that for a digraph that has an undirected spanning tree, the attribute
+    <C>UndirectedSpanningTree</C> returns the same digraph as the attribute
+    <C>UndirectedSpanningForest</C>.
+
+    <Example><![CDATA[
+gap> gr := Digraph([[1, 2, 1, 3], [1], [4], [3, 4, 3]]);
+<multidigraph with 4 vertices, 9 edges>
+gap> UndirectedSpanningTree(gr);
+fail
+gap> forest := UndirectedSpanningForest(gr);
+<digraph with 4 vertices, 4 edges>
+gap> OutNeighbours(forest);
+[ [ 2 ], [ 1 ], [ 4 ], [ 3 ] ]
+gap> IsUndirectedSpanningForest(gr, forest);
+true
+gap> DigraphConnectedComponents(forest).comps;
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> DigraphConnectedComponents(MaximalSymmetricSubdigraph(gr)).comps;
+[ [ 1, 2 ], [ 3, 4 ] ]
+gap> UndirectedSpanningForest(MaximalSymmetricSubdigraph(gr))
+> = forest;
+true
+gap> gr := CompleteDigraph(4);
+<digraph with 4 vertices, 12 edges>
+gap> tree := UndirectedSpanningTree(gr);
+<digraph with 4 vertices, 6 edges>
+gap> IsUndirectedSpanningTree(gr, tree);
+true
+gap> tree = UndirectedSpanningForest(gr);
+true
+gap> UndirectedSpanningForest(EmptyDigraph(0));
+fail]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -53,6 +53,63 @@ false]]></Example>
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="IsUndirectedSpanningTree">
+<ManSection>
+  <Oper Name="IsUndirectedSpanningTree" Arg="super, sub"/>
+  <Oper Name="IsUndirectedSpanningForest" Arg="super, sub"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    The operation <C>IsUndirectedSpanningTree</C> returns <K>true</K> if the
+    digraph <A>sub</A> is an undirected spanning tree of the digraph
+    <A>super</A>, and the operation <C>IsUndirectedSpanningForest</C> returns
+    <K>true</K> if the digraph <A>sub</A> is an undirected spanning forest of
+    the digraph <A>super</A>. <P/>
+
+    An <E>undirected spanning tree</E> of a digraph <A>super</A> is a subdigraph
+    of <A>super</A> that is an undirected tree (see <Ref Oper="IsSubdigraph" />
+    and <Ref Prop="IsUndirectedTree" />). Note that a digraph whose <Ref
+      Attr="MaximalSymmetricSubdigraph"/> is not connected has no undirected
+    spanning trees (see <Ref Prop="IsConnectedDigraph"/>). <P/>
+
+    An <E>undirected spanning forest</E> of a digraph <A>super</A> is a
+    subdigraph of <A>super</A> that is an undirected forest (see <Ref
+      Oper="IsSubdigraph"/> and <Ref Oper="IsUndirectedForest"/>), and is not
+    contained in any larger such subdigraph of <A>super</A>.  Equivalently, an
+    undirected spanning forest is a subdigraph of <A>super</A> whose connected
+    components coincide with those of the <Ref
+      Attr="MaximalSymmetricSubdigraph"/> of <A>super</A> (see <Ref
+      Attr="DigraphConnectedComponents"/>). <P/>
+
+    Note that an undirected spanning tree is an undirected spanning forest that
+    is connected.
+
+    <Example><![CDATA[
+gap> gr := CompleteDigraph(4);
+<digraph with 4 vertices, 12 edges>
+gap> tree := Digraph([[3], [4], [1, 4], [2, 3]]);
+<digraph with 4 vertices, 6 edges>
+gap> IsSubdigraph(gr, tree) and IsUndirectedTree(tree);
+true
+gap> IsUndirectedSpanningTree(gr, tree);
+true
+gap> forest := EmptyDigraph(4);
+<digraph with 4 vertices, 0 edges>
+gap> IsSubdigraph(gr, forest) and IsUndirectedForest(forest);
+true
+gap> IsUndirectedSpanningForest(gr, forest);
+false
+gap> IsSubdigraph(tree, forest);
+true
+gap> gr := DigraphDisjointUnion(CycleDigraph(2), CycleDigraph(2));
+<digraph with 4 vertices, 4 edges>
+gap> IsUndirectedTree(gr);
+false
+gap> IsUndirectedForest(gr) and IsUndirectedSpanningForest(gr, gr);
+true]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="DigraphReverse">
 <ManSection>
   <Oper Name="DigraphReverse" Arg="digraph"/>

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -611,31 +611,53 @@ true
 <#GAPDoc Label="IsUndirectedTree">
 <ManSection>
   <Prop Name="IsUndirectedTree" Arg="digraph"/>
+  <Prop Name="IsUndirectedForest" Arg="digraph"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
-    This property returns <K>true</K> if the digraph <A>digraph</A> is an
-    undirected tree.<P/>
+    The property <C>IsUndirectedTree</C> returns <K>true</K> if the digraph
+    <A>digraph</A> is an undirected tree, and the property
+    <C>IsUndirectedForest</C> returns <K>true</K> if <A>digraph</A> is an
+    undirected forest; otherwise, these properties return <K>false</K>. <P/>
 
-    An undirected tree is a symmetric digraph without loops, in which for any
-    pair of distinct vertices <C>u</C> and <C>v</C>, there is exactly one
+    An <E>undirected tree</E> is a symmetric digraph without loops, in which for
+    any pair of distinct vertices <C>u</C> and <C>v</C>, there is exactly one
     directed path from <C>u</C> to <C>v</C>. See <Ref
       Prop="IsSymmetricDigraph"/> and <Ref Prop="DigraphHasLoops"/>, and see
     section <Ref Subsect="Definitions" Style="Number" /> for the definition of
-    directed path. <P/>
+    directed path. This definition implies that an undirected tree has
+    no multiple edges. <P/>
 
-    Please note that the digraph with zero vertices is not considered to be an
-    undirected tree. <P/>
+    An <E>undirected forest</E> is a digraph, each of whose connected components
+    is an undirected tree. In other words, an undirected forest is isomorphic to
+    a disjoint union of undirected trees. See <Ref
+      Attr="DigraphConnectedComponents" /> and <Ref Func="DigraphDisjointUnion"
+      Label="for a list of digraphs" />. In particular, every
+    undirected tree is an undirected forest. <P/>
+
+    Please note that the digraph with zero vertices is considered to be neither
+    an undirected tree nor an undirected forest.
 
     <Example><![CDATA[
 gap> gr := Digraph([[3], [3], [1, 2]]);
 <digraph with 3 vertices, 4 edges>
 gap> IsUndirectedTree(gr);
 true
-gap> gr := Digraph([[], [1]]);
-<digraph with 2 vertices, 1 edge>
+gap> IsSymmetricDigraph(gr) and not DigraphHasLoops(gr);
+true
+gap> gr := Digraph([[3], [5], [1, 4], [3], [2]]);
+<digraph with 5 vertices, 6 edges>
+gap> IsConnectedDigraph(gr);
+false
 gap> IsUndirectedTree(gr);
 false
-]]></Example>
+gap> IsUndirectedForest(gr);
+true
+gap> gr := Digraph([[1, 2], [1], [2]]);
+<digraph with 3 vertices, 4 edges>
+gap> IsUndirectedTree(gr) or IsUndirectedForest(gr);
+false
+gap> IsSymmetricDigraph(gr) or not DigraphHasLoops(gr);
+false]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -27,6 +27,7 @@
     <#Include Label="InducedSubdigraph">
     <#Include Label="ReducedDigraph">
     <#Include Label="MaximalSymmetricSubdigraph">
+    <#Include Label="UndirectedSpanningTree">
     <#Include Label="QuotientDigraph">
     <#Include Label="DigraphReverse">
     <#Include Label="DigraphDual">

--- a/doc/z-chap3.xml
+++ b/doc/z-chap3.xml
@@ -41,5 +41,6 @@
    </List>
 
    <#Include Label="IsSubdigraph">
+   <#Include Label="IsUndirectedSpanningTree">
   </Section>
 </Chapter>

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  attr.gd
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -63,6 +63,9 @@ DeclareAttribute("ReducedDigraph", IsDigraph);
 DeclareAttribute("MaximalSymmetricSubdigraph", IsDigraph);
 DeclareAttribute("MaximalSymmetricSubdigraphWithoutLoops", IsDigraph);
 DeclareOperation("DIGRAPHS_MaximalSymmetricSubdigraph", [IsDigraph, IsBool]);
+
+DeclareAttribute("UndirectedSpanningTree", IsDigraph);
+DeclareAttribute("UndirectedSpanningForest", IsDigraph);
 
 # AsGraph must be mutable for grape to function properly
 DeclareAttribute("AsGraph", IsDigraph, "mutable");

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  attr.gi
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -1347,4 +1347,39 @@ function(gr, loops)
   SetIsSymmetricDigraph(new_gr, true);
   SetDigraphVertexLabels(new_gr, DigraphVertexLabels(gr));
   return new_gr;
+end);
+
+#
+
+InstallMethod(UndirectedSpanningForest,
+"for a digraph",
+[IsDigraph],
+function(gr)
+  local out;
+  if DigraphNrVertices(gr) = 0 then
+    return fail;
+  fi;
+
+  gr := MaximalSymmetricSubdigraph(gr);
+  out := Digraph(DIGRAPH_SYMMETRIC_SPANNING_FOREST(OutNeighbours(gr)));
+  SetIsUndirectedForest(out, true);
+  SetIsMultiDigraph(out, false);
+  SetDigraphHasLoops(out, false);
+  return out;
+end);
+
+#
+
+InstallMethod(UndirectedSpanningTree,
+"for a digraph",
+[IsDigraph],
+function(gr)
+  local out;
+  if DigraphNrVertices(gr) = 0
+      or not IsStronglyConnectedDigraph(MaximalSymmetricSubdigraph(gr)) then
+    return fail;
+  fi;
+  out := UndirectedSpanningForest(gr);
+  SetIsUndirectedTree(out, true);
+  return out;
 end);

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -1,13 +1,15 @@
 #############################################################################
 ##
 #W  oper.gd
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
 #############################################################################
 ##
 DeclareOperation("IsSubdigraph", [IsDigraph, IsDigraph]);
+DeclareOperation("IsUndirectedSpanningTree", [IsDigraph, IsDigraph]);
+DeclareOperation("IsUndirectedSpanningForest", [IsDigraph, IsDigraph]);
 
 DeclareOperation("AsBinaryRelation", [IsDigraph]);
 DeclareOperation("OnDigraphs", [IsDigraph, IsPerm]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  oper.gi
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -46,6 +46,42 @@ function(super, sub)
     fi;
   od;
   return true;
+end);
+
+#
+
+InstallMethod(IsUndirectedSpanningForest, "for a digraph and a digraph",
+[IsDigraph, IsDigraph],
+function(super, sub)
+  local sym, comps1, comps2;
+
+  if not IsUndirectedForest(sub) then
+    return false;
+  fi;
+
+  sym := MaximalSymmetricSubdigraph(super);
+
+  if not IsSubdigraph(sym, sub) then
+    return false;
+  fi;
+
+  comps1 := DigraphConnectedComponents(sym).comps;
+  comps2 := DigraphConnectedComponents(sub).comps;
+
+  if Length(comps1) <> Length(comps2) then
+    return false;
+  fi;
+
+  return Set(comps1, SortedList) = Set(comps2, SortedList);
+end);
+
+#
+
+InstallMethod(IsUndirectedSpanningTree, "for a digraph and a digraph",
+[IsDigraph, IsDigraph],
+function(super, sub)
+  return IsConnectedDigraph(MaximalSymmetricSubdigraph(super))
+    and IsUndirectedSpanningForest(super, sub);
 end);
 
 #

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  props.gd
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -30,6 +30,7 @@ DeclareProperty("IsRegularDigraph", IsDigraph);
 DeclareProperty("IsDistanceRegularDigraph", IsDigraph);
 DeclareProperty("IsDirectedTree", IsDigraph);
 DeclareProperty("IsUndirectedTree", IsDigraph);
+DeclareProperty("IsUndirectedForest", IsDigraph);
 DeclareProperty("IsEulerianDigraph", IsDigraph);
 
 InstallTrueMethod(IsAntisymmetricDigraph, IsTournament);
@@ -37,8 +38,11 @@ InstallTrueMethod(IsAntisymmetricDigraph, IsAcyclicDigraph);
 InstallTrueMethod(IsTransitiveDigraph, IsTournament and IsAcyclicDigraph);
 InstallTrueMethod(IsAcyclicDigraph, IsTournament and IsTransitiveDigraph);
 InstallTrueMethod(IsSymmetricDigraph, IsCompleteDigraph);
+InstallTrueMethod(IsSymmetricDigraph, IsUndirectedForest);
 InstallTrueMethod(IsTransitiveDigraph, IsCompleteDigraph);
 InstallTrueMethod(IsAcyclicDigraph, IsEmptyDigraph);
 InstallTrueMethod(IsRegularDigraph, IsInRegularDigraph and IsOutRegularDigraph);
 InstallTrueMethod(IsStronglyConnectedDigraph,
                   IsConnectedDigraph and IsSymmetricDigraph);
+InstallTrueMethod(IsStronglyConnectedDigraph, IsUndirectedTree);
+InstallTrueMethod(IsUndirectedForest, IsUndirectedTree);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  prop.gi
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -393,6 +393,24 @@ InstallMethod(IsUndirectedTree, "for a digraph", [IsDigraph],
 function(gr)
   return DigraphNrEdges(gr) = 2 * (DigraphNrVertices(gr) - 1)
            and IsSymmetricDigraph(gr) and IsConnectedDigraph(gr);
+end);
+
+InstallMethod(IsUndirectedForest, "for a digraph", [IsDigraph],
+function(gr)
+  local comps, comp;
+
+  if not IsSymmetricDigraph(gr) or DigraphNrVertices(gr) = 0
+      or IsMultiDigraph(gr) then
+    return false;
+  fi;
+  comps := DigraphConnectedComponents(gr).comps;
+  for comp in comps do
+    comp := InducedSubdigraph(gr, comp);
+    if DigraphNrEdges(comp) <> 2 * (DigraphNrVertices(comp) - 1) then
+      return false;
+    fi;
+  od;
+  return true;
 end);
 
 #

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1,7 +1,8 @@
 #############################################################################
 ##
 #W  standard/attr.tst
-#Y  Copyright (C) 2014-15                                James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
+##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -1313,6 +1314,48 @@ gap> gr := DigraphAddVertex(gr);;
 gap> ChromaticNumber(gr);
 4
 
+#T# UndirectedSpanningTree and UndirectedSpanningForest
+gap> gr := EmptyDigraph(0);
+<digraph with 0 vertices, 0 edges>
+gap> tree := UndirectedSpanningTree(gr);
+fail
+gap> forest := UndirectedSpanningForest(gr);
+fail
+gap> gr := EmptyDigraph(1);
+<digraph with 1 vertex, 0 edges>
+gap> tree := UndirectedSpanningTree(gr);
+<digraph with 1 vertex, 0 edges>
+gap> forest := UndirectedSpanningForest(gr);
+<digraph with 1 vertex, 0 edges>
+gap> IsUndirectedSpanningTree(gr, gr);
+true
+gap> IsUndirectedSpanningTree(gr, forest);
+true
+gap> gr = forest;
+true
+gap> gr := EmptyDigraph(2);
+<digraph with 2 vertices, 0 edges>
+gap> tree := UndirectedSpanningTree(gr);
+fail
+gap> forest := UndirectedSpanningForest(gr);
+<digraph with 2 vertices, 0 edges>
+gap> IsUndirectedTree(forest);
+false
+gap> IsUndirectedSpanningForest(gr, forest);
+true
+gap> gr = forest;
+true
+gap> gr := DigraphFromDigraph6String("+I?PIMAQc@A?W?ADPP?");
+<digraph with 10 vertices, 23 edges>
+gap> IsStronglyConnectedDigraph(gr);
+true
+gap> UndirectedSpanningTree(gr);
+fail
+gap> DigraphEdges(UndirectedSpanningForest(gr));
+[ [ 2, 7 ], [ 7, 2 ] ]
+gap> IsUndirectedSpanningForest(gr, UndirectedSpanningForest(gr));
+true
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);
@@ -1320,6 +1363,7 @@ gap> Unbind(adj2);
 gap> Unbind(circuit);
 gap> Unbind(complete15);
 gap> Unbind(cycle12);
+gap> Unbind(forest);
 gap> Unbind(gr);
 gap> Unbind(gr1);
 gap> Unbind(gr2);
@@ -1341,6 +1385,7 @@ gap> Unbind(topo);
 gap> Unbind(trans);
 gap> Unbind(trans1);
 gap> Unbind(trans2);
+gap> Unbind(tree);
 gap> Unbind(wcc);
 
 #E#

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1,7 +1,8 @@
 #############################################################################
 ##
 #W  standard/oper.tst
-#Y  Copyright (C) 2014-15                                James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
+##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -1745,6 +1746,50 @@ gap> gr2 := Digraph([[], [2, 2]]);
 <multidigraph with 2 vertices, 2 edges>
 gap> IsSubdigraph(gr1, gr2) or IsSubdigraph(gr2, gr1);
 false
+
+#T# IsUndirectedSpanningForest
+gap> gr1 := CompleteDigraph(10);
+<digraph with 10 vertices, 90 edges>
+gap> gr2 := EmptyDigraph(9);
+<digraph with 9 vertices, 0 edges>
+gap> IsUndirectedSpanningForest(gr1, gr2);
+false
+gap> gr2 := DigraphAddEdge(EmptyDigraph(10), [1, 2]);
+<digraph with 10 vertices, 1 edge>
+gap> IsUndirectedSpanningForest(gr1, gr2);
+false
+gap> gr2 := DigraphAddEdge(gr2, [2, 1]);
+<digraph with 10 vertices, 2 edges>
+gap> IsUndirectedSpanningForest(gr1, gr2);
+false
+gap> IsUndirectedSpanningForest(gr1, DigraphFromSparse6String(":I`ESyTl^F"));
+true
+gap> gr := DigraphFromDigraph6String("+I?PIMAQc@A?W?ADPP?");
+<digraph with 10 vertices, 23 edges>
+gap> IsUndirectedSpanningForest(gr, DigraphByEdges([[2, 7], [7, 2]], 10));
+true
+
+#T# IsUndirectedSpanningTree
+gap> IsUndirectedSpanningTree(EmptyDigraph(1), EmptyDigraph(1));
+true
+gap> IsUndirectedSpanningTree(EmptyDigraph(2), EmptyDigraph(2));
+false
+gap> gr := DigraphFromDigraph6String("+I?PIMAQc@A?W?ADPP?");
+<digraph with 10 vertices, 23 edges>
+gap> IsUndirectedSpanningTree(gr, EmptyDigraph(10));
+false
+gap> gr := DigraphFromGraph6String("INB`cZoQ_");
+<digraph with 10 vertices, 38 edges>
+gap> IsUndirectedSpanningTree(gr, gr);
+false
+gap> gr1 := DigraphEdgeUnion(CycleDigraph(5), DigraphReverse(CycleDigraph(5)));
+<digraph with 5 vertices, 10 edges>
+gap> gr2 := DigraphEdgeUnion(ChainDigraph(5), DigraphReverse(ChainDigraph(5)));
+<digraph with 5 vertices, 8 edges>
+gap> IsUndirectedSpanningTree(gr1, gr2);
+true
+gap> IsUndirectedSpanningTree(gr2, gr2);
+true
 
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(a);

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1,7 +1,8 @@
 #############################################################################
 ##
 #W  standard/prop.tst
-#Y  Copyright (C) 2014-15                                James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
+##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -913,6 +914,48 @@ false
 gap> g := Digraph([[1], [2]]);
 <digraph with 2 vertices, 2 edges>
 gap> IsConnectedDigraph(g);
+false
+
+#T# IsUndirectedForest
+gap> gr := ChainDigraph(10);
+<digraph with 10 vertices, 9 edges>
+gap> IsUndirectedForest(gr);
+false
+gap> gr := EmptyDigraph(0);
+<digraph with 0 vertices, 0 edges>
+gap> IsUndirectedForest(gr);
+false
+gap> gr := EmptyDigraph(1);
+<digraph with 1 vertex, 0 edges>
+gap> IsUndirectedForest(gr);
+true
+gap> gr := Digraph([[1, 1]]);
+<multidigraph with 1 vertex, 2 edges>
+gap> IsUndirectedForest(gr);
+false
+gap> gr := Digraph([[1]]);
+<digraph with 1 vertex, 1 edge>
+gap> IsUndirectedForest(gr);
+false
+gap> gr := DigraphSymmetricClosure(ChainDigraph(4));
+<digraph with 4 vertices, 6 edges>
+gap> HasIsUndirectedTree(gr) or HasIsUndirectedForest(gr);
+false
+gap> IsUndirectedTree(gr);
+true
+gap> HasIsUndirectedForest(gr);
+true
+gap> IsUndirectedForest(gr);
+true
+gap> gr := DigraphDisjointUnion(gr, gr, gr);
+<digraph with 12 vertices, 18 edges>
+gap> IsUndirectedTree(gr);
+false
+gap> IsUndirectedForest(gr);
+true
+gap> gr := DigraphDisjointUnion(CompleteDigraph(2), CycleDigraph(3));
+<digraph with 5 vertices, 5 edges>
+gap> IsUndirectedForest(gr);
 false
 
 #T# IsEulerianDigraph


### PR DESCRIPTION
The package already includes the property `IsUndirectedTree`, which decides whether a digraph is a tree in the usual graph-theoretic sense (symmetric, connected, no cycles).

This PR adds several new features related to undirected trees:

* property`IsUndirectedForest`: an undirected forest is a disjoint union of undirected trees.
* attributes `UndirectedSpanningTree` and `UndirectedSpanningForest`: spanning tree has the usual sense, and a spanning forest is a subdigraph that is a forest and is maximal (with respect to containment of subdigraphs) with this property. This later attribute is the most important one for my purposes. Every digraph has a spanning forest (which may be an empty digraph); not every digraph has a spanning tree.
* operations `IsUndirectedSpanningTree` and `IsUndirectedSpanningForest`.

I will use the attribute `UndirectedSpanningForest` in the Semigroups package. In particular, I'll add a method for `IdempotentGeneratedSubsemigroup` for a Rees 0-matrix semigroup over a group, which will be able to return a semigroup with a much smaller generating set than before. This involves calculating a spanning forest of the `RZMSDigraph`.