### PR TITLE
Add more attributes for Cayley digraphs

### DIFF
--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -903,6 +903,12 @@ gap> CycleDigraph(123);
 
     If the optional second argument <A>gens</A> is not present, then the
     generators of <A>G</A> are used by default.
+
+    The digraph created by this operation belongs to the category <Ref
+      Filt="IsCayleyDigraph"/>, the group <A>G</A> can be recovered from the
+    digraph using <Ref Attr="GroupOfCayleyDigraph"/>, and the generators
+    <A>gens</A> can be obtained using <Ref Attr="GeneratorsOfCayleyDigraph"/>.
+
     <Example><![CDATA[
 gap> G := DihedralGroup(8);
 <pc group of size 8 with 3 generators>
@@ -912,8 +918,70 @@ gap> G := DihedralGroup(IsPermGroup, 8);
 Group([ (1,2,3,4), (2,4) ])
 gap> CayleyDigraph(G);
 <digraph with 8 vertices, 16 edges>
-gap> CayleyDigraph(G, [()]);
-<digraph with 8 vertices, 8 edges>]]></Example>
+gap> digraph := CayleyDigraph(G, [()]);
+<digraph with 8 vertices, 8 edges>
+gap> GroupOfCayleyDigraph(digraph) = G;
+true
+gap> GeneratorsOfCayleyDigraph(digraph);
+[ () ]]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="GroupOfCayleyDigraph">
+<ManSection>
+  <Attr Name="GroupOfCayleyDigraph" Arg="digraph"/>
+  <Attr Name="SemigroupOfCayleyDigraph" Arg="digraph"/>
+  <Returns>A group or semigroup.</Returns>
+  <Description>
+    If <A>digraph</A> is a Cayley graph of a group <C>G</C> and
+    <A>digraph</A> belongs to the category <Ref Filt="IsCayleyDigraph"/>, then
+    <C>GroupOfCayleyDigraph</C> returns <C>G</C>.
+    <P/>
+
+    If <A>digraph</A> is a Cayley graph of a semigroup <C>S</C> and
+    <A>digraph</A> belongs to the category <Ref Filt="IsCayleyDigraph"/>, then
+    <C>SemigroupOfCayleyDigraph</C> returns <C>S</C>.
+    <P/>
+
+    See also <Ref Attr="GeneratorsOfCayleyDigraph"/>.
+    <Example><![CDATA[
+gap> G := DihedralGroup(IsPermGroup, 8);
+Group([ (1,2,3,4), (2,4) ])
+gap> digraph := CayleyDigraph(G);
+<digraph with 8 vertices, 16 edges>
+gap> GroupOfCayleyDigraph(digraph) = G;
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="GeneratorsOfCayleyDigraph">
+<ManSection>
+  <Attr Name="GeneratorsOfCayleyDigraph" Arg="digraph"/>
+  <Returns>A list of generators.</Returns>
+  <Description>
+    If <A>digraph</A> is a Cayley graph of a group or semigroup with
+    respect to a set of generators <C>gens</C> and <A>digraph</A> belongs to
+    the category <Ref Filt="IsCayleyDigraph"/>, then
+    <C>GeneratorsOfCayleyDigraph</C> return the list of generators <C>gens</C>
+    over which <A>digraph</A> is defined.
+    <P/>
+
+    See also <Ref Attr="GroupOfCayleyDigraph"/> 
+    or <Ref Attr="SemigroupOfCayleyDigraph"/>.
+    <Example><![CDATA[
+gap> G := DihedralGroup(IsPermGroup, 8);
+Group([ (1,2,3,4), (2,4) ])
+gap> digraph := CayleyDigraph(G);
+<digraph with 8 vertices, 16 edges>
+gap> GeneratorsOfCayleyDigraph(digraph) = GeneratorsOfGroup(G);
+true
+gap> digraph := CayleyDigraph(G, [()]);
+<digraph with 8 vertices, 8 edges>
+gap> GeneratorsOfCayleyDigraph(digraph) = [()];
+true]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -12,6 +12,7 @@
     <#Include Label="DigraphByEdges">
     <#Include Label="EdgeOrbitsDigraph">
     <#Include Label="DigraphByInNeighbours">
+    <#Include Label="CayleyDigraph">
   </Section>
 
   <Section><Heading>Changing representations</Heading>
@@ -72,7 +73,6 @@
     <#Include Label="CompleteMultipartiteDigraph">
     <#Include Label="CycleDigraph">
     <#Include Label="EmptyDigraph">
-    <#Include Label="CayleyDigraph">
     <#Include Label="JohnsonDigraph">
   </Section>
 

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -59,4 +59,10 @@
     <#Include Label="DigraphDegeneracy">
     <#Include Label="DigraphDegeneracyOrdering">
   </Section>
+  
+  <Section><Heading>Cayley graphs of groups</Heading>
+    <#Include Label="GroupOfCayleyDigraph">
+    <#Include Label="GeneratorsOfCayleyDigraph">
+  </Section>
+
 </Chapter>

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -14,6 +14,10 @@ DeclareCategory("IsDigraph", IsObject);
 DeclareCategory("IsDigraphWithAdjacencyFunction", IsDigraph);
 DeclareCategory("IsCayleyDigraph", IsDigraph);
 
+DeclareAttribute("GroupOfCayleyDigraph", IsCayleyDigraph);
+DeclareAttribute("SemigroupOfCayleyDigraph", IsCayleyDigraph);
+DeclareAttribute("GeneratorsOfCayleyDigraph", IsCayleyDigraph);
+
 # meaning it really has multiple edges!!
 DeclareProperty("IsMultiDigraph", IsDigraph);
 

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -181,9 +181,7 @@ function(G, gens)
   if not IsFinite(G) then
     ErrorNoReturn("Digraphs: CayleyDigraph: usage,\n",
                   "the first argument <G> must be a finite group,");
-  fi;
-
-  if not ForAll(gens, x -> x in G) then
+  elif not ForAll(gens, x -> x in G) then
     ErrorNoReturn("Digraphs: CayleyDigraph: usage,\n",
                   "elements in the 2nd argument <gens> must ",
                   "all belong to the 1st argument <G>,");
@@ -194,6 +192,9 @@ function(G, gens)
   end;
   digraph := Digraph(G, AsList(G), OnRight, adj);
   SetFilterObj(digraph, IsCayleyDigraph);
+  SetGroupOfCayleyDigraph(digraph, G);
+  SetGeneratorsOfCayleyDigraph(digraph, gens);
+
   return digraph;
 end);
 
@@ -201,6 +202,12 @@ InstallMethod(CayleyDigraph, "for a group with generators",
 [IsGroup and HasGeneratorsOfGroup],
 function(G)
   return CayleyDigraph(G, GeneratorsOfGroup(G));
+end);
+
+InstallImmediateMethod(SemigroupOfCayleyDigraph,
+IsCayleyDigraph and HasGroupOfCayleyDigraph, 0,
+function(digraph)
+  return GroupOfCayleyDigraph(digraph);
 end);
 
 InstallMethod(DoubleDigraph, "for a digraph",

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1276,6 +1276,12 @@ gap> IsCayleyDigraph(digraph);
 true
 gap> IsDigraph(digraph);
 true
+gap> digraph := CayleyDigraph(group, [()]);
+<digraph with 8 vertices, 8 edges>
+gap> GroupOfCayleyDigraph(digraph) = group;
+true
+gap> GeneratorsOfCayleyDigraph(digraph);
+[ () ]
 gap> digraph := CayleyDigraph(group, [(1, 2, 3, 4), (2, 5)]);
 Error, Digraphs: CayleyDigraph: usage,
 elements in the 2nd argument <gens> must all belong to the 1st argument <G>,


### PR DESCRIPTION
Namely, `GroupOfCayleyDigraph`, `SemigroupOfCayleyDigraph`,
and `GeneratorsOfCayleyDigraph`, so that the digraph output by
`CayleyDigraph` can recover the semigroup and generating set
used to create the digraph.