### PR TITLE
Improve user-facing isomorphism and canonical labelling functions, especially with colourings

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -13,17 +13,19 @@
   <Attr Name="ChromaticNumber" Arg="digraph"/>
   <Returns> A non-negative integer.</Returns>
   <Description>
-    A digraph coloring is a labeling of the vertices (using precisely <A>n</A>
-    colors) in such a way that two adjacent vertices can not have the same
-    label.  Alternatively, it can be defined to be a <Ref
-      Oper="DigraphEpimorphism"/> from <A>digraph</A> onto a complete digraph
-    with <A>n</A> vertices.<P/>
+    A <E>proper colouring</E> of a digraph is a labelling of its
+    vertices in such a way that adjacent vertices have different labels.
+    Equivalently, a proper digraph colouring can be defined to be a <Ref
+      Oper="DigraphEpimorphism"/> from a digraph onto a complete digraph. <P/>
 
-    <C>ChromaticNumber</C> returns the least non-negative integer <C>n</C> such
-    that there is a coloring of the loopless digraph <A>digraph</A> with
-    <C>n</C> colors.  In other words, <C>ChromaticNumber</C> returns the least
-    value <C>n</C> such that <C>DigraphColoring(<A>digraph</A>, n)</C> does not
-    return <K>fail</K>.
+    If <A>digraph</A> is a digraph without loops (see <Ref
+      Prop="DigraphHasLoops"/>, then <C>ChromaticNumber</C> returns the least
+    non-negative integer <C>n</C> such that there is a proper colouring of
+    <A>digraph</A> with <C>n</C> colours.  In other words, for a digraph with at
+    least one vertex, <C>ChromaticNumber</C> returns the least number <C>n</C>
+    such that <C>DigraphColouring(<A>digraph</A>, n)</C> does not return
+    <K>fail</K>. See <Ref Oper="DigraphColouring"
+      Label="for a digraph and a number of colours"/>.
 
     <Example><![CDATA[
 gap> ChromaticNumber(NullDigraph(10));

--- a/doc/bliss.xml
+++ b/doc/bliss.xml
@@ -2,6 +2,7 @@
 ##
 #W  bliss.xml
 #Y  Copyright (C) 2014-17                               James D. Mitchell
+##                                                         Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -11,83 +12,59 @@
 <#GAPDoc Label="AutomorphismGroupDigraph">
 <ManSection>
   <Attr Name="AutomorphismGroup" Label="for a digraph" Arg="digraph"/>
-  <Oper Name="AutomorphismGroup" Label="for a digraph and a homogeneous list"
-    Arg="digraph, colors"/>
   <Returns>A permutation group.</Returns>
   <Description>
-    If <A>digraph</A> is a digraph without multiple edges, then this function
-    returns the automorphism group of <A>digraph</A>, as a group of
-    permutations on the vertices of <A>digraph</A>. <P/>
+    If <A>digraph</A> is a digraph, then this attribute contains the group of
+    automorphisms of <A>digraph</A>.  An <E>automorphism</E> of <A>digraph</A>
+    is an isomorphism from <A>digraph</A> to itself. See <Ref
+      Oper="IsomorphismDigraphs" Label="for digraphs" /> for more information
+    about isomorphisms of digraphs. <P/>
 
-    If the <A>colors</A> argument is specified, then the group will consist of
-    only those automorphisms which respect the given colouring.  The colouring
-    <A>colors</A> can be in one of two forms: <P/>
+    The form in which the automorphism group is returned depends on whether
+    <A>digraph</A> has multiple edges; see <Ref Prop="IsMultiDigraph" />. <P/>
 
     <List>
+      <Mark>for a digraph without multiple edges</Mark>
       <Item>
-        A list of positive integers of size the number of vertices of
-        <A>digraph</A>, where <A>colors</A><C>[i]</C> is the colour of vertex
-        <C>i</C>.
+        If <A>digraph</A> has no multiple edges, then the automorphism group is
+        returned as a group of permutations on the vertices of <A>digraph</A>.
       </Item>
+      <Mark>for a multidigraph</Mark>
       <Item>
-        A list of lists, such that <A>colors</A><C>[i]</C> is a list of all
-        vertices with colour <C>i</C>.
+        If <A>digraph</A> is a multidigraph, then the automorphism group is
+        a group of permutations on the vertices and edges of <A>digraph</A>.
+        <P/>
+
+        For convenience, the group is returned as the direct product <C>G</C> of
+        the group of automorphisms of the vertices of <A>digraph</A> with the
+        stabiliser of the vertices in the automorphism group of the edges. These
+        two groups can be accessed using the operation <Ref Oper="Projection"
+          Label="for a domain and a positive integer" BookName="ref"/>, with the
+        second argument being <C>1</C> or <C>2</C>, respectively. <P/>
+
+        The permutations in the group <C>Projection(G, 1)</C> act on the
+        vertices of <A>digraph</A>, and the permutations in the group
+        <C>Projection(G, 2)</C> act on the indices of
+        <C>DigraphEdges(<A>digraph</A>)</C>.
       </Item>
     </List>
 
-    The automorphism group is found using <URL
-      Text="bliss">http://www.tcs.tkk.fi/Software/bliss/index.html</URL> by
-    Tommi Junttila and Petteri Kaski.
+    The automorphism group is found using &bliss; by Tommi Junttila and Petteri
+    Kaski.
 
     <Example><![CDATA[
 gap> johnson := DigraphFromGraph6String("E}lw");
 <digraph with 6 vertices, 24 edges>
-gap> AutomorphismGroup(johnson);
+gap> G := AutomorphismGroup(johnson);
 Group([ (3,4), (2,3)(4,5), (1,2)(5,6) ])
-gap> Size(last);
-48
+gap> StructureDescription(G);
+"C2 x S4"
 gap> cycle := CycleDigraph(9);
 <digraph with 9 vertices, 9 edges>
-gap> a := AutomorphismGroup(cycle);;
-gap> StructureDescription(a);
+gap> G := AutomorphismGroup(cycle);
+Group([ (1,2,3,4,5,6,7,8,9) ])
+gap> StructureDescription(G);
 "C9"
-gap> a := AutomorphismGroup(cycle, [1, 2, 3, 1, 2, 3, 1, 2, 3]);;
-gap> StructureDescription(a);
-"C3"
-gap> a := AutomorphismGroup(cycle, [[1, 4, 7], [2, 5, 8], [3, 6, 9]]);;
-gap> StructureDescription(a);
-"C3"
-]]></Example>
-    </Description>
-  </ManSection>
-<#/GAPDoc>
-
-<#GAPDoc Label="AutomorphismGroupMultiDigraph">
-  <ManSection>
-    <Attr Name="AutomorphismGroup" Label="for a multidigraph" Arg="digraph"/>
-    <Returns>A direct product of permutation groups.</Returns>
-    <Description>
-    If <A>digraph</A> is a multidigraph, then this function returns the
-    automorphism group of <A>digraph</A>, as a group of permutations on the
-    vertices and edges of <A>digraph</A>.<P/>
-
-    For convenience, the returned group is the direct product of the group of
-    automorphisms of the vertices of <A>digraph</A> with the stabiliser of the
-    vertices in the automorphism group of the edges. These two groups can be
-    accessed using the <Ref Oper="Projection"
-      Label="for a domain and a positive integer" BookName="ref"/> with second
-    argument <C>1</C> and <C>2</C>,
-    respectively.
-    <P/>
-
-    The permutations in the automorphism group of the edges act on the indices
-    of the edges of <A>digraph</A>.<P/>
-
-    The automorphism group is found using <URL
-      Text="bliss">http://www.tcs.tkk.fi/Software/bliss/index.html</URL> by
-    Tommi Junttila and Petteri Kaski.
-
-    <Example><![CDATA[
 gap> gr := DigraphEdgeUnion(CycleDigraph(3), CycleDigraph(3));
 <multidigraph with 3 vertices, 6 edges>
 gap> G := AutomorphismGroup(gr);
@@ -97,78 +74,324 @@ Group([ (1,2,3) ])
 gap> Range(Projection(G, 2));
 Group([ (5,6), (3,4), (1,2) ])
 gap> Size(G);
-24]]></Example>
-  </Description>
+24
+gap> gr := Digraph([[2], [3, 3], [3], [2]]);
+<multidigraph with 4 vertices, 5 edges>
+gap> G := AutomorphismGroup(gr);
+Group([ (1,2), (3,4) ])
+gap> P1 := Projection(G, 1); 
+1st projection of Group([ (1,2), (3,4) ])
+gap> P2 := Projection(G, 2);
+2nd projection of Group([ (1,2), (3,4) ])
+gap> DigraphVertices(gr);
+[ 1 .. 4 ]
+gap> Range(P1);
+Group([ (1,4) ])
+gap> DigraphEdges(gr);
+[ [ 1, 2 ], [ 2, 3 ], [ 2, 3 ], [ 3, 3 ], [ 4, 2 ] ]
+gap> Range(P2);
+Group([ (2,3) ])]]></Example>
+    </Description>
   </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="AutomorphismGroupDigraphColours">
+<ManSection>
+  <Oper Name="AutomorphismGroup" Label="for a digraph and a homogeneous list"
+    Arg="digraph, colours"/>
+  <Returns>A permutation group.</Returns>
+  <Description>
+
+    This operation computes the automorphism group of a coloured digraph.
+    A coloured digraph can be specified by its underlying digraph
+    <A>digraph</A> and its colouring <A>colours</A>. Let <C>n</C> be the
+    number of vertices of <A>digraph</A>. The colouring <A>colours</A> may
+    have one of the following two forms:
+
+    <List>
+      <Item>
+        a list of <C>n</C> integers, where <A>colours</A><C>[i]</C> is the
+        colour of vertex <C>i</C>, using the colours <C>[1 .. m]</C> for some
+        <C>m &lt;= n</C>; or
+      </Item>
+      <Item>
+        a list of non-empty disjoint lists whose union is
+        <C>DigraphVertices(<A>digraph</A>)</C>, such that
+        <A>colours</A><C>[i]</C> is the list of all vertices with colour
+        <C>i</C>.
+      </Item>
+    </List>
+
+    The <E>automorphism group</E> of a coloured digraph <A>digraph</A> with
+    colouring <A>colours</A> is the group consisting of its automorphisms; an
+    <E>automorphism</E> of <A>digraph</A> is an isomorphism of coloured
+    digraphs from <A>digraph</A> to itself.  This group is equal to the
+    subgroup of <C>AutomorphismGroup(<A>digraph</A>)</C> consisting of those
+    automorphisms that preserve the colouring specified by <A>colours</A>. See
+    <Ref Attr="AutomorphismGroup" Label="for a digraph" />, and see <Ref
+      Oper="IsomorphismDigraphs" Label="for digraphs and homogeneous lists" />
+    for more information about isomorphisms of coloured digraphs. <P/>
+
+    The form in which the automorphism group is returned depends on whether
+    <A>digraph</A> has multiple edges; see <Ref Prop="IsMultiDigraph" />.
+
+    <List>
+      <Mark>for a digraph without multiple edges</Mark>
+      <Item>
+        If <A>digraph</A> has no multiple edges, then the automorphism group
+        is returned as a group of permutations on the vertices of
+        <A>digraph</A>.
+      </Item>
+      <Mark>for a multidigraph</Mark>
+      <Item>
+        If <A>digraph</A> is a multidigraph, then the automorphism group is
+        a group of permutations on the vertices and edges of <A>digraph</A>.
+        <P/>
+
+        For convenience, the group is returned as the direct product <C>G</C> of
+        the group of automorphisms of the vertices of <A>digraph</A> with the
+        stabiliser of the vertices in the automorphism group of the edges. These
+        two groups can be accessed using the operation <Ref Oper="Projection"
+          Label="for a domain and a positive integer" BookName="ref"/>, with the
+        second argument being <C>1</C> or <C>2</C>, respectively. <P/>
+
+        The permutations in the group <C>Projection(G, 1)</C> act on the
+        vertices of <A>digraph</A>, and the permutations in the group
+        <C>Projection(G, 2)</C> act on the indices of
+        <C>DigraphEdges(<A>digraph</A>)</C>.
+      </Item>
+    </List>
+
+    The automorphism group is found using &bliss; by Tommi Junttila and Petteri
+    Kaski.
+
+  <Example><![CDATA[
+gap> cycle := CycleDigraph(9);
+<digraph with 9 vertices, 9 edges>
+gap> G := AutomorphismGroup(cycle);;
+gap> StructureDescription(G);
+"C9"
+gap> colours := [[1, 4, 7], [2, 5, 8], [3, 6, 9]];;
+gap> H := AutomorphismGroup(cycle, colours);;
+gap> StructureDescription(H);
+"C3"
+gap> H = AutomorphismGroup(cycle, [1, 2, 3, 1, 2, 3, 1, 2, 3]);
+true
+gap> H = SubgroupByProperty(G, p -> OnTuplesSets(colours, p) = colours);
+true
+gap> IsTrivial(AutomorphismGroup(cycle, [1, 1, 2, 2, 2, 2, 2, 2, 2]));
+true
+gap> gr := Digraph([[2], [3, 3], [3], [2], [2]]);
+<multidigraph with 5 vertices, 6 edges>
+gap> G := AutomorphismGroup(gr, [1, 1, 2, 3, 1]);
+Group([ (1,2), (3,4) ])
+gap> P1 := Projection(G, 1); 
+1st projection of Group([ (1,2), (3,4) ])
+gap> P2 := Projection(G, 2);
+2nd projection of Group([ (1,2), (3,4) ])
+gap> DigraphVertices(gr);
+[ 1 .. 5 ]
+gap> Range(P1);
+Group([ (1,5) ])
+gap> DigraphEdges(gr);
+[ [ 1, 2 ], [ 2, 3 ], [ 2, 3 ], [ 3, 3 ], [ 4, 2 ], [ 5, 2 ] ]
+gap> Range(P2);
+Group([ (2,3) ])]]></Example>
+  </Description>
+</ManSection>
 <#/GAPDoc>
 
 <#GAPDoc Label="DigraphCanonicalLabelling">
 <ManSection>
   <Attr Name="DigraphCanonicalLabelling" Label="for a digraph" Arg="digraph"/>
-  <Oper Name="DigraphCanonicalLabelling" Label="for a digraph and a list"
-    Arg="digraph, colors"/>
-  <Returns> A permutation.</Returns>
+  <Returns>A permutation, or a list of two permutations.</Returns>
   <Description>
-    A function <M>\rho</M> from a digraph to a digraph is a <E>canonical
-    representative map</E> if the following two conditions hold:
-    <List>
-      <Item>
-        <M>\rho(G)</M> and <M>G</M> are isomorphic; and
-      </Item>
-      <Item>
-        <M>\rho(G)=\rho(H)</M> if and only if <M>G</M> and <M>H</M> are isomorphic.
-      </Item>
-    </List>
-
-    A canonical labelling of a digraph <A>digraph</A> (under <M>\rho</M>) is
-    an isomorphism of <A>digraph</A> onto its canonical representative
-    <M>\rho(</M><A>digraph</A><M>)</M> given as a permutation of the vertices
-    (and the edges in case <A>digraph</A> has multiple edges). <P/>
-
-    If the <A>colors</A> argument is specified, then the canonical labelling
-    will respect the given colouring.  The colouring
-    <A>colors</A> can be in one of two forms: <P/>
+    A function <M>\rho</M> that maps a digraph to a digraph is a <E>canonical
+      representative map</E> if the following two conditions hold for all
+    digraphs <M>G</M> and <M>H</M>: <P/>
 
     <List>
       <Item>
-        A list of positive integers of size the number of vertices of
-        <A>digraph</A>, where <A>colors</A><C>[i]</C> is the colour of vertex
-        <C>i</C>.
+        <M>\rho(G)</M> and <M>G</M> are isomorphic as digraphs; and
       </Item>
       <Item>
-        A list of lists, such that <A>colors</A><C>[i]</C> is a list of all
-        vertices with colour <C>i</C>.
+        <M>\rho(G)=\rho(H)</M> if and only if <M>G</M> and <M>H</M> are
+        isomorphic as digraphs.
       </Item>
     </List>
 
-    The canonical labelling is found using <URL
-      Text="bliss">http://www.tcs.tkk.fi/Software/bliss/index.html</URL> by
-    Tommi Junttila and Petteri Kaski.
+    A <E>canonical labelling</E> of a digraph <M>G</M> (under <M>\rho</M>) is an
+    isomorphism of <M>G</M> onto its <E>canonical representative</E>,
+    <M>\rho(G)</M>.  See <Ref Oper="IsomorphismDigraphs" Label="for digraphs" />
+    for more information about isomorphisms of digraphs. <P/>
+
+    The attribute <C>DigraphCanonicalLabelling</C> returns a canonical labelling
+    of the digraph <A>digraph</A>.  The form of the canonical labelling returned
+    by <C>DigraphCanonicalLabelling</C> depends on whether <A>digraph</A> has
+    multiple edges; see <Ref Prop="IsMultiDigraph" />. <P/>
+
+    <List>
+      <Mark>for a digraph without multiple edges</Mark>
+      <Item>
+        If the digraph <A>digraph</A> has no multiple edges, then the canonical
+        labelling of <A>digraph</A> is given as a permutation of its vertices.
+        The canonical representative of <A>digraph</A> can be created from
+        <A>digraph</A> and its canonical labelling <C>p</C> by using the
+        operation <Ref Oper="OnDigraphs" Label="for a digraph and a perm" />:
+        <Log>gap> OnDigraphs(digraph, p);</Log>
+      </Item>
+      <Mark>for a multidigraph</Mark>
+      <Item>
+        The canonical labelling of the multidigraph <A>digraph</A> is given as a
+        pair <C>P</C> of permutations. The first, <C>P[1]</C>, is a permutation
+        of the vertices of <A>digraph</A>. The second, <C>P[2]</C>, is a
+        permutation of the edges of <A>digraph</A>; it acts on the indices of
+        the list <C>DigraphEdges(<A>digraph</A>)</C>.  The canonical
+        representative of <A>digraph</A> can be created from <A>digraph</A> and
+        its canonical labelling <C>P</C> by using the operation <Ref
+          Oper="OnMultiDigraphs" />:
+        <Log>gap> OnMultiDigraphs(digraph, P);</Log>
+      </Item>
+    </List>
+
+    The canonical labelling is found using &bliss; by Tommi Junttila and Petteri
+    Kaski.
     <Example><![CDATA[
-gap> G := DigraphFromDiSparse6String(".ImNS_AiB?qRN");
+gap> digraph1 := DigraphFromDiSparse6String(".ImNS_AiB?qRN");
 <digraph with 10 vertices, 8 edges>
-gap> DigraphCanonicalLabelling(G);
+gap> DigraphCanonicalLabelling(digraph1);
 (1,3,4)(2,10,6,7,9,8)
-gap> DigraphCanonicalLabelling(G, [[1 .. 5], [6 .. 10]]);
-(1,4,3,5)(6,8)(7,9,10)
-gap> DigraphCanonicalLabelling(G, [1, 1, 1, 1, 2, 3, 1, 3, 2, 1]);
-(2,3,4,6,10,5,8,9,7)
 gap> p := (1, 2, 7, 5)(3, 9)(6, 10, 8);;
-gap> H := Digraph(
->  10,
->  OnTuples([1, 1, 3, 4, 4, 5, 8, 8], p),
->  OnTuples([6, 3, 3, 9, 10, 9, 4, 10], p)
-> );
+gap> digraph2 := OnDigraphs(digraph1, p);
 <digraph with 10 vertices, 8 edges>
-gap> G = H;
+gap> digraph1 = digraph2;
 false
-gap> OnDigraphs(G, DigraphCanonicalLabelling(G)) =
->    OnDigraphs(H, DigraphCanonicalLabelling(H));
+gap> OnDigraphs(digraph1, DigraphCanonicalLabelling(digraph1)) =
+>    OnDigraphs(digraph2, DigraphCanonicalLabelling(digraph2));
 true
 gap> gr := DigraphFromDiSparse6String(".ImEk|O@SK?od");
 <multidigraph with 10 vertices, 10 edges>
 gap> DigraphCanonicalLabelling(gr);
-[ (1,9,7,5)(2,10,3), (1,6,9)(2,5,10,4,8)(3,7) ]]]></Example>
+[ (1,9,7,5)(2,10,3), (1,6,9)(2,5,10,4,8)(3,7) ]
+gap> gr := Digraph([[2], [3, 3], [3], [2], [2]]);
+<multidigraph with 5 vertices, 6 edges>
+gap> DigraphCanonicalLabelling(gr, [1, 2, 2, 1, 3]);
+[ (1,2,4), (1,2,6,4,3,5) ]]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphCanonicalLabellingColours">
+<ManSection>
+  <Oper Name="DigraphCanonicalLabelling" Label="for a digraph and a list"
+    Arg="digraph, colours"/>
+  <Returns>A permutation.</Returns>
+  <Description>
+    A function <M>\rho</M> that maps a coloured digraph to a coloured digraph is
+    a <E>canonical representative map</E> if the following two conditions hold
+    for all coloured digraphs <M>G</M> and <M>H</M>:
+
+    <List>
+      <Item>
+        <M>\rho(G)</M> and <M>G</M> are isomorphic as coloured digraphs; and
+      </Item>
+      <Item>
+        <M>\rho(G)=\rho(H)</M> if and only if <M>G</M> and <M>H</M> are
+        isomorphic as coloured digraphs.
+      </Item>
+    </List>
+
+    A <E>canonical labelling</E> of a coloured digraph <M>G</M> (under
+    <M>\rho</M>) is an isomorphism of <M>G</M> onto its <E>canonical
+      representative</E>, <M>\rho(G)</M>.  See <Ref Oper="IsomorphismDigraphs"
+      Label="for digraphs and homogeneous lists" /> for more information about
+    isomorphisms of coloured digraphs. <P/>
+
+    A coloured digraph can be specified by its underlying digraph <A>digraph</A>
+    and its colouring <A>colours</A>.  Let <C>n</C> be the number of vertices of
+    <A>digraph</A>. The colouring <A>colours</A> may have one of the following
+    two forms: <P/>
+
+    <List>
+      <Item>
+        a list of <C>n</C> integers, where <A>colours</A><C>[i]</C> is the
+        colour of vertex <C>i</C>, using the colours <C>[1 .. m]</C> for some
+        <C>m &lt;= n</C>; or
+      </Item>
+      <Item>
+        a list of non-empty disjoint lists whose union is
+        <C>DigraphVertices(<A>digraph</A>)</C>, such that
+        <A>colours</A><C>[i]</C> is the list of all vertices with colour
+        <C>i</C>.
+      </Item>
+    </List>
+
+    If <A>digraph</A> and <A>colours</A> together form a coloured digraph, then
+    the operation <C>DigraphCanonicalLabelling</C> returns a canonical labelling
+    of the coloured digraph. The form of the canonical labelling returned
+    by <C>DigraphCanonicalLabelling</C> depends on whether <A>digraph</A> has
+    multiple edges; see <Ref Prop="IsMultiDigraph" />. <P/>
+
+    <List>
+      <Mark>for a digraph without multiple edges</Mark>
+      <Item>
+        If the digraph <A>digraph</A> has no multiple edges, then the canonical
+        labelling of <A>digraph</A> is given as a permutation of its vertices.
+        The canonical representative of <A>digraph</A> can be created from
+        <A>digraph</A> and its canonical labelling <C>p</C> by using the
+        operation <Ref Oper="OnDigraphs" Label="for a digraph and a perm" />:
+        <Log>gap> OnDigraphs(digraph, p);</Log>
+      </Item>
+      <Mark>for a multidigraph</Mark>
+      <Item>
+        The canonical labelling of the multidigraph <A>digraph</A> is given as a
+        pair <C>P</C> of permutations. The first, <C>P[1]</C>, is a permutation
+        of the vertices of <A>digraph</A>. The second, <C>P[2]</C>, is a
+        permutation of the edges of <A>digraph</A>; it acts on the indices of
+        the list <C>DigraphEdges(<A>digraph</A>)</C>.  The canonical
+        representative of <A>digraph</A> can be created from <A>digraph</A> and
+        its canonical labelling <C>P</C> by using the operation <Ref
+          Oper="OnMultiDigraphs" />:
+        <Log>gap> OnMultiDigraphs(digraph, P);</Log>
+      </Item>
+    </List>
+    
+    In either case, the colouring of the canonical representative can easily be
+    constructed. A vertex <C>v</C> (in <A>digraph</A>) has colour <C>i</C> if
+    and only if the vertex <C>v ^ p</C> (in the canonical representative) has
+    colour <C>i</C>, where <C>p</C> is the permutation of the canonical
+    labelling that acts on the vertices of <A>digraph</A>. In particular, if
+    <A>colours</A> has the first form that is described above, then the
+    colouring of the canonical representative is given by:
+
+    <Log>gap> List(DigraphVertices(digraph), i -> colours[i / p]);</Log>
+
+    On the other hand, if <A>colours</A> has the second form above, then the
+    canonical representative has colouring:
+
+    <Log>gap> OnTuplesSets(colours, p);</Log>
+
+    <P/>
+
+    The canonical labelling is found using &bliss; by Tommi Junttila and Petteri
+    Kaski.
+    <Example><![CDATA[
+gap> digraph := DigraphFromDiSparse6String(".ImNS_AiB?qRN");
+<digraph with 10 vertices, 8 edges>
+gap> colours := [[1, 2, 8, 9, 10], [3, 4, 5, 6, 7]];;
+gap> p := DigraphCanonicalLabelling(digraph, colours);
+(2,3,7,10)(4,6,9,5,8)
+gap> OnDigraphs(digraph, p);
+<digraph with 10 vertices, 8 edges>
+gap> OnTuplesSets(colours, p);
+[ [ 1, 2, 3, 4, 5 ], [ 6, 7, 8, 9, 10 ] ]
+gap> colours := [1, 1, 1, 1, 2, 3, 1, 3, 2, 1];;
+gap> p := DigraphCanonicalLabelling(digraph, colours);
+(2,3,4,6,10,5,8,9,7)
+gap> OnDigraphs(digraph, p);
+<digraph with 10 vertices, 8 edges>
+gap> List(DigraphVertices(digraph), i -> colours[i / p]);
+[ 1, 1, 1, 1, 1, 1, 2, 2, 3, 3 ]]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -178,12 +401,13 @@ gap> DigraphCanonicalLabelling(gr);
   <Oper Name="IsIsomorphicDigraph" Label="for digraphs" Arg="digraph1, digraph2"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
-    This operation returns <K>true</K> if the digraph <A>digraph1</A> is
-    isomorphic to the digraph <A>digraph2</A>.<P/>
+    This operation returns <K>true</K> if there exists an isomorphism from the
+    digraph <A>digraph1</A> to the digraph <A>digraph2</A>.  See <Ref
+      Oper="IsomorphismDigraphs" Label="for digraphs" /> for more information
+    about isomorphisms of digraphs. <P/>
 
-    This operation uses the canonical labelling of the digraphs found with <URL
-      Text="bliss">http://www.tcs.tkk.fi/Software/bliss/index.html</URL> by
-    Tommi Junttila and Petteri Kaski.
+    This operation uses the canonical labelling of the digraphs found with
+    &bliss; by Tommi Junttila and Petteri Kaski.
 
     <Example><![CDATA[
 gap> digraph1 := CycleDigraph(4);
@@ -212,38 +436,119 @@ true]]></Example>
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="IsomorphismDigraphs">
+<#GAPDoc Label="IsIsomorphicDigraphColours">
 <ManSection>
-  <Oper Name="IsomorphismDigraphs" Label="for digraphs" Arg="digraph1, digraph2"/>
-  <Returns> A permutation or <K>fail</K>.</Returns>
+  <Oper Name="IsIsomorphicDigraph" Label="for digraphs and homogeneous lists"
+    Arg="digraph1, digraph2, colours1, colours2"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
-    If <A>digraph1</A> and <A>digraph2</A> are isomorphic digraphs, then this
-    operation returns an isomorphism from <A>digraph1</A> to <A>digraphs2</A>.
-
-    More precisely,
+    This operation tests for isomorphism of coloured digraphs.  A coloured
+    digraph can be specified by its underlying digraph <A>digraph1</A> and its
+    colouring <A>colours1</A>.  Let <C>n</C> be the number of vertices of
+    <A>digraph1</A>. The colouring <A>colours1</A> may have one of the following
+    two forms:
 
     <List>
-      <Mark>for multidigraphs</Mark>
       <Item>
-        this operation returns a pair of permutations <C>P</C> such that
-        <C>OnMultiDigraphs(<A>digraph1</A>, P) = digraph2</C>. The first
-        permutation is defined on the vertices of <A>digraph1</A> and the second
-        on the edges.
+        a list of <C>n</C> integers, where <A>colours</A><C>[i]</C> is the
+        colour of vertex <C>i</C>, using the colours <C>[1 .. m]</C> for some
+        <C>m &lt;= n</C>; or
       </Item>
-      <Mark>for digraphs without multiple edges</Mark>
       <Item>
-        this operation returns a permutation <C>p</C> such that
-        <C>OnDigraphs(<A>digraph1</A>, p) = digraph2</C>.
+        a list of non-empty disjoint lists whose union is
+        <C>DigraphVertices(<A>digraph</A>)</C>, such that
+        <A>colours</A><C>[i]</C> is the list of all vertices with colour
+        <C>i</C>.
       </Item>
     </List>
 
-    If <A>digraph1</A> and <A>digraph2</A> are not isomorphic, then <K>fail</K>
-    is returned.
+    If <A>digraph1</A> and <A>digraph2</A> are digraphs without multiple edges,
+    and <A>colours1</A> and <A>colours2</A> are colourings of <A>digraph1</A>
+    and <A>digraph2</A>, respectively, then this operation returns <K>true</K>
+    if there exists an isomorphism between these two coloured digraphs.  See
+    <Ref Oper="IsomorphismDigraphs" Label="for digraphs and homogeneous lists"
+      /> for more information about isomorphisms of coloured digraphs. <P/>
+
+    This operation uses the canonical labelling of the digraphs found with
+    &bliss; by Tommi Junttila and Petteri Kaski.
+
+    <Example><![CDATA[
+gap> digraph1 := ChainDigraph(4);
+<digraph with 4 vertices, 3 edges>
+gap> digraph2 := ChainDigraph(3);
+<digraph with 3 vertices, 2 edges>
+gap> IsIsomorphicDigraph(digraph1, digraph2,
+>  [[1, 4], [2, 3]], [[1, 2], [3]]);
+false
+gap> digraph2 := DigraphReverse(digraph1);
+<digraph with 4 vertices, 3 edges>
+gap> IsIsomorphicDigraph(digraph1, digraph2,
+>  [1, 1, 1, 1], [1, 1, 1, 1]);
+true
+gap> IsIsomorphicDigraph(digraph1, digraph2,
+>  [1, 2, 2, 1], [1, 2, 2, 1]);
+true
+gap> IsIsomorphicDigraph(digraph1, digraph2,
+>  [1, 1, 2, 2], [1, 1, 2, 2]);
+false
+gap> digraph1 := Digraph([[2, 1, 2], [1, 2, 1]]);
+<multidigraph with 2 vertices, 6 edges>
+gap> IsIsomorphicDigraph(digraph1, digraph1, [2, 1], [1, 2]);
+true
+gap> IsIsomorphicDigraph(digraph1, digraph1, [1, 1], [1, 2]);
+false]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsomorphismDigraphs">
+<ManSection>
+  <Oper Name="IsomorphismDigraphs" Label="for digraphs" Arg="digraph1, digraph2"/>
+  <Returns> A permutation, or a pair of permutations, or <K>fail</K>.</Returns>
+  <Description>
+    This operation returns an isomorphism between the digraphs <A>digraph1</A>
+    and <A>digraph2</A> if one exists, else this operation returns <K>fail</K>.
     <P/>
 
-    This operation uses the canonical labelling of the digraphs found with <URL
-    Text="bliss">http://www.tcs.tkk.fi/Software/bliss/index.html</URL> by
-    Tommi Junttila and Petteri Kaski.
+    <List>
+      <Mark>for digraphs without multiple edges</Mark>
+      <Item>
+        An <E>isomorphism</E> from a digraph <A>digraph1</A> to a digraph
+        <A>digraph2</A> is a bijection <C>p</C> from the vertices of
+        <A>digraph1</A> to the vertices of <A>digraph2</A> with the following
+        property: for all vertices <C>i</C> and <C>j</C> of <A>digraph1</A>,
+        <C>[i, j]</C> is an edge of <A>digraph1</A> if and only if <C>[i ^ p, j
+          ^ p]</C> is an edge of <A>digraph2</A>. <P/>
+
+        If there exists such an isomorphism, then this operation returns one.
+        The form of this isomorphism is a permutation <C>p</C> of the vertices of
+        <A>digraph1</A> such that <P/>
+
+        <C>OnDigraphs(<A>digraph1</A>, p) = digraph2</C>.
+      </Item>
+      <Mark>for multidigraphs</Mark>
+      <Item>
+        An <E>isomorphism</E> from a multidigraph <A>digraph1</A> to a
+        multidigraph <A>digraph2</A> is a bijection <C>P[1]</C> from the
+        vertices of <A>digraph1</A> to the vertices of <A>digraph2</A> and a
+        bijection <C>P[2]</C> from the indices of edges of <A>digraph1</A> to
+        the indices of edges of <A>digraph2</A> with the following property:
+        <C>[i, j]</C> is the <C>k</C>th edge of <A>digraph1</A> if and only if
+        <C>[i ^ P[1], j ^ P[1]]</C> is the <C>(k ^ P[2])</C>th edge of
+        <A>digraph2</A>. <P/>
+
+        If there exists such an isomorphism, then this operation returns one.
+        The form of this isomorphism is a pair of permutations <C>P</C> -– where
+        the first is a permutation of the vertices of <A>digraph1</A> and the
+        second is a permutation of the indices of
+        <C>DigraphEdges(<A>digraph1</A>)</C> –- such that <P/>
+
+        <C>OnMultiDigraphs(<A>digraph1</A>, P) = <A>digraph2</A></C>.
+      </Item>
+    </List>
+
+    This operation uses the canonical labelling of the digraphs found with
+    &bliss; by Tommi Junttila and Petteri Kaski.
 
     <Example><![CDATA[
 gap> digraph1 := CycleDigraph(4);
@@ -252,19 +557,19 @@ gap> digraph2 := CycleDigraph(5);
 <digraph with 5 vertices, 5 edges>
 gap> IsomorphismDigraphs(digraph1, digraph2);
 fail
-gap> gr1 := CompleteBipartiteDigraph(10, 5);
+gap> digraph1 := CompleteBipartiteDigraph(10, 5);
 <digraph with 15 vertices, 100 edges>
-gap> gr2 := CompleteBipartiteDigraph(5, 10);
+gap> digraph2 := CompleteBipartiteDigraph(5, 10);
 <digraph with 15 vertices, 100 edges>
-gap> p := IsomorphismDigraphs(gr1, gr2);
+gap> p := IsomorphismDigraphs(digraph1, digraph2);
 (1,6,11)(2,7,12)(3,8,13)(4,9,14)(5,10,15)
-gap> OnDigraphs(gr1, p) = gr2;
+gap> OnDigraphs(digraph1, p) = digraph2;
 true
-gap> gr1 := DigraphFromDiSparse6String(".ImNS_?DSE@ce[~");
+gap> digraph1 := DigraphFromDiSparse6String(".ImNS_?DSE@ce[~");
 <multidigraph with 10 vertices, 10 edges>
-gap> gr2 := DigraphFromDiSparse6String(".IkOlQefi_kgOf");
+gap> digraph2 := DigraphFromDiSparse6String(".IkOlQefi_kgOf");
 <multidigraph with 10 vertices, 10 edges>
-gap> IsomorphismDigraphs(gr1, gr2);
+gap> IsomorphismDigraphs(digraph1, digraph2);
 [ (1,9,5,3,10,6,4,7,2), (1,8,6,3,7)(2,9,4,10,5) ]
 gap> digraph1 := DigraphByEdges([[7, 10], [7, 10]], 10);
 <multidigraph with 10 vertices, 2 edges>
@@ -272,6 +577,90 @@ gap> digraph2 := DigraphByEdges([[2, 3], [2, 3]], 10);
 <multidigraph with 10 vertices, 2 edges>
 gap> IsomorphismDigraphs(digraph1, digraph2);
 [ (2,4,6,8,9,10,3,5,7), () ]]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsomorphismDigraphsColours">
+<ManSection>
+  <Oper Name="IsomorphismDigraphs" Label="for digraphs and homogeneous lists"
+    Arg="digraph1, digraph2, colours1, colours2"/>
+  <Returns> A permutation, or <K>fail</K>.</Returns>
+  <Description>
+    This operation searches for an isomorphism between coloured digraphs.  A
+    coloured digraph can be specified by its underlying digraph <A>digraph1</A>
+    and its colouring <A>colours1</A>.  Let <C>n</C> be the number of vertices
+    of <A>digraph1</A>. The colouring <A>colours1</A> may have one of the
+    following two forms:
+
+    <List>
+      <Item>
+        a list of <C>n</C> integers, where <A>colours</A><C>[i]</C> is the
+        colour of vertex <C>i</C>, using the colours <C>[1 .. m]</C> for some
+        <C>m &lt;= n</C>; or
+      </Item>
+      <Item>
+        a list of non-empty disjoint lists whose union is
+        <C>DigraphVertices(<A>digraph</A>)</C>, such that
+        <A>colours</A><C>[i]</C> is the list of all vertices with colour
+        <C>i</C>.
+      </Item>
+    </List>
+
+    An <E>isomorphism</E> between coloured digraphs is an isomorphism between
+    the underlying digraphs that preserves the colourings.  See <Ref
+      Oper="IsomorphismDigraphs" Label="for digraphs"/> for more information
+    about isomorphisms of digraphs. More precisely, let <C>f</C> be an
+    isomorphism of digraphs from the digraph <A>digraph1</A> (with colouring
+    <A>colours1</A>) to the digraph <A>digraph2</A> (with colouring
+    <A>colours2</A>), and let <C>p</C> be the permutation of the vertices of
+    <A>digraph1</A> that corresponds to <C>f</C>.  Then <C>f</C> preserves the
+    colourings of <A>digraph1</A> and <A>digraph2</A> – and hence is an
+    isomorphism of coloured digraphs – if <C><A>colours1</A>[i] =
+      <A>colours2</A>[i ^ p]</C> for all vertices <C>i</C> in <A>digraph1</A>.
+    <P/>
+
+    This operation returns such an isomorphism if one exists, else it returns
+    <K>fail</K>. <P/>
+
+    This operation uses the canonical labelling of the digraphs found with
+    &bliss; by Tommi Junttila and Petteri Kaski.
+
+    <Example><![CDATA[
+gap> digraph1 := ChainDigraph(4);
+<digraph with 4 vertices, 3 edges>
+gap> digraph2 := ChainDigraph(3);
+<digraph with 3 vertices, 2 edges>
+gap> IsomorphismDigraphs(digraph1, digraph2,
+>  [[1, 4], [2, 3]], [[1, 2], [3]]);
+fail
+gap> digraph2 := DigraphReverse(digraph1);
+<digraph with 4 vertices, 3 edges>
+gap> colours1 := [1, 1, 1, 1];;
+gap> colours2 := [1, 1, 1, 1];;
+gap> p := IsomorphismDigraphs(digraph1, digraph2, colours1, colours2);
+(1,4)(2,3)
+gap> OnDigraphs(digraph1, p) = digraph2;
+true
+gap> List(DigraphVertices(digraph1), i -> colours1[i ^ p]) = colours2;
+true
+gap> colours1 := [1, 1, 2, 2];;
+gap> colours2 := [2, 2, 1, 1];;
+gap> p := IsomorphismDigraphs(digraph1, digraph2, colours1, colours2);
+(1,4)(2,3)
+gap> OnDigraphs(digraph1, p) = digraph2;
+true
+gap> List(DigraphVertices(digraph1), i -> colours1[i ^ p]) = colours2;
+true
+gap> IsomorphismDigraphs(digraph1, digraph2,
+>  [1, 1, 2, 2], [1, 1, 2, 2]);
+fail
+gap> digraph1 := Digraph([[2, 2], [2], [1]]);
+<multidigraph with 3 vertices, 4 edges>
+gap> digraph2 := Digraph([[1], [1, 1], [2]]);
+<multidigraph with 3 vertices, 4 edges>
+gap> IsomorphismDigraphs(digraph1, digraph2, [1, 2, 2], [2, 1, 2]);
+[ (1,2), (1,2,3) ]]]></Example>
 </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -336,43 +336,49 @@ gap> GeneratorsOfEndomorphismMonoid(gr, [[1], [2, 3]]);
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="DigraphColoring">
+<#GAPDoc Label="DigraphColouring">
 <ManSection>
-  <Oper Name="DigraphColoring" Arg="digraph, n"
-    Label="for a digraph and a number of colors"/>
   <Oper Name="DigraphColouring" Arg="digraph, n"
-    Label="for a digraph and a number of colors"/>
-  <Attr Name="DigraphColoring" Arg="digraph"
-    Label="for a digraph"/>
+    Label="for a digraph and a number of colours"/>
+  <Oper Name="DigraphColoring" Arg="digraph, n"
+    Label="for a digraph and a number of colours"/>
   <Attr Name="DigraphColouring" Arg="digraph"
+    Label="for a digraph"/>
+  <Attr Name="DigraphColoring" Arg="digraph"
     Label="for a digraph"/>
   <Returns> A transformation, or <K>fail</K>.</Returns>
   <Description>
-    A digraph coloring is a labeling of the vertices (using precisely <A>n</A>
-    colors) in such a way that two adjacent vertices can not have the same
-    label.  Alternatively, it can be defined to be a <Ref
-      Oper="DigraphEpimorphism"/> from <A>digraph</A> onto a complete digraph
-    with <A>n</A> vertices.<P/>
+    A <E>proper colouring</E> of a digraph is a labelling of its vertices in
+    such a way that adjacent vertices have different labels. A <E>proper
+      <C>n</C>-colouring</E> is a proper colouring that uses exactly <C>n</C>
+    colours.  Equivalently, a proper (<C>n</C>-)colouring of a digraph can be
+    defined to be a <Ref Oper="DigraphEpimorphism"/> from a digraph onto the
+    complete digraph (with <C>n</C> vertices); see <Ref Oper="CompleteDigraph"/>.
+    <P/>
 
-    <C>DigraphColoring</C> returns such an epimorphism if one exists, else it
-    returns <K>fail</K>. <P/>
+    <C>DigraphColouring(<A>digraph</A>, <A>n</A>)</C> returns an epimorphism
+    from <A>digraph</A> onto the complete digraph with <A>n</A> vertices, if one
+    exists, else it returns <K>fail</K>. <P/>
 
-    Note that a digraph with at least two vertices has a 2-coloring if and only
-    if it is bipartite, see <Ref Prop="IsBipartiteDigraph"/>.<P/>
+    If the optional second argument <A>n</A> is not provided, then
+    <C>DigraphColouring</C> uses a greedy algorithm to obtain some proper
+    colouring of <A>digraph</A>, which may not use the minimal number of
+    colours. <P/>
 
-    If the third form is used, a greedy algorithm is used to obtain a
-    colouring, which possibly is not minimal.
+    Note that a digraph with at least two vertices has a 2-colouring if and only
+    if it is bipartite, see <Ref Prop="IsBipartiteDigraph"/>.
+
     <Example><![CDATA[
-gap> DigraphColoring(CompleteDigraph(5), 4);
+gap> DigraphColouring(CompleteDigraph(5), 4);
 fail
-gap> DigraphColoring(ChainDigraph(10), 1);
+gap> DigraphColouring(ChainDigraph(10), 1);
 fail
 gap> gr := ChainDigraph(10);;
-gap> t := DigraphColoring(gr, 2);
+gap> t := DigraphColouring(gr, 2);
 Transformation( [ 1, 2, 1, 2, 1, 2, 1, 2, 1, 2 ] )
 gap> ForAll(DigraphEdges(gr), e -> e[1] ^ t <> e[2] ^ t);
 true
-gap> DigraphColoring(gr);
+gap> DigraphColouring(gr);
 Transformation( [ 1, 2, 1, 2, 1, 2, 1, 2, 1, 2 ] )
 ]]></Example>
   </Description>
@@ -387,8 +393,9 @@ Transformation( [ 1, 2, 1, 2, 1, 2, 1, 2, 1, 2 ] )
     An embedding of a digraph <A>digraph1</A> into another digraph
     <A>digraph2</A> is a <Ref Oper="DigraphMonomorphism"/> from <A>digraph1</A>
     to <A>digraph2</A> which has the additional property that a pair of
-    vertices <C>[i,j]</C> which have no edge <C>i->j</C> in <A>digraph1</A> are
-    mapped to a pair of vertices <C>[a,b]</C> which have no edge <C>a->b</C> in
+    vertices <C>[i, j]</C> which have no edge <C>i -> j</C> in <A>digraph1</A> are
+
+    mapped to a pair of vertices <C>[a, b]</C> which have no edge <C>a->b</C> in
     <A>digraph2</A>.<P/>
 
     In other words, an embedding <C>t</C> is an isomorphism from

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -453,7 +453,7 @@ true
   vertices of <A>digraph</A> can be partitioned into two non-empty sets such
   that the source and range of any edge of <A>digraph</A> lie in distinct sets.
   Equivalently, a digraph is bipartite if and only if it is 2-colorable; see
-  <Ref Attr="DigraphColoring" Label="for a digraph"/>. <P/>
+  <Ref Attr="DigraphColouring" Label="for a digraph"/>. <P/>
 
   See also <Ref Attr="DigraphBicomponents"/>.
     <Example><![CDATA[

--- a/doc/z-appA.xml
+++ b/doc/z-appA.xml
@@ -1204,12 +1204,12 @@
           <C>VertexColouring</C>
         </Item>
         <Item>
-          <Ref Attr="DigraphColoring" Label="for a digraph"/>
+          <Ref Attr="DigraphColouring" Label="for a digraph"/>
         </Item>
         <Item>
           <Alt Only="HTML">
             <C>VertexColouring</C> in &Grape; is equivalent to <Ref
-            Attr="DigraphColoring" Label="for a digraph"/> in &Digraphs;,
+            Attr="DigraphColouring" Label="for a digraph"/> in &Digraphs;,
             except it return a transformation rather than a list of vertex
             colors.
           </Alt>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -42,7 +42,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="DigraphEpimorphism">
     <#Include Label="EpimorphismsDigraphs">
     <#Include Label="GeneratorsOfEndomorphismMonoid">
-    <#Include Label="DigraphColoring">
+    <#Include Label="DigraphColouring">
     <#Include Label="DigraphEmbedding">
     <#Include Label="ChromaticNumber">
   </Section>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -15,16 +15,19 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
 
   <Section><Heading>Isomorphisms, and Canonical labellings</Heading>
     <#Include Label="AutomorphismGroupDigraph">
-    <#Include Label="AutomorphismGroupMultiDigraph">
-    <#Include Label="DigraphGroup">
-    <#Include Label="DigraphSchreierVector">
-    <#Include Label="DigraphOrbitReps">
-    <#Include Label="DigraphStabilizer">
-    <#Include Label="DigraphOrbits">
-    <#Include Label="RepresentativeOutNeighbours">
+    <#Include Label="AutomorphismGroupDigraphColours">
     <#Include Label="DigraphCanonicalLabelling">
+    <#Include Label="DigraphCanonicalLabellingColours">
+    <#Include Label="DigraphGroup">
+    <#Include Label="DigraphOrbits">
+    <#Include Label="DigraphOrbitReps">
+    <#Include Label="DigraphSchreierVector">
+    <#Include Label="DigraphStabilizer">
     <#Include Label="IsIsomorphicDigraph">
+    <#Include Label="IsIsomorphicDigraphColours">
     <#Include Label="IsomorphismDigraphs">
+    <#Include Label="IsomorphismDigraphsColours">
+    <#Include Label="RepresentativeOutNeighbours">
   </Section>
 
   <Section><Heading>Homomorphisms of digraphs</Heading>

--- a/gap/bliss.gd
+++ b/gap/bliss.gd
@@ -14,3 +14,5 @@ DeclareAttribute("DigraphCanonicalLabelling", IsDigraph);
 DeclareOperation("DigraphCanonicalLabelling", [IsDigraph, IsHomogeneousList]);
 DeclareOperation("IsIsomorphicDigraph", [IsDigraph, IsDigraph]);
 DeclareOperation("IsomorphismDigraphs", [IsDigraph, IsDigraph]);
+
+DeclareGlobalFunction("DIGRAPHS_ValidateVertexColouring");

--- a/gap/bliss.gd
+++ b/gap/bliss.gd
@@ -1,7 +1,8 @@
 #############################################################################
 ##
 #W  bliss.gd
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
+##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -13,6 +14,10 @@ DeclareOperation("AutomorphismGroup", [IsDigraph, IsHomogeneousList]);
 DeclareAttribute("DigraphCanonicalLabelling", IsDigraph);
 DeclareOperation("DigraphCanonicalLabelling", [IsDigraph, IsHomogeneousList]);
 DeclareOperation("IsIsomorphicDigraph", [IsDigraph, IsDigraph]);
+DeclareOperation("IsIsomorphicDigraph",
+                 [IsDigraph, IsDigraph, IsHomogeneousList, IsHomogeneousList]);
 DeclareOperation("IsomorphismDigraphs", [IsDigraph, IsDigraph]);
+DeclareOperation("IsomorphismDigraphs",
+                 [IsDigraph, IsDigraph, IsHomogeneousList, IsHomogeneousList]);
 
 DeclareGlobalFunction("DIGRAPHS_ValidateVertexColouring");

--- a/gap/bliss.gi
+++ b/gap/bliss.gi
@@ -15,9 +15,9 @@ InstallMethod(DigraphCanonicalLabelling, "for a digraph",
 function(digraph)
 
   if IsMultiDigraph(digraph) then
-    return MULTIDIGRAPH_CANONICAL_LABELLING(digraph);
+    return MULTIDIGRAPH_CANONICAL_LABELLING(digraph, fail);
   fi;
-  return DIGRAPH_CANONICAL_LABELLING(digraph);
+  return DIGRAPH_CANONICAL_LABELLING(digraph, fail);
 end);
 
 InstallMethod(DigraphCanonicalLabelling,
@@ -52,7 +52,7 @@ function(graph, list)
     colors := list;
   fi;
 
-  return DIGRAPH_CANONICAL_LABELLING_COLOURS(graph, colors);
+  return DIGRAPH_CANONICAL_LABELLING(graph, colors);
 end);
 
 #
@@ -84,12 +84,12 @@ function(graph)
   local x;
 
   if IsMultiDigraph(graph) then
-    x := MULTIDIGRAPH_AUTOMORPHISMS(graph);
+    x := MULTIDIGRAPH_AUTOMORPHISMS(graph, fail);
     SetDigraphCanonicalLabelling(graph, x[1]);
     return DirectProduct(Group(x[2]), Group(x[3]));
   fi;
 
-  x := DIGRAPH_AUTOMORPHISMS(graph);
+  x := DIGRAPH_AUTOMORPHISMS(graph, fail);
   SetDigraphCanonicalLabelling(graph, x[1]);
   if not HasDigraphGroup(graph) then
     SetDigraphGroup(graph, Group(x[2]));
@@ -127,7 +127,7 @@ function(graph, list)
     fi;
     colors := list;
   fi;
-  return Group(DIGRAPH_AUTOMORPHISMS_COLOURS(graph, colors));
+  return Group(DIGRAPH_AUTOMORPHISMS(graph, colors)[2]);
 end);
 
 #

--- a/gap/bliss.gi
+++ b/gap/bliss.gi
@@ -12,12 +12,12 @@
 
 InstallMethod(DigraphCanonicalLabelling, "for a digraph",
 [IsDigraph],
-function(graph)
+function(digraph)
 
-  if IsMultiDigraph(graph) then
-    return MULTIDIGRAPH_CANONICAL_LABELING(graph);
+  if IsMultiDigraph(digraph) then
+    return MULTIDIGRAPH_CANONICAL_LABELLING(digraph);
   fi;
-  return DIGRAPH_CANONICAL_LABELING(graph);
+  return DIGRAPH_CANONICAL_LABELLING(digraph);
 end);
 
 InstallMethod(DigraphCanonicalLabelling,
@@ -52,7 +52,7 @@ function(graph, list)
     colors := list;
   fi;
 
-  return DIGRAPH_CANONICAL_LABELING_COLORS(graph, colors);
+  return DIGRAPH_CANONICAL_LABELLING_COLOURS(graph, colors);
 end);
 
 #
@@ -127,8 +127,7 @@ function(graph, list)
     fi;
     colors := list;
   fi;
-
-  return Group(DIGRAPH_AUTOMORPHISMS_COLORS(graph, colors));
+  return Group(DIGRAPH_AUTOMORPHISMS_COLOURS(graph, colors));
 end);
 
 #

--- a/gap/bliss.gi
+++ b/gap/bliss.gi
@@ -150,3 +150,110 @@ function(g1, g2)
 
   return DigraphCanonicalLabelling(g1) / DigraphCanonicalLabelling(g2);
 end);
+
+# Given a non-negative integer <n> and a homogeneous list <partition>,
+# this global function tests whether <partition> is a valid partition
+# of the list [1 .. n]. A valid partition of [1 .. n] is either:
+#
+# 1. A list of length <n> consisting of a numbers, such that the set of these
+#    numbers is [1 .. m] for some m <= n.
+# 2. A list of non-empty disjoint lists whose union is [1 .. n].
+#
+# If <partition> is a valid partition of [1 .. n] then this global function
+# returns the partition, in form 1 (converting it to this form if necessary).
+# If <partition> is invalid, then the function returns <fail>.
+
+InstallGlobalFunction(DIGRAPHS_ValidateVertexColouring,
+function(n, partition, method)
+  local colours, i, missing, seen, x;
+
+  if not IsInt(n) or n < 0 then
+    ErrorNoReturn("Digraphs: DIGRAPHS_ValidateVertexColouring: usage,\n",
+                  "the first argument <n> must be a non-negative integer,");
+  elif not IsString(method) then
+    ErrorNoReturn("Digraphs: DIGRAPHS_ValidateVertexColouring: usage,\n",
+                  "the third argument <method> must be a string,");
+  elif not IsHomogeneousList(partition) then
+    ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                  "in order to define a colouring, the argument <partition> ",
+                  "must be a homogeneous\nlist,");
+  elif n = 0 then
+    if IsEmpty(partition) then
+      return partition;
+    fi;
+    ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                  "the only valid partition of the vertices of the digraph ",
+                  "with 0 vertices is the\nempty list,");
+  elif not IsEmpty(partition) then
+    if IsPosInt(partition[1]) and Length(partition) = n then
+      # <partition> seems to be a list of colours
+      colours := [];
+      for i in partition do
+        if not IsPosInt(i) then
+          ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                        "the argument <partition> does not define a colouring ",
+                        "of the vertices [1 .. ", n, "],\nsince it contains ",
+                        "the element <i>, which is not a positive integer,");
+        elif i > n then
+          ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                        "the argument <partition> does not define a colouring ",
+                        "of the vertices [1 .. ", n, "],\nsince it contains ",
+                        "the integer ", i, ", which is greater than ", n, ",");
+        fi;
+        AddSet(colours, i);
+      od;
+      i := Length(colours);
+      missing := Difference([1 .. i], colours);
+      if not IsEmpty(missing) then
+        ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                      "the argument <partition> does not define a colouring ",
+                      "of the vertices [1 .. ", n, "],\nsince it contains the ",
+                      "colour ", colours[i], ", but it lacks the colour ",
+                      missing[1], ". A colouring must\nuse precisely the ",
+                      "colours [1 .. m], for some positive integer m <= ", n,
+                      ",");
+      fi;
+      return partition;
+    elif IsList(partition[1]) then
+      seen := BlistList([1 .. n], []);
+      colours := EmptyPlist(n);
+      for i in [1 .. Length(partition)] do
+        # guaranteed to be non-empty since <partition> is homogeneous
+        for x in partition[i] do
+          if not IsPosInt(x) or x > n then
+            ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                          "the argument <partition> does not define a ",
+                          "colouring of the vertices [1 .. ", n, "],\nsince ",
+                          "<partition[i]> contains <x>, which is not an ",
+                          "integer in the range\n[1 .. ", n, "],");
+          elif seen[x] then
+            ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                          "the argument <partition> does not define a ",
+                          "colouring of the vertices [1 .. ", n, "],\nsince ",
+                          "it contains the vertex ", x, " more than once,");
+          fi;
+          seen[x] := true;
+          colours[x] := i;
+        od;
+      od;
+      i := First([1 .. n], x -> not seen[x]);
+      if i <> fail then
+        ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                      "the argument <partition> does not define a ",
+                      "colouring of the vertices [1 .. ", n, "],\nsince ",
+                      "it does not assign a colour to the vertex ", i, ",");
+      fi;
+      return colours;
+    fi;
+  fi;
+  ErrorNoReturn("Digraphs: ", method, ": usage,\n",
+                "the argument <partition> does not define a ",
+                "colouring of the vertices [1 .. ", n, "].\nThe list ",
+                "<partition> must have one of the following forms:\n",
+                "1. <partition> is a list of length ", n, " consisting of ",
+                "every integer in the range\n   [1 .. m], for some m <= ", n,
+                ";\n2. <partition> is a list of non-empty disjoint lists ",
+                "whose union is [1 .. ", n, "].\nIn the first form, ",
+                "<partition[i]> is the colour of vertex i; in the second\n",
+                "form, <partition[i]> is the list of vertices with colour i,");
+end);

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -27,8 +27,8 @@ DeclareOperation("EpimorphismsDigraphsRepresentatives", [IsDigraph, IsDigraph]);
 
 DeclareOperation("DigraphEmbedding", [IsDigraph, IsDigraph]);
 
