### PR TITLE
Fix IsAntisymmetricDigraph

### DIFF
--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -701,7 +701,7 @@ static Obj FuncIS_ANTISYMMETRIC_DIGRAPH(Obj self, Obj adj) {
           level++;
           nbs = ELM_PLIST(adj, j);
           stack += 4;
-          stack[0] = INT_INTOBJ(ADDR_OBJ(nbs)[k]);
+          stack[0] = INT_INTOBJ(ELM_LIST(nbs, k));
           stack[1] = 1;
           stack[2] = j;  // I am wasting memory here, duplicating info
           stack[3] = last1;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -271,6 +271,11 @@ gap> AsDigraph(f);
 gap> AsDigraph(f, 4);
 fail
 
+# Issue 52: Bug in FuncIS_ANTISYMMETRIC_DIGRAPH causing seg fault
+gap> gr := Digraph([[1], [2], [1 .. 3]]);;
+gap> IsAntisymmetricDigraph(gr);
+true
+
 #T# Issue 55: Bug in FuncDIGRAPH_TOPO_SORT
 gap> gr := Digraph([[1 .. 4], [2, 4], [3, 4], [4]]);
 <digraph with 4 vertices, 9 edges>


### PR DESCRIPTION
This PR fixes a (probably long standing) bug in the kernel function `FuncIS_ANTISYMMETRIC_DIGRAPH` which assumed incorrectly that a variable was a plain list. 

This resolves Issue #52 and is the cause of the segmentation fault on travis for PR #51. 