### PR TITLE
Don't set StructInitInfo members filename and isGapRootRelative

### DIFF
--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -2689,9 +2689,8 @@ static StructInitInfo module = {
     /* checkInit   = */ 0,
     /* preSave     = */ 0,
     /* postSave    = */ 0,
-    /* postRestore = */ 0,
-    /* filename    = */ (char*) "pkg/digraphs/digraphs.c",
-    /* isGapRootR  = */ true};
+    /* postRestore = */ 0
+};
 
 #ifndef GRAPHSSTATIC
 StructInitInfo* Init__Dynamic(void) {


### PR DESCRIPTION
Note that GAP always overrides these values anyway. And right now I am working on a patch to remove them in GAP, which would arrive in GAP 4.9. To be more precise, I am not removing but moving them to another struct, in order to not expose this internal implementation detail needlessly to kernel extensions.

The one drawback of this I see is that it might trigger some warnings when compiling Digraph.