-DeclareOperation("DigraphColoring", [IsDigraph, IsInt]);
-DeclareAttribute("DigraphColoring", IsDigraph);
-DeclareSynonymAttr("DigraphColouring", DigraphColoring);
+DeclareOperation("DigraphColouring", [IsDigraph, IsInt]);
+DeclareAttribute("DigraphColouring", IsDigraph);
+DeclareSynonymAttr("DigraphColoring", DigraphColouring);
 
 DeclareGlobalFunction("HomomorphismDigraphsFinder");

--- a/gap/utils.gd
+++ b/gap/utils.gd
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  utils.gd
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2014-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##

--- a/gap/utils.gi
+++ b/gap/utils.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  utils.gi
-#Y  Copyright (C) 2013-15                                James D. Mitchell
+#Y  Copyright (C) 2013-17                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -5,7 +5,7 @@
 **                                                            Michael Torpey
 **                                                            Wilf A. Wilson
 **
-**  Copyright (C) 2014-15 - Julius Jonusas, James Mitchell, Michael Torpey,
+**  Copyright (C) 2014-17 - Julius Jonusas, James Mitchell, Michael Torpey,
 **  Wilf A. Wilson
 **
 **  This file is free software, see the digraphs/LICENSE.
@@ -1609,21 +1609,21 @@ BlissGraph* buildBlissMultiDigraph(Obj digraph) {
   return graph;
 }
 
