### PR TITLE
cliques: fix error message

### DIFF
--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -625,7 +625,7 @@ function(gr, hook, user_param, limit, include, exclude, max, size, reps)
     fi;
   elif not IsList(user_param) then
     ErrorNoReturn("Digraphs: CliquesFinder: usage,\n",
-                  "when the fourth argument <hook> is fail, the third ",
+                  "when the second argument <hook> is fail, the third ",
                   "argument <user_param> has\nto be a list,");
   fi;
 

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -343,7 +343,7 @@ the second argument <hook> has to be either fail, or a function with two
 arguments,
 gap> CliquesFinder(gr, fail, fail, fail, fail, fail, fail, fail, fail);
 Error, Digraphs: CliquesFinder: usage,
-when the fourth argument <hook> is fail, the third argument <user_param> has
+when the second argument <hook> is fail, the third argument <user_param> has
 to be a list,
 gap> f := function(a, b) return; end;;
 gap> CliquesFinder(gr, f, fail, fail, fail, fail, fail, fail, fail);


### PR DESCRIPTION
Previously the error referred to the fourth argument <hook>, when it
should be the second argument.