### PR TITLE
Add BooleanAdjacencyMatrixMutableCopy

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -200,11 +200,12 @@ gap> DigraphTopologicalSort(gr);
     This function returns the adjacency matrix <C>mat</C> of the digraph
     <A>digraph</A>.
     The value of the matrix entry <C>mat[i][j]</C> is the number of edges
-    in <A>digraph</A> with source <C>i</C> and range <C>j</C>. <P/>
+    in <A>digraph</A> with source <C>i</C> and range <C>j</C>. If <A>digraph</A>
+    has no vertices, then the empty list is returned. <P/>
 
     The function <C>AdjacencyMatrix</C> returns an immutable list of immutable
     lists, whereas the function <C>AdjacencyMatrixMutableCopy</C> returns a copy
-    of <C>AdjacencyMatrix</C> which is a mutable list of mutable lists. <P/>
+    of <C>AdjacencyMatrix</C> that is a mutable list of mutable lists. <P/>
 
     <Example><![CDATA[
 gap> gr := Digraph([
@@ -232,6 +233,7 @@ gap> Display(mat);
 <#GAPDoc Label="BooleanAdjacencyMatrix">
 <ManSection>
   <Attr Name="BooleanAdjacencyMatrix" Arg="digraph"/>
+  <Oper Name="BooleanAdjacencyMatrixMutableCopy" Arg="digraph"/>
   <Returns>A square matrix of booleans.</Returns>
   <Description>
     If <A>digraph</A> is a digraph with a positive number of vertices
@@ -239,13 +241,16 @@ gap> Display(mat);
     returns the boolean adjacency matrix <C>mat</C> of <A>digraph</A>.  The
     value of the matrix entry <C>mat[j][i]</C> is <K>true</K> if and only if
     there exists an edge in <A>digraph</A> with source <C>j</C> and range
-    <C>i</C>.<P/>
+    <C>i</C>.  If <A>digraph</A> has no vertices, then the empty list is
+    returned. <P/>
 
-    Note this the boolean adjacency loses information about multiple edges.
-    <P/>
+    Note that the boolean adjacency matrix loses information about multiple
+    edges.  <P/>
 
-    If <A>digraph</A> has no vertices, then this attribute returns the empty
-    list.
+    The attribute <C>BooleanAdjacencyMatrix</C> returns an immutable list of
+    immutable lists, whereas the function
+    <C>BooleanAdjacencyMatrixMutableCopy</C> returns a copy of the
+    <C>BooleanAdjacencyMatrix</C> that is a mutable list of mutable lists. <P/>
     <Example><![CDATA[
 gap> gr := Digraph([[3, 4], [2, 3], [1, 2, 4], [4]]);
 <digraph with 4 vertices, 8 edges>

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -82,6 +82,7 @@ DeclareSynonym("OutNeighborsMutableCopy", OutNeighboursMutableCopy);
 DeclareOperation("InNeighboursMutableCopy", [IsDigraph]);
 DeclareSynonym("InNeighborsMutableCopy", InNeighboursMutableCopy);
 DeclareOperation("AdjacencyMatrixMutableCopy", [IsDigraph]);
+DeclareOperation("BooleanAdjacencyMatrixMutableCopy", [IsDigraph]);
 
 DeclareOperation("DigraphLayers", [IsDigraph, IsPosInt]);
 DeclareAttribute("DIGRAPHS_Layers", IsDigraph, "mutable");

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1431,21 +1431,19 @@ end);
 
 InstallMethod(OutNeighboursMutableCopy, "for a digraph",
 [IsDigraph],
-function(digraph)
-  return List(OutNeighbours(digraph), ShallowCopy);
-end);
+digraph -> List(OutNeighbours(digraph), ShallowCopy));
 
 InstallMethod(InNeighboursMutableCopy, "for a digraph",
 [IsDigraph],
-function(digraph)
-  return List(InNeighbours(digraph), ShallowCopy);
-end);
+digraph -> List(InNeighbours(digraph), ShallowCopy));
 
 InstallMethod(AdjacencyMatrixMutableCopy, "for a digraph",
 [IsDigraph],
-function(digraph)
-  return List(AdjacencyMatrix(digraph), ShallowCopy);
-end);
+digraph -> List(AdjacencyMatrix(digraph), ShallowCopy));
+
+InstallMethod(BooleanAdjacencyMatrixMutableCopy, "for a digraph",
+[IsDigraph],
+digraph -> List(BooleanAdjacencyMatrix(digraph), ShallowCopy));
 
 InstallMethod(DigraphLongestDistanceFromVertex, "for a digraph and a pos int",
 [IsDigraph, IsPosInt],

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1260,6 +1260,21 @@ gap> PrintArray(adj);
   [  0,  0,  1 ],
   [  1,  1,  0 ] ]
 
+#T# BooleanAdjacencyMatrixMutableCopy
+gap> gr := Digraph([[3], [2, 3], [3], [2, 4]]);;
+gap> adj := BooleanAdjacencyMatrixMutableCopy(gr);;
+gap> PrintArray(adj);
+[ [  false,  false,   true,  false ],
+  [  false,   true,   true,  false ],
+  [  false,  false,   true,  false ],
+  [  false,   true,  false,   true ] ]
+gap> adj[3][1] := true;;
+gap> PrintArray(adj);
+[ [  false,  false,   true,  false ],
+  [  false,   true,   true,  false ],
+  [   true,  false,   true,  false ],
+  [  false,   true,  false,   true ] ]
+
 #T# DigraphRemoveAllMultipleEdges
 gap> gr1 := Digraph([[1, 1, 2, 1], [1]]);
 <multidigraph with 2 vertices, 5 edges>


### PR DESCRIPTION
We've got `OutNeighboursMutableCopy`, `InNeighboursMutableCopy`, and `AdjacencyMatrixMutableCopy`, so I thought I should add `BooleanAdjacencyMatrixMutableCopy`. Julius should be able to make use of it in PR #57.