-BlissGraph* buildBlissDigraphWithColors(Obj digraph, Obj colors) {
+BlissGraph* buildBlissDigraphWithColours(Obj digraph, Obj colours) {
   UInt        n, i, j, nr;
   Obj         adji, adj;
   BlissGraph* graph;
 
   n = DigraphNrVertices(digraph);
-  if (colors) {
-    assert(n == LEN_LIST(colors));
+  if (colours) {
+    assert(n == LEN_LIST(colours));
   }
   graph = bliss_digraphs_new(0);
   adj   = OutNeighbours(digraph);
 
-  if (colors) {
+  if (colours) {
     for (i = 1; i <= n; i++) {
-      bliss_digraphs_add_vertex(graph, INT_INTOBJ(ELM_LIST(colors, i)));
+      bliss_digraphs_add_vertex(graph, INT_INTOBJ(ELM_LIST(colours, i)));
     }
   } else {
     for (i = 1; i <= n; i++) {
@@ -1678,7 +1678,7 @@ static Obj FuncDIGRAPH_AUTOMORPHISMS(Obj self, Obj digraph) {
   const unsigned int* canon;
   Int                 i;
 
-  graph = buildBlissDigraphWithColors(digraph, NULL);
+  graph = buildBlissDigraphWithColours(digraph, NULL);
 
   autos = NEW_PLIST(T_PLIST, 2);
   n     = INTOBJ_INT(DigraphNrVertices(digraph));
@@ -1712,12 +1712,12 @@ static Obj FuncDIGRAPH_AUTOMORPHISMS(Obj self, Obj digraph) {
   return autos;
 }
 
-static Obj FuncDIGRAPH_AUTOMORPHISMS_COLORS(Obj self, Obj digraph, Obj colors) {
+static Obj FuncDIGRAPH_AUTOMORPHISMS_COLOURS(Obj self, Obj digraph, Obj colours) {
   Obj                 autos, n;
   BlissGraph*         graph;
   const unsigned int* canon;
 
-  graph = buildBlissDigraphWithColors(digraph, colors);
+  graph = buildBlissDigraphWithColours(digraph, colours);
 
   autos = NEW_PLIST(T_PLIST, 2);
   n     = INTOBJ_INT(DigraphNrVertices(digraph));
@@ -1851,14 +1851,14 @@ static Obj FuncMULTIDIGRAPH_AUTOMORPHISMS(Obj self, Obj digraph) {
   return autos;
 }
 
-static Obj FuncDIGRAPH_CANONICAL_LABELING(Obj self, Obj digraph) {
+static Obj FuncDIGRAPH_CANONICAL_LABELLING(Obj self, Obj digraph) {
   Obj                 p;
   UInt4*              ptr;
   BlissGraph*         graph;
   Int                 n, i;
   const unsigned int* canon;
 
-  graph = buildBlissDigraphWithColors(digraph, NULL);
+  graph = buildBlissDigraphWithColours(digraph, NULL);
 
   canon = bliss_digraphs_find_canonical_labeling(graph, 0, 0, 0);
 
@@ -1875,14 +1875,14 @@ static Obj FuncDIGRAPH_CANONICAL_LABELING(Obj self, Obj digraph) {
 }
 
 static Obj
-FuncDIGRAPH_CANONICAL_LABELING_COLORS(Obj self, Obj digraph, Obj colors) {
+FuncDIGRAPH_CANONICAL_LABELLING_COLOURS(Obj self, Obj digraph, Obj colours) {
   Obj                 p;
   UInt4*              ptr;
   BlissGraph*         graph;
   Int                 n, i;
   const unsigned int* canon;
 
-  graph = buildBlissDigraphWithColors(digraph, colors);
+  graph = buildBlissDigraphWithColours(digraph, colours);
 
   canon = bliss_digraphs_find_canonical_labeling(graph, 0, 0, 0);
 
@@ -1898,7 +1898,7 @@ FuncDIGRAPH_CANONICAL_LABELING_COLORS(Obj self, Obj digraph, Obj colors) {
   return p;
 }
 
-static Obj FuncMULTIDIGRAPH_CANONICAL_LABELING(Obj self, Obj digraph) {
+static Obj FuncMULTIDIGRAPH_CANONICAL_LABELLING(Obj self, Obj digraph) {
   Obj                 p, q, out;
   UInt4*              ptr;
   BlissGraph*         graph;
@@ -2000,7 +2000,7 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
   unsigned int i, hint_arg, nr1, nr2;
   UInt8        max_results_arg;
   Obj          user_param_arg;
-  UIntS *      partial_map, *colors1, *colors2;
+  UIntS *      partial_map, *colours1, *colours2;
 
   // get the args . . .
 
@@ -2020,9 +2020,9 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
   // kernel <kernel>
   Obj partial_map_gap =
       ELM_PLIST(args, 10);  // only look for extensions of <partial_map_gap>
-  Obj colors1_gap =
+  Obj colours1_gap =
       ELM_PLIST(args, 11);  // only look for extensions of <partial_map_gap>
-  Obj colors2_gap =
+  Obj colours2_gap =
       ELM_PLIST(args, 12);  // only look for extensions of <partial_map_gap>
 
   // get the c graph objects . . .
@@ -2087,19 +2087,19 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
     }
   }
 
-  // process the vertex colors . . .
-  if (colors1_gap == Fail || colors2_gap == Fail || !IS_LIST(colors1_gap)
-      || !IS_LIST(colors2_gap)) {
-    colors1 = NULL;
-    colors2 = NULL;
+  // process the vertex colours . . .
+  if (colours1_gap == Fail || colours2_gap == Fail || !IS_LIST(colours1_gap)
+      || !IS_LIST(colours2_gap)) {
+    colours1 = NULL;
+    colours2 = NULL;
   } else {
-    colors1 = malloc(nr1 * sizeof(UIntS));
-    colors2 = malloc(nr2 * sizeof(UIntS));
+    colours1 = malloc(nr1 * sizeof(UIntS));
+    colours2 = malloc(nr2 * sizeof(UIntS));
     for (i = 0; i < nr1; i++) {
-      colors1[i] = INT_INTOBJ(ELM_LIST(colors1_gap, i + 1)) - 1;
+      colours1[i] = INT_INTOBJ(ELM_LIST(colours1_gap, i + 1)) - 1;
     }
     for (i = 0; i < nr2; i++) {
-      colors2[i] = INT_INTOBJ(ELM_LIST(colors2_gap, i + 1)) - 1;
+      colours2[i] = INT_INTOBJ(ELM_LIST(colours2_gap, i + 1)) - 1;
     }
   }
 
@@ -2114,8 +2114,8 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
                          hint_arg,
                          image,
                          partial_map,
-                         colors1,
-                         colors2);
+                         colours1,
+                         colours2);
     } else {
       GAP_FUNC = hook_gap;
       GraphHomomorphisms(graph1,
@@ -2126,8 +2126,8 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
                          hint_arg,
                          image,
                          partial_map,
-                         colors1,
-                         colors2);
+                         colours1,
+                         colours2);
     }
   } else {
     if (hook_gap == Fail) {
@@ -2138,8 +2138,8 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
                          max_results_arg,
                          image,
                          partial_map,
-                         colors1,
-                         colors2);
+                         colours1,
+                         colours2);
     } else {
       GAP_FUNC = hook_gap;
       GraphMonomorphisms(graph1,
@@ -2149,8 +2149,8 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
                          max_results_arg,
                          image,
                          partial_map,
-                         colors1,
-                         colors2);
+                         colours1,
+                         colours2);
     }
   }
 
@@ -2162,11 +2162,11 @@ Obj FuncGRAPH_HOMOS(Obj self, Obj args) {
   if (image != NULL) {
     free_bit_array(image);
   }
-  if (colors1 != NULL) {
-    free(colors1);
+  if (colours1 != NULL) {
+    free(colours1);
   }
-  if (colors2 != NULL) {
-    free(colors2);
+  if (colours2 != NULL) {
+    free(colours2);
   }
   free(partial_map);
   free_graph(graph1);
@@ -2196,7 +2196,7 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
   unsigned int i, hint_arg, nr1, nr2;
   UInt8        max_results_arg;
   Obj          user_param_arg;
-  UIntS *      partial_map, *colors1, *colors2;
+  UIntS *      partial_map, *colours1, *colours2;
 
   // get the args . . .
 
@@ -2217,9 +2217,9 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
   // kernel <kernel>
   Obj partial_map_gap =
       ELM_PLIST(args, 10);  // only look for extensions of <partial_map_gap>
-  Obj colors1_gap =
+  Obj colours1_gap =
       ELM_PLIST(args, 11);  // only look for extensions of <partial_map_gap>
-  Obj colors2_gap =
+  Obj colours2_gap =
       ELM_PLIST(args, 12);  // only look for extensions of <partial_map_gap>
 
   // get the c digraph objects . . .
@@ -2284,19 +2284,19 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
     }
   }
 
-  // process the vertex colors . . .
-  if (colors1_gap == Fail || colors2_gap == Fail || !IS_LIST(colors1_gap)
-      || !IS_LIST(colors2_gap)) {
-    colors1 = NULL;
-    colors2 = NULL;
+  // process the vertex colours . . .
+  if (colours1_gap == Fail || colours2_gap == Fail || !IS_LIST(colours1_gap)
+      || !IS_LIST(colours2_gap)) {
+    colours1 = NULL;
+    colours2 = NULL;
   } else {
-    colors1 = malloc(nr1 * sizeof(UIntS));
-    colors2 = malloc(nr2 * sizeof(UIntS));
+    colours1 = malloc(nr1 * sizeof(UIntS));
+    colours2 = malloc(nr2 * sizeof(UIntS));
     for (i = 0; i < nr1; i++) {
-      colors1[i] = INT_INTOBJ(ELM_LIST(colors1_gap, i + 1)) - 1;
+      colours1[i] = INT_INTOBJ(ELM_LIST(colours1_gap, i + 1)) - 1;
     }
     for (i = 0; i < nr2; i++) {
-      colors2[i] = INT_INTOBJ(ELM_LIST(colors2_gap, i + 1)) - 1;
+      colours2[i] = INT_INTOBJ(ELM_LIST(colours2_gap, i + 1)) - 1;
     }
   }
 
@@ -2311,8 +2311,8 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
                            hint_arg,
                            image,
                            partial_map,
-                           colors1,
-                           colors2);
+                           colours1,
+                           colours2);
     } else {
       GAP_FUNC = hook_gap;
       DigraphHomomorphisms(digraph1,
@@ -2323,8 +2323,8 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
                            hint_arg,
                            image,
                            partial_map,
-                           colors1,
-                           colors2);
+                           colours1,
+                           colours2);
     }
   } else {
     if (hook_gap == Fail) {
@@ -2335,8 +2335,8 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
                            max_results_arg,
                            image,
                            partial_map,
-                           colors1,
-                           colors2);
+                           colours1,
+                           colours2);
     } else {
       GAP_FUNC = hook_gap;
       DigraphMonomorphisms(digraph1,
@@ -2346,8 +2346,8 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
                            max_results_arg,
                            image,
                            partial_map,
-                           colors1,
-                           colors2);
+                           colours1,
+                           colours2);
     }
   }
 
