### PR TITLE
attr: add ArticulationPoints and IsBiconnectedDigraph

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -8,6 +8,42 @@
 #############################################################################
 ##
 
+<#GAPDoc Label="ArticulationPoints">
+<ManSection>
+  <Attr Name="ArticulationPoints" Arg="digraph"/>
+  <Returns>A list of vertices.</Returns>
+  <Description>
+
+    A connected digraph is <E>biconnected</E> if it is still connected (in the
+    sense of <Ref Prop="IsConnectedDigraph"/>) when any vertex is removed. 
+    If the digraph <A>digraph</A> is not biconnected but is connected, then any
+    vertex <C>v</C> of <A>digraph</A> whose removal makes the resulting digraph
+    disconnected is called an <E>articulation point</E>.<P/>
+
+    <C>ArticulationPoints</C> returns a list of the articulation points of
+    <A>digraph</A>, if any, and, in particular, returns the empty list if
+    <A>digraph</A> is not connected. <P/>
+
+    Multiple edges and loops are ignored by this method. <P/>
+    
+    The method used in this operation has complexity <M>O(m+n)</M> where
+    <M>m</M> is the number of edges (counting multiple edges as one, and not
+    counting loops) and <M>n</M> is the number of vertices in the digraph.
+
+    See also <Ref Attr="IsBiconnectedDigraph"/>.
+<Example><![CDATA[
+gap> ArticulationPoints(CycleDigraph(5));
+[  ]
+gap> ArticulationPoints(Digraph([[2, 7], [3, 5], [4], [2], [6], [1], []]));
+[ 2, 1 ]
+gap> ArticulationPoints(ChainDigraph(5));
+[ 4, 3, 2 ]
+gap> ArticulationPoints(NullDigraph(5));
+[  ]]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="ChromaticNumber">
 <ManSection>
   <Attr Name="ChromaticNumber" Arg="digraph"/>

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -8,6 +8,36 @@
 #############################################################################
 ##
 
+<#GAPDoc Label="IsBiconnectedDigraph">
+<ManSection>
+  <Prop Name="IsBiconnectedDigraph" Arg="digraph"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    A connected digraph is <E>biconnected</E> if it is still connected (in the
+    sense of <Ref Prop="IsConnectedDigraph"/>) when any vertex is removed. 
+    <C>IsBiconnectedDigraph</C> returns <K>true</K> if the digraph
+    <A>digraph</A> is biconnected, and <K>false</K> if it is not. In
+    particular, <C>IsBiconnectedDigraph</C> returns <K>false</K> if
+    <A>digraph</A> is not connected. <P/>
+
+    Multiple edges and loops are ignored by this method. <P/>
+
+    The method used in this operation has complexity <M>O(m+n)</M> where
+    <M>m</M> is the number of edges (counting multiple edges as one, and not
+    counting loops) and <M>n</M> is the number of vertices in the digraph.
+
+    See also <Ref Attr="ArticulationPoints"/>.
+<Example><![CDATA[
+gap> IsBiconnectedDigraph(Digraph([[1, 3], [2, 3], [3]]));
+false
+gap> IsBiconnectedDigraph(CycleDigraph(5));
+true
+gap> IsBiconnectedDigraph(Digraph([[1, 1], [1, 1, 2], [3], [3, 3, 4, 4]]));
+false]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IsPartialOrderDigraph">
 <ManSection>
   <Prop Name="IsPartialOrderDigraph" Arg="digraph"/>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -45,6 +45,7 @@
     <#Include Label="DigraphConnectedComponent">
     <#Include Label="DigraphStronglyConnectedComponents">
     <#Include Label="DigraphStronglyConnectedComponent">
+    <#Include Label="ArticulationPoints">
     <#Include Label="DigraphPeriod">
     <#Include Label="DigraphFloydWarshall">
     <#Include Label="IsReachable">

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -25,6 +25,7 @@
   <Section><Heading>Connectivity and cycles</Heading>
     <#Include Label="IsAcyclicDigraph">
     <#Include Label="IsConnectedDigraph">
+    <#Include Label="IsBiconnectedDigraph">
     <#Include Label="IsStronglyConnectedDigraph">
     <#Include Label="IsAperiodicDigraph">
     <#Include Label="IsDirectedTree">

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -48,6 +48,9 @@ DeclareAttribute("DigraphDegeneracy", IsDigraph);
 DeclareAttribute("DigraphDegeneracyOrdering", IsDigraph);
 DeclareAttribute("DIGRAPHS_Degeneracy", IsDigraph);
 
+DeclareAttribute("ArticulationPoints", IsDigraph);
+DeclareSynonymAttr("CutVertices", ArticulationPoints);
+
 DeclareAttribute("DigraphSymmetricClosure", IsDigraph);
 DeclareAttribute("DigraphReflexiveTransitiveClosure", IsDigraph);
 DeclareAttribute("DigraphTransitiveClosure", IsDigraph);

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -10,6 +10,7 @@
 
 DeclareProperty("IsAcyclicDigraph", IsDigraph);
 DeclareProperty("IsBipartiteDigraph", IsDigraph);
+DeclareProperty("IsBiconnectedDigraph", IsDigraph);
 DeclareProperty("IsCompleteDigraph", IsDigraph);
 DeclareProperty("IsCompleteBipartiteDigraph", IsDigraph);
 DeclareProperty("IsConnectedDigraph", IsDigraph);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -8,6 +8,12 @@
 #############################################################################
 ##
 
+InstallMethod(IsBiconnectedDigraph, "for a digraph", [IsDigraph],
+function(digraph)
+  return IsEmpty(ArticulationPoints(digraph))
+         and IsConnectedDigraph(digraph);
+end);
+
 InstallMethod(DIGRAPHS_IsMeetJoinSemilatticeDigraph,
 "for a homogeneous list and a positive integer",
 [IsHomogeneousList],

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1356,6 +1356,74 @@ gap> DigraphEdges(UndirectedSpanningForest(gr));
 gap> IsUndirectedSpanningForest(gr, UndirectedSpanningForest(gr));
 true
 
+# ArticulationPoints
+gap> ArticulationPoints(CycleDigraph(5));
+[  ]
+gap> ArticulationPoints(Digraph([[2, 7], [3, 5], [4], [2], [6], [1], []]));
+[ 2, 1 ]
+gap> ArticulationPoints(ChainDigraph(5));
+[ 4, 3, 2 ]
+gap> ArticulationPoints(NullDigraph(5));
+[  ]
+gap> gr :=
+> Digraph([[35, 55, 87], [38], [6, 53], [], [66], [56], [36], []
+> , [], [19], [23], [], [40, 76], [72, 79], [46, 48], [22, 68], [
+> 26], [17, 60], [17], [42], [34, 91], [68, 87], [14, 46], [23, 80
+> ], [6, 8], [], [], [], [], [], [28, 35], [], [18, 40, 94], [], [
+>  27, 44, 78], [], [25], [71], [72], [2, 33], [87], [], [42], [
+> ], [43], [63], [], [58, 89], [68, 97], [24, 40], [13], [9], [
+> 44], [80], [], [40], [78], [9], [], [35, 44, 57], [], [], [67, 
+> 74, 81], [], [86], [], [54, 93], [66, 79], [], [], [], [], [100 
+> ], [19], [62, 68], [87], [4, 15, 89], [61, 86], [], [41], [21, 
+> 41], [59, 64], [], [53], [59], [14, 33], [], [], [37, 71, 92], [
+> 3, 20], [56], [56], [], [89], [], [1, 14, 38, 85], [], [19], [
+> 30], [56, 98]]);
+<digraph with 100 vertices, 110 edges>
+gap> IsConnectedDigraph(gr);
+false
+gap> ArticulationPoints(gr);
+[  ]
+gap> gr := DigraphCopy(gr);
+<digraph with 100 vertices, 110 edges>
+gap> ArticulationPoints(gr);
+[  ]
+gap> IsConnectedDigraph(gr);
+false
+gap> ArticulationPoints(Digraph([[1, 2], [2]]));
+[  ]
+gap> gr := Digraph([[1, 1, 2, 2, 2, 2, 2], [2, 2, 3, 3], []]); # path 
+<multidigraph with 3 vertices, 11 edges>
+gap> ArticulationPoints(gr);
+[ 2 ]
+gap> gr := Digraph([[1, 1, 2, 2, 2, 2, 2], [2, 2, 3, 3], [1, 1, 1]]); # cycle
+<multidigraph with 3 vertices, 14 edges>
+gap> ArticulationPoints(gr);
+[  ]
+gap> gr := Digraph([[2], [3], [], [3]]);
+<digraph with 4 vertices, 3 edges>
+gap> ArticulationPoints(gr);
+[ 3, 2 ]
+gap> IsConnectedDigraph(DigraphRemoveVertex(gr, 3));
+false
+gap> IsConnectedDigraph(DigraphRemoveVertex(gr, 2));
+false
+gap> IsConnectedDigraph(DigraphRemoveVertex(gr, 1));
+true
+gap> IsConnectedDigraph(DigraphRemoveVertex(gr, 4));
+true
+gap> ArticulationPoints(Digraph([]));
+[  ]
+gap> ArticulationPoints(Digraph([[]]));
+[  ]
+gap> ArticulationPoints(Digraph([[1]]));
+[  ]
+gap> ArticulationPoints(Digraph([[1, 1]]));
+[  ]
+gap> ArticulationPoints(Digraph([[1], [2]]));
+[  ]
+gap> ArticulationPoints(Digraph([[2], [1]]));
+[  ]
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1107,6 +1107,40 @@ false
 gap> IsLatticeDigraph(gr);
 false
 
+#T# IsBiconnectedDigraph
+gap> gr := Digraph([]);
+<digraph with 0 vertices, 0 edges>
+gap> IsBiconnectedDigraph(gr);
+true
+gap> gr := Digraph([[]]);
+<digraph with 1 vertex, 0 edges>
+gap> IsBiconnectedDigraph(gr);
+true
+gap> gr := Digraph([[1]]);
+<digraph with 1 vertex, 1 edge>
+gap> IsBiconnectedDigraph(gr);
+true
+gap> gr := Digraph([[1, 1]]);
+<multidigraph with 1 vertex, 2 edges>
+gap> IsBiconnectedDigraph(gr);
+true
+gap> gr := Digraph([[1], [2]]);
+<digraph with 2 vertices, 2 edges>
+gap> IsBiconnectedDigraph(gr);
+false
+gap> gr := Digraph([[2], [1]]);
+<digraph with 2 vertices, 2 edges>
+gap> IsBiconnectedDigraph(gr);
+true
+gap> gr := Digraph([[2], [3], [], []]);
+<digraph with 4 vertices, 2 edges>
+gap> IsBiconnectedDigraph(gr);
+false
+gap> gr := Digraph([[2], [3], [], [3]]);
+<digraph with 4 vertices, 3 edges>
+gap> IsBiconnectedDigraph(gr);
+false
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(circuit);


### PR DESCRIPTION
This PR adds two features: the ability to compute `ArticulationPoints` and as a consequence check if a digraph is biconnected. This uses a pretty straightforward depth first search originally by Tarjan.
