### PR TITLE
Fix bug in FuncDIGRAPH_TOPO_SORT

### DIFF
--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -779,7 +779,7 @@ static Obj FuncDIGRAPH_TOPO_SORT(Obj self, Obj adj) {
   nr = LEN_PLIST(adj);
 
   if (nr == 0) {
-    return adj;
+    return NEW_PLIST(T_PLIST_EMPTY + IMMUTABLE, 0);
   }
   out = NEW_PLIST(T_PLIST_CYC + IMMUTABLE, nr);
   SET_LEN_PLIST(out, nr);
@@ -843,7 +843,7 @@ static Obj FuncDIGRAPH_TOPO_SORT(Obj self, Obj adj) {
           level++;
           nbs = ELM_PLIST(adj, j);
           stack += 2;
-          stack[0] = INT_INTOBJ(ADDR_OBJ(nbs)[k]);
+          stack[0] = INT_INTOBJ(ELM_LIST(nbs, k));
           stack[1] = 1;
         }
       }

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -271,6 +271,12 @@ gap> AsDigraph(f);
 gap> AsDigraph(f, 4);
 fail
 
+#T# Issue 55: Bug in FuncDIGRAPH_TOPO_SORT
+gap> gr := Digraph([[1 .. 4], [2, 4], [3, 4], [4]]);
+<digraph with 4 vertices, 9 edges>
+gap> DigraphTopologicalSort(gr);
+[ 4, 2, 3, 1 ]
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);


### PR DESCRIPTION
This PR resolves Issue #55.

The problem was in line 864. The ADDR_OBJ macro was used on an
entry of the out-neighbours, without the guarantee that the entry
was a plain list. Thus, when given a range, this caused a seg fault.
This commit fixes this issue by using ELM_LIST(nbs, k) instead of
ADDR_OBJ(nbs)[k].

I also changed line 782 to behave like the other functions in the file.