@@ -2359,11 +2359,11 @@ Obj FuncDIGRAPH_HOMOS(Obj self, Obj args) {
   if (image != NULL) {
     free_bit_array(image);
   }
-  if (colors1 != NULL) {
-    free(colors1);
+  if (colours1 != NULL) {
+    free(colours1);
   }
-  if (colors2 != NULL) {
-    free(colors2);
+  if (colours2 != NULL) {
+    free(colours2);
   }
 
   free(partial_map);
@@ -2538,11 +2538,11 @@ static StructGVarFunc GVarFuncs[] = {
      FuncDIGRAPH_AUTOMORPHISMS,
      "src/digraphs.c:FuncDIGRAPH_AUTOMORPHISMS"},
 
-    {"DIGRAPH_AUTOMORPHISMS_COLORS",
+    {"DIGRAPH_AUTOMORPHISMS_COLOURS",
      2,
-     "digraph, colors",
-     FuncDIGRAPH_AUTOMORPHISMS_COLORS,
-     "src/digraphs.c:FuncDIGRAPH_AUTOMORPHISMS_COLORS"},
+     "digraph, colours",
+     FuncDIGRAPH_AUTOMORPHISMS_COLOURS,
+     "src/digraphs.c:FuncDIGRAPH_AUTOMORPHISMS_COLOURS"},
 
     {"MULTIDIGRAPH_AUTOMORPHISMS",
      1,
@@ -2550,23 +2550,23 @@ static StructGVarFunc GVarFuncs[] = {
      FuncMULTIDIGRAPH_AUTOMORPHISMS,
      "src/digraphs.c:FuncMULTIDIGRAPH_AUTOMORPHISMS"},
 
-    {"DIGRAPH_CANONICAL_LABELING",
+    {"DIGRAPH_CANONICAL_LABELLING",
      1,
      "digraph",
-     FuncDIGRAPH_CANONICAL_LABELING,
-     "src/digraphs.c:FuncDIGRAPH_CANONICAL_LABELING"},
+     FuncDIGRAPH_CANONICAL_LABELLING,
+     "src/digraphs.c:FuncDIGRAPH_CANONICAL_LABELLING"},
 
-    {"DIGRAPH_CANONICAL_LABELING_COLORS",
+    {"DIGRAPH_CANONICAL_LABELLING_COLOURS",
      2,
-     "digraph, colors",
-     FuncDIGRAPH_CANONICAL_LABELING_COLORS,
-     "src/digraphs.c:FuncDIGRAPH_CANONICAL_LABELING_COLORS"},
+     "digraph, colours",
+     FuncDIGRAPH_CANONICAL_LABELLING_COLOURS,
+     "src/digraphs.c:FuncDIGRAPH_CANONICAL_LABELLING_COLOURS"},
 
-    {"MULTIDIGRAPH_CANONICAL_LABELING",
+    {"MULTIDIGRAPH_CANONICAL_LABELLING",
      1,
      "digraph",
-     FuncMULTIDIGRAPH_CANONICAL_LABELING,
-     "src/digraphs.c:FuncMULTIDIGRAPH_CANONICAL_LABELING"},
+     FuncMULTIDIGRAPH_CANONICAL_LABELLING,
+     "src/digraphs.c:FuncMULTIDIGRAPH_CANONICAL_LABELLING"},
 
     {"GRAPH_HOMOS",
      10,

--- a/tst/standard/bliss.tst
+++ b/tst/standard/bliss.tst
@@ -395,6 +395,98 @@ gap> gr := Digraph([[2, 2], []]);
 gap> DigraphCanonicalLabelling(gr, [1, 2]);
 fail
 
+#T# DIGRAPHS_ValidateVertexColouring, 1, errors
+gap> DIGRAPHS_ValidateVertexColouring();
+Error, Function: number of arguments must be 3 (not 0)
+gap> DIGRAPHS_ValidateVertexColouring(fail);
+Error, Function: number of arguments must be 3 (not 1)
+gap> DIGRAPHS_ValidateVertexColouring(fail, fail);
+Error, Function: number of arguments must be 3 (not 2)
+gap> DIGRAPHS_ValidateVertexColouring(0, fail, "TestFunction");
+Error, Digraphs: TestFunction: usage,
+in order to define a colouring, the argument <partition> must be a homogeneous
+list,
+gap> DIGRAPHS_ValidateVertexColouring(fail, [], "TestFunction");
+Error, Digraphs: DIGRAPHS_ValidateVertexColouring: usage,
+the first argument <n> must be a non-negative integer,
+gap> DIGRAPHS_ValidateVertexColouring(0, [], fail);
+Error, Digraphs: DIGRAPHS_ValidateVertexColouring: usage,
+the third argument <method> must be a string,
+
+#T# DIGRAPHS_ValidateVertexColouring, 2
+gap> DIGRAPHS_ValidateVertexColouring(0, [], "TestFunction");
+[  ]
+gap> DIGRAPHS_ValidateVertexColouring(0, [2], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the only valid partition of the vertices of the digraph with 0 vertices is the
+empty list,
+gap> DIGRAPHS_ValidateVertexColouring(1, [], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 1].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 1 consisting of every integer in the range
+   [1 .. m], for some m <= 1;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 1].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
+gap> DIGRAPHS_ValidateVertexColouring(1, [fail], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 1].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 1 consisting of every integer in the range
+   [1 .. m], for some m <= 1;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 1].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
+gap> DIGRAPHS_ValidateVertexColouring(1, [1, 1], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 1].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 1 consisting of every integer in the range
+   [1 .. m], for some m <= 1;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 1].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
+gap> DIGRAPHS_ValidateVertexColouring(2, [1, -1], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the element <i>, which is not a positive integer,
+gap> DIGRAPHS_ValidateVertexColouring(2, [2, 3], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the integer 3, which is greater than 2,
+gap> DIGRAPHS_ValidateVertexColouring(2, [2, 0], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the element <i>, which is not a positive integer,
+gap> DIGRAPHS_ValidateVertexColouring(2, [[]], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it does not assign a colour to the vertex 1,
+gap> DIGRAPHS_ValidateVertexColouring(1, [[1, 1]], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 1],
+since it contains the vertex 1 more than once,
+gap> DIGRAPHS_ValidateVertexColouring(1, [[0, 1]], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 1],
+since <partition[i]> contains <x>, which is not an integer in the range
+[1 .. 1],
+gap> DIGRAPHS_ValidateVertexColouring(1, [[2]], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 1],
+since <partition[i]> contains <x>, which is not an integer in the range
+[1 .. 1],
+gap> DIGRAPHS_ValidateVertexColouring(4, [[3], [2, 1], [4]], "TestFunction");
+[ 2, 2, 1, 3 ]
+gap> DIGRAPHS_ValidateVertexColouring(4, [1, 1, 3, 4], "TestFunction");
+Error, Digraphs: TestFunction: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 4],
+since it contains the colour 4, but it lacks the colour 2. A colouring must
+use precisely the colours [1 .. m], for some positive integer m <= 4,
+gap> DIGRAPHS_ValidateVertexColouring(4, [1, 1, 3, 2], "TestFunction");
+[ 1, 1, 3, 2 ]
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(canon);

--- a/tst/standard/bliss.tst
+++ b/tst/standard/bliss.tst
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  standard/bliss.tst
-#Y  Copyright (C) 2015                                      Wilf A. Wilson
+#Y  Copyright (C) 2015-17                                   Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -207,6 +207,67 @@ gap> gr2 := OnDigraphs(gr, (3, 9));;
 gap> IsIsomorphicDigraph(gr, gr2);
 true
 
+#T# IsIsomorphicDigraph: for digraphs with colourings and without multiple edges
+gap> gr1 := Digraph([[2, 2], [1]]);
+<multidigraph with 2 vertices, 3 edges>
+gap> gr2 := CompleteDigraph(2);
+<digraph with 2 vertices, 2 edges>
+gap> IsIsomorphicDigraph(gr1, gr2, [1, 1], [1, 1]);
+false
+gap> IsIsomorphicDigraph(gr2, gr1, [1, 1], [1, 1]);
+false
+gap> IsIsomorphicDigraph(gr1, gr1, [1, 1], [1, 1]);
+true
+gap> IsIsomorphicDigraph(gr2, gr2, [], [1, 1]);
+Error, Digraphs: IsIsomorphicDigraph: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 2 consisting of every integer in the range
+   [1 .. m], for some m <= 2;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 2].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
+gap> IsIsomorphicDigraph(gr2, gr2, [2, 2], []);
+Error, Digraphs: IsIsomorphicDigraph: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the colour 2, but it lacks the colour 1. A colouring must
+use precisely the colours [1 .. m], for some positive integer m <= 2,
+gap> IsIsomorphicDigraph(EmptyDigraph(1), EmptyDigraph(2), [1], [1, 1]);
+false
+gap> IsIsomorphicDigraph(EmptyDigraph(1), Digraph([[1]]), [1], [1]);
+false
+gap> IsIsomorphicDigraph(EmptyDigraph(2), EmptyDigraph(2), [1, 1], [1, 2]);
+false
+gap> IsIsomorphicDigraph(EmptyDigraph(2), EmptyDigraph(2), [1, 1], [1, 1]);
+true
+gap> IsIsomorphicDigraph(gr2, gr2, [1, 1], [2, 2]);
+Error, Digraphs: IsIsomorphicDigraph: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the colour 2, but it lacks the colour 1. A colouring must
+use precisely the colours [1 .. m], for some positive integer m <= 2,
+gap> IsIsomorphicDigraph(gr2, gr2, [1, 2], [2, 1]);
+true
+gap> gr1 := CycleDigraph(4);
+<digraph with 4 vertices, 4 edges>
+gap> gr2 := DigraphDisjointUnion(CycleDigraph(2), CycleDigraph(2));
+<digraph with 4 vertices, 4 edges>
+gap> IsIsomorphicDigraph(gr1, gr2, [1, 1, 1, 1], [1, 1, 1, 1]);
+false
+gap> IsIsomorphicDigraph(gr1, gr1, [1, 1, 2, 2], [1, 1, 1, 2]);
+false
+
+#T# IsIsomorphicDigraph: for multidigraphs with colourings
+gap> gr1 := Digraph([[2, 1, 2], []]);;
+gap> gr2 := Digraph([[], [2, 1, 1]]);;
+gap> IsIsomorphicDigraph(gr1, gr1, [1, 1], [1, 1]);
+true
+gap> IsIsomorphicDigraph(gr1, gr1, [1, 1], [1, 2]);
+false
+gap> IsIsomorphicDigraph(gr1, gr2, [1, 2], [2, 1]);
+true
+gap> IsIsomorphicDigraph(gr1, gr2, [1, 2], [1, 2]);
+false
+
 #T# IsomorphismDigraphs: for digraphs without multiple edges
 
 # Non-isomorphic graphs
@@ -243,6 +304,8 @@ gap> gr := Digraph([
 >   [8, 3, 6, 8, 8, 7, 7, 8, 9], [6, 1, 6, 7, 8, 4, 2, 5, 4],
 >   [1, 5, 2, 3, 9]]);
 <multidigraph with 9 vertices, 52 edges>
+gap> IsomorphismDigraphs(gr, gr);
+[ (), () ]
 gap> DigraphCanonicalLabelling(gr);
 [ (1,5,4,2,3,7,9,6), (1,30,49)(2,34,47,35,45,39,38,51,8,12,18,24,21,28,23,13,
     4,29,22,27,20,25,14)(3,33,48)(5,31,52,7,19,26,17,9,16,10,11,15,6,32,
@@ -271,6 +334,67 @@ gap> OnMultiDigraphs(gr, iso) = gr1;
 true
 gap> iso[1] = p;
 true
+
+#T# IsomorphismDigraphs: for digraphs with colourings and without multiple edges
+gap> gr1 := Digraph([[2, 2], [1]]);
+<multidigraph with 2 vertices, 3 edges>
+gap> gr2 := CompleteDigraph(2);
+<digraph with 2 vertices, 2 edges>
+gap> IsomorphismDigraphs(gr1, gr2, [1, 1], [1, 1]);
+fail
+gap> IsomorphismDigraphs(gr2, gr1, [1, 1], [1, 1]);
+fail
+gap> IsomorphismDigraphs(gr1, gr1, [1, 1], [1, 1]);
+[ (), () ]
+gap> IsomorphismDigraphs(gr2, gr2, [], [1, 1]);
+Error, Digraphs: IsomorphismDigraphs: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 2 consisting of every integer in the range
+   [1 .. m], for some m <= 2;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 2].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
+gap> IsomorphismDigraphs(gr2, gr2, [2, 2], []);
+Error, Digraphs: IsomorphismDigraphs: usage,
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the colour 2, but it lacks the colour 1. A colouring must
+use precisely the colours [1 .. m], for some positive integer m <= 2,
+gap> IsomorphismDigraphs(EmptyDigraph(1), EmptyDigraph(2), [1], [1, 1]);
+fail
+gap> IsomorphismDigraphs(EmptyDigraph(1), Digraph([[1]]), [1], [1]);
+fail
+gap> IsomorphismDigraphs(EmptyDigraph(2), EmptyDigraph(2), [1, 1], [1, 2]);
+fail
+gap> IsomorphismDigraphs(EmptyDigraph(2), EmptyDigraph(2), [1, 1], [1, 1]);
+()
+gap> IsomorphismDigraphs(gr2, gr2, [1, 1], [[1, 2]]);
+()
+gap> IsomorphismDigraphs(gr2, gr2, [1, 2], [2, 1]);
+(1,2)
+gap> gr1 := CycleDigraph(4);
+<digraph with 4 vertices, 4 edges>
+gap> gr2 := DigraphDisjointUnion(CycleDigraph(2), CycleDigraph(2));
+<digraph with 4 vertices, 4 edges>
+gap> IsomorphismDigraphs(gr1, gr2, [1, 1, 1, 1], [1, 1, 1, 1]);
+fail
+gap> gr1 := CompleteDigraph(3);;
+gap> IsomorphismDigraphs(gr1, gr1, [1, 2, 2], [[1, 3], [2]]);
+fail
+
+#T# IsomorphismDigraphs: for multidigraphs with colourings
+gap> gr1 := Digraph([[2, 1, 2], []]);;
+gap> gr2 := Digraph([[], [2, 1, 1]]);;
+gap> IsomorphismDigraphs(gr1, gr1, [1, 1], [1, 1]);
+[ (), () ]
+gap> IsomorphismDigraphs(gr1, gr1, [1, 1], [1, 2]);
+fail
+gap> IsomorphismDigraphs(gr1, gr2, [1, 2], [2, 1]);
+[ (1,2), (1,2) ]
+gap> IsomorphismDigraphs(gr1, gr2, [1, 2], [1, 2]);
+fail
+gap> IsomorphismDigraphs(gr1, gr2, [1, 1], [1, 1]);
+[ (1,2), (1,2) ]
 
 #T# DigraphCanonicalLabelling: for a digraph without multiple edges
 
@@ -346,22 +470,38 @@ gap> gr := CompleteBipartiteDigraph(4, 4);
 <digraph with 8 vertices, 32 edges>
 gap> AutomorphismGroup(gr, [[1 .. 4], [5 .. 9]]);
 Error, Digraphs: AutomorphismGroup: usage,
-the union of the lists in the second arg should equal [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8],
+since <partition[i]> contains <x>, which is not an integer in the range
+[1 .. 8],
 gap> AutomorphismGroup(gr, ["a", "b"]);
 Error, Digraphs: AutomorphismGroup: usage,
-the union of the lists in the second arg should equal [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8],
+since <partition[i]> contains <x>, which is not an integer in the range
+[1 .. 8],
 gap> AutomorphismGroup(gr, [1 .. 10]);
 Error, Digraphs: AutomorphismGroup: usage,
-the second arg must be a list of length 8 of integers in [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 8 consisting of every integer in the range
+   [1 .. m], for some m <= 8;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 8].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
 gap> AutomorphismGroup(gr, [-1 .. -10]);
 Error, Digraphs: AutomorphismGroup: usage,
-the second arg must be a list of length 8 of integers in [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 8 consisting of every integer in the range
+   [1 .. m], for some m <= 8;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 8].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
 
 #T# AutomorphismGroup: for a multidigraph
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> AutomorphismGroup(gr, [1, 2]);
-fail
+Group([ (), (1,2) ])
 
 #T# DigraphCanonicalLabelling: for a digraph with colored vertices
 gap> gr := CompleteBipartiteDigraph(4, 4);
@@ -378,22 +518,38 @@ gap> gr := CompleteBipartiteDigraph(4, 4);
 <digraph with 8 vertices, 32 edges>
 gap> DigraphCanonicalLabelling(gr, [[1 .. 4], [5 .. 9]]);
 Error, Digraphs: DigraphCanonicalLabelling: usage,
-the union of the lists in the second arg should equal [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8],
+since <partition[i]> contains <x>, which is not an integer in the range
+[1 .. 8],
 gap> DigraphCanonicalLabelling(gr, ["a", "b"]);
 Error, Digraphs: DigraphCanonicalLabelling: usage,
-the union of the lists in the second arg should equal [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8],
+since <partition[i]> contains <x>, which is not an integer in the range
+[1 .. 8],
 gap> DigraphCanonicalLabelling(gr, [1 .. 10]);
 Error, Digraphs: DigraphCanonicalLabelling: usage,
-the second arg must be a list of length 8 of integers in [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 8 consisting of every integer in the range
+   [1 .. m], for some m <= 8;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 8].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
 gap> DigraphCanonicalLabelling(gr, [-1 .. -10]);
 Error, Digraphs: DigraphCanonicalLabelling: usage,
-the second arg must be a list of length 8 of integers in [1 .. 8],
+the argument <partition> does not define a colouring of the vertices [1 .. 8].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 8 consisting of every integer in the range
+   [1 .. m], for some m <= 8;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 8].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
 
 #T# DigraphCanonicalLabelling: for a multidigraph
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> DigraphCanonicalLabelling(gr, [1, 2]);
-fail
+[ (), (1,2) ]
 
 #T# DIGRAPHS_ValidateVertexColouring, 1, errors
 gap> DIGRAPHS_ValidateVertexColouring();

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  standard/grahom.tst
-#Y  Copyright (C) 2015                                      Wilf A. Wilson
+#Y  Copyright (C) 2015-17                                   Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -145,7 +145,8 @@ gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, false, [1, 2],
 gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, false, [1, 2],
 > [], [[1, 2], [2]], [[1, 2]]);
 Error, Digraphs: HomomorphismDigraphsFinder: usage,
-the union of the lists in the 10th arg should equal [1 .. 2],
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the vertex 2 more than once,
 gap> gr := CompleteDigraph(513);;
 gap> HomomorphismDigraphsFinder(gr, gr, fail, [], 1, fail, false, [1 .. 513],
 > [], fail, fail);
@@ -157,15 +158,23 @@ gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, false, [1, 2],
 gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, false, [1, 2],
 > [], [1, 2, 3], [2, 1]);
 Error, Digraphs: HomomorphismDigraphsFinder: usage,
-the 10th arg must be a list of length 2 of integers in [1 .. 2],
+the argument <partition> does not define a colouring of the vertices [1 .. 2].
+The list <partition> must have one of the following forms:
+1. <partition> is a list of length 2 consisting of every integer in the range
+   [1 .. m], for some m <= 2;
+2. <partition> is a list of non-empty disjoint lists whose union is [1 .. 2].
+In the first form, <partition[i]> is the colour of vertex i; in the second
+form, <partition[i]> is the list of vertices with colour i,
 gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, false, [1, 2],
 > [], [1, 3], [2, 1]);
 Error, Digraphs: HomomorphismDigraphsFinder: usage,
-the 10th arg must be a list of length 2 of integers in [1 .. 2],
+the argument <partition> does not define a colouring of the vertices [1 .. 2],
+since it contains the integer 3, which is greater than 2,
 gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, false, [1, 2],
 > [], [1, fail], [2, 1]);
 Error, Digraphs: HomomorphismDigraphsFinder: usage,
-the 10th arg must be a list of length 2 of integers in [1 .. 2],
+in order to define a colouring, the argument <partition> must be a homogeneous
+list,
 gap> gr := ChainDigraph(2);
 <digraph with 2 vertices, 1 edge>
 gap> GeneratorsOfEndomorphismMonoid();
@@ -187,11 +196,11 @@ gap> gr := EmptyDigraph(2);
 <digraph with 2 vertices, 0 edges>
 gap> GeneratorsOfEndomorphismMonoid(gr, Group(()), Group((1, 2)));
 Error, Digraphs: GeneratorsOfEndomorphismMonoid: usage,
-<colors> must be a homogenous list,
+<colours> must be a homogenous list,
 gap> gr := EmptyDigraph(2);;
 gap> GeneratorsOfEndomorphismMonoid(gr, Group(()));
 Error, Digraphs: GeneratorsOfEndomorphismMonoid: usage,
-<colors> must be a homogenous list,
+<colours> must be a homogenous list,
 gap> gr := EmptyDigraph(2);;
 gap> GeneratorsOfEndomorphismMonoid(gr, 1);
 [ Transformation( [ 2, 1 ] ) ]
@@ -245,56 +254,56 @@ gap> GeneratorsOfEndomorphismMonoid(gr);
 [ Transformation( [ 2, 1 ] ), IdentityTransformation, 
   Transformation( [ 3, 3, 3 ] ) ]
 
-#T# DigraphColoring and DigraphColouring: checking errors and robustness
+#T# DigraphColouring and DigraphColouring: checking errors and robustness
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> DigraphColouring(gr, 1);
 fail
 gap> gr := EmptyDigraph(3);
 <digraph with 3 vertices, 0 edges>
-gap> DigraphColoring(gr, 4);
+gap> DigraphColouring(gr, 4);
 fail
-gap> DigraphColoring(gr, 3);
+gap> DigraphColouring(gr, 3);
 IdentityTransformation
-gap> DigraphColoring(gr, 2);
+gap> DigraphColouring(gr, 2);
 Transformation( [ 1, 1, 2 ] )
-gap> DigraphColoring(gr, 1);
+gap> DigraphColouring(gr, 1);
 Transformation( [ 1, 1, 1 ] )
 gap> gr := CompleteDigraph(3);
 <digraph with 3 vertices, 6 edges>
-gap> DigraphColoring(gr, 1);
+gap> DigraphColouring(gr, 1);
 fail
-gap> DigraphColoring(gr, 2);
+gap> DigraphColouring(gr, 2);
 fail
-gap> DigraphColoring(gr, 3);
+gap> DigraphColouring(gr, 3);
 IdentityTransformation
 gap> gr := EmptyDigraph(0);
 <digraph with 0 vertices, 0 edges>
-gap> DigraphColoring(gr, 1);
+gap> DigraphColouring(gr, 1);
 fail
-gap> DigraphColoring(gr, 2);
+gap> DigraphColouring(gr, 2);
 fail
-gap> DigraphColoring(gr, 3);
+gap> DigraphColouring(gr, 3);
 fail
 gap> gr := EmptyDigraph(1);
 <digraph with 1 vertex, 0 edges>
-gap> DigraphColoring(gr, 1);
+gap> DigraphColouring(gr, 1);
 IdentityTransformation
-gap> DigraphColoring(gr, 2);
+gap> DigraphColouring(gr, 2);
 fail
 gap> gr := Digraph([[1, 2], []]);;
 gap> DigraphColouring(gr, -1);
-Error, Digraphs: DigraphColoring: usage,
+Error, Digraphs: DigraphColouring: usage,
 the second argument <n> must be a non-negative integer,
-gap> DigraphColoring(NullDigraph(0), 1);
+gap> DigraphColouring(NullDigraph(0), 1);
 fail
-gap> DigraphColoring(NullDigraph(0), 0);
+gap> DigraphColouring(NullDigraph(0), 0);
 IdentityTransformation
-gap> DigraphColoring(CompleteDigraph(1), 0);
+gap> DigraphColouring(CompleteDigraph(1), 0);
 fail
 
-#T# DigraphColoring
-gap> DigraphColoring(EmptyDigraph(0));
+#T# DigraphColouring
+gap> DigraphColouring(EmptyDigraph(0));
 IdentityTransformation
 gap> DigraphColouring(Digraph([[1]]));
 IdentityTransformation
@@ -310,6 +319,20 @@ gap> DigraphColouring(CycleDigraph(6));
 Transformation( [ 1, 2, 1, 2, 1, 2 ] )
 gap> DigraphColouring(CompleteDigraph(10));
 IdentityTransformation
+gap> gr := CompleteDigraph(4);;
+gap> HasDigraphColoring(gr) or HasDigraphColouring(gr);
+false
+gap> DigraphColoring(gr);
+IdentityTransformation
+gap> HasDigraphColoring(gr) and HasDigraphColouring(gr);
+true
+gap> gr := CycleDigraph(4);;
+gap> HasDigraphColoring(gr) or HasDigraphColouring(gr);
+false
+gap> DigraphColouring(gr);
+Transformation( [ 1, 2, 1, 2 ] )
+gap> HasDigraphColoring(gr) and HasDigraphColouring(gr);
+true
 
 #T# HomomorphismDigraphsFinder 1
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);;


