### PR TITLE
Fix DigraphColouring to return fail for digraphs with loops (Issue #62)

### DIFF
--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -353,11 +353,15 @@ gap> GeneratorsOfEndomorphismMonoid(gr, [[1], [2, 3]]);
       <C>n</C>-colouring</E> is a proper colouring that uses exactly <C>n</C>
     colours.  Equivalently, a proper (<C>n</C>-)colouring of a digraph can be
     defined to be a <Ref Oper="DigraphEpimorphism"/> from a digraph onto the
-    complete digraph (with <C>n</C> vertices); see <Ref Oper="CompleteDigraph"/>.
+    complete digraph (with <C>n</C> vertices); see <Ref
+      Oper="CompleteDigraph"/>.  Note that a digraph with loops (<Ref
+      Prop="DigraphHasLoops"/>) does not have a proper <C>n</C>-colouring for
+    any value <C>n</C>.
     <P/>
 
+    If <A>digraph</A> is a digraph and <A>n</A> is a non-negative integer, then
     <C>DigraphColouring(<A>digraph</A>, <A>n</A>)</C> returns an epimorphism
-    from <A>digraph</A> onto the complete digraph with <A>n</A> vertices, if one
+    from <A>digraph</A> onto the complete digraph with <A>n</A> vertices if one
     exists, else it returns <K>fail</K>. <P/>
 
     If the optional second argument <A>n</A> is not provided, then

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -231,6 +231,8 @@ function(digraph)
 
   if DigraphNrVertices(digraph) = 0  then
     return IdentityTransformation;
+  elif DigraphHasLoops(digraph) then
+    return fail;
   fi;
 
   vertices  := DigraphVertices(digraph);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -305,8 +305,12 @@ fail
 #T# DigraphColouring
 gap> DigraphColouring(EmptyDigraph(0));
 IdentityTransformation
-gap> DigraphColouring(Digraph([[1]]));
+gap> DigraphColouring(Digraph([[]]));
 IdentityTransformation
+gap> DigraphColouring(Digraph([[1]]));
+fail
+gap> DigraphColouring(Digraph([[1]]), 1);
+fail
 gap> DigraphColouring(CycleDigraph(2));
 IdentityTransformation
 gap> DigraphColouring(CycleDigraph(3));


### PR DESCRIPTION
Currently, the one-argument version of `DigraphColouring` returns a colouring for a digraph, even if it has loops. This was inconsistent, and became issue #62.

This commit resolves issue #62.