### PR TITLE
Fix some anomalies in the doc

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -30,7 +30,7 @@
     <M>m</M> is the number of edges (counting multiple edges as one, and not
     counting loops) and <M>n</M> is the number of vertices in the digraph.
 
-    See also <Ref Attr="IsBiconnectedDigraph"/>.
+    See also <Ref Prop="IsBiconnectedDigraph"/>.
 <Example><![CDATA[
 gap> ArticulationPoints(CycleDigraph(5));
 [  ]

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1442,8 +1442,8 @@ fail
     vertices of <A>digraph</A> that contains all the edges of <A>digraph</A>
     and satsifies the property that the sum of the degrees of every two
     non-adjacenct vertices in <C>C</C> is less than <A>k</A>. See <Ref
-    Oper="IsSymmetricDigraph"/>, <Ref Oper="DigraphHasLoops"/>, <Ref
-    Oper="IsMultiDigraph"/>, and <Ref Oper="OutDegreeOfVertex"/>. <P/>
+    Prop="IsSymmetricDigraph"/>, <Ref Prop="DigraphHasLoops"/>, <Ref
+    Prop="IsMultiDigraph"/>, and <Ref Oper="OutDegreeOfVertex"/>. <P/>
 
     The operation <C>DigraphClosure</C> returns the <A>k</A>-closure of <A>digraph</A>.
     <Example><![CDATA[

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -7,7 +7,6 @@
     <#Include Label="DigraphSinks">
     <#Include Label="DigraphSources">
     <#Include Label="DigraphTopologicalSort">
-    <#Include Label="DigraphBicomponents">
     <#Include Label="DigraphVertexLabel">
     <#Include Label="DigraphVertexLabels">
     <#Include Label="DigraphEdgeLabel">
@@ -32,6 +31,7 @@
     <#Include Label="InDegreeOfVertex">
     <#Include Label="InNeighboursOfVertex">
     <#Include Label="DigraphLoops">
+    <#Include Label="PartialOrderDigraphMeetOfVertices">
   </Section>
 
   <Section><Heading>Reachability and connectivity</Heading>
@@ -46,6 +46,7 @@
     <#Include Label="DigraphConnectedComponent">
     <#Include Label="DigraphStronglyConnectedComponents">
     <#Include Label="DigraphStronglyConnectedComponent">
+    <#Include Label="DigraphBicomponents">
     <#Include Label="ArticulationPoints">
     <#Include Label="DigraphPeriod">
     <#Include Label="DigraphFloydWarshall">
@@ -58,11 +59,4 @@
     <#Include Label="DigraphDegeneracy">
     <#Include Label="DigraphDegeneracyOrdering">
   </Section>
-
-  
-  <Section><Heading>Partial Orders</Heading>
-    <#Include Label="PartialOrderDigraphMeetOfVertices">
-  </Section>
-
-
 </Chapter>

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -13,6 +13,8 @@
     <#Include Label="IsSymmetricDigraph">
     <#Include Label="IsTournament">
     <#Include Label="IsTransitiveDigraph">
+    <#Include Label="IsPartialOrderDigraph">
+    <#Include Label="IsMeetSemilatticeDigraph">
   </Section>
 
   <Section><Heading>Regularity</Heading>
@@ -23,7 +25,6 @@
   </Section>
 
   <Section><Heading>Connectivity and cycles</Heading>
-
     <#Include Label="IsAcyclicDigraph">
     <#Include Label="IsConnectedDigraph">
     <#Include Label="IsBiconnectedDigraph">
@@ -35,8 +36,4 @@
     <#Include Label="IsCycleDigraph">
   </Section>
   
-  <Section><Heading>Partial Orders</Heading>
-    <#Include Label="IsPartialOrderDigraph">
-    <#Include Label="IsMeetSemilatticeDigraph">
-  </Section>
 </Chapter>


### PR DESCRIPTION
In particular, 
1. fixed some things pointed out by `DIGRAPHS_CheckManualConsistency`
2. removed the two sections for partial orders which each only contained a single man section (these are redeployed elsewhere)
3. move the doc for `DigraphBicomponents` to the same section as the connected components.