### PR DESCRIPTION
This PR adds support for isomorphism testing, and isomorphism finding, for *coloured* digraphs.

---

Previously in the Digraphs package... you could ask for the automorphism group of a coloured digraph without multiple edges (i.e. the subgroup of the automorphism of the digraph consisting of those elements that preserve the colouring), and you could ask for the canonical labelling of a coloured digraph without multiple edges.

I've now added similar support for coloured digraphs to the operations `IsIsomorphicDigraph` and `IsomorphismDigraphs`, for testing whether two coloured digraphs without multiple edges are isomorphic as coloured digraphs (i.e. whether there exists an isomorphism between the digraphs that respects the colourings of the vertices).

In addition to these new features, I've made minor improvements to the existing code, such as checking in `IsIsomorphicDigraph` whether the two digraphs are equal before going on to compute a canonical labelling.

The main change of this type is a new global function `DIGRAPHS_ValidateVertexPartition`. Creating this function allows me to replace a large amount of duplicated code which existed to validate whether the "colouring" given as an argument to `AutomorphismGroup` or `DigraphCanonicalLabelling` was indeed a valid colouring of the relevant digraph. This is now also used by `IsIsomorphicDigraph` and `IsomorphismDigraphs`.

Given a non-negative integer `n` and a homogeneous list `partition`, this `DIGRAPHS_ValidateVertexPartition` tests whether `partition` is a valid partition `[1 .. n]`. A valid partition of `[1 .. n]` is either:
1. a list of length `n` consisting of numbers in the range `[0 .. n]` (so that `partition[i]` is the colour of vertex `i`), or
2. a list of non-empty disjoint lists whose union is `[1 .. n]` (so that `partition[i]` is the list of those vertices with colour `i`).

If `partition` *is* a valid partition of `[1 .. n]` then it returns the partition in form 1 (this is the form that bliss likes); otherwise it returns `fail`.

This is both a more and less permissive definition of colouring than existed previously.

It's more permissive, since in the first form, I now allow the colour `0` to be used. This is because:

* bliss works fine with any colour in the range `[0 .. n]` (but not outside of this range), and
* in the Semigroups package, a method for `CanonicalBooleanMat` calculates the canonical labelling of a particular colouring digraph which uses colours 0 and 1. Since colour 0 is not currently allowed in Digraphs, this method uses `DIGRAPH_CANONICAL_LABELING_COLORS`. I think it would be better if this method used the operation `DigraphCanonicalLabelling` for a digraph and a colouring.

It's less permissive, since in the second form, I now require the list to consist of *disjoint* lists. This was currently allowed, but to my mind that was a mistake, as it doesn't make sense for a vertex to have two colours.

In time, this global function should also replace the validation of the colouring given to `HomomorphismDigraphsFinder`.

---

However, the main work on this PR is an improvement to documentation all of the functions `AutomorphismGroup`, `DigraphCanonicalLabelling`, `IsIsomorphicDigraph`, and `IsomorphismDigraphs` in the file `bliss.*`.

The previous documentation for these functions was either incorrect, incomplete, or confusing (this confusion prompted issue #19). It certainly left me scratching my head for a while. I've tried to make the documentation as clear, as thorough, and as helpful as possible.

---

As an aside, since in the `bliss.xml` documentation we talk a lot about colourings, where we simply mean a labelling, I now emphasise in the documentation for `DigraphColouring` and `ChromaticNumber` that these colourings are special in some sense -- they are *proper* colourings.

