### PR TITLE
Add DotVertexLabelledDigraph

### DIFF
--- a/doc/display.xml
+++ b/doc/display.xml
@@ -90,19 +90,26 @@ gap> Splash(DotDigraph(RandomDigraph(4)));
 <#GAPDoc Label="DotDigraph">
   <ManSection>
     <Attr Name="DotDigraph" Arg="digraph"/>
+    <Oper Name="DotVertexLabelledDigraph" Arg="digraph"/>
     <Returns>A string.</Returns>
     <Description>
-      This function produces a graphical representation of the digraph
+      <C>DotDigraph</C> produces a graphical representation of the digraph
       <A>digraph</A>. Vertices are displayed as circles, numbered consistently
       with <A>digraph</A>. Edges are displayed as arrowed lines between
       vertices, with the arrowhead of each line pointing towards the range
       of the edge.<P/>
 
+      <C>DotVertexLabelledDigraph</C> differs from <C>DotDigraph</C> only in
+      that the values in <Ref Oper="DigraphVertexLabels"/> are used to label
+      the vertices in the produced picture rather than the numbers <C>1</C> to
+      the number of vertices of the digraph. <P/>
+
       The output is in <C>dot</C> format (also known as <C>GraphViz</C>)
       format. For details about this file format, and information about how to
       display or edit this format see <URL>http://www.graphviz.org</URL>. <P/>
 
-      The string returned by <C>DotDigraph</C> can be written to a file using
+      The string returned by <C>DotDigraph</C> or
+      <C>DotVertexLabelledDigraph</C> can be written to a file using
       the command <Ref Func="FileString" BookName="GAPDoc"/>.<P/>
 
       <Log><![CDATA[

--- a/gap/display.gd
+++ b/gap/display.gd
@@ -1,12 +1,13 @@
 #############################################################################
 ##
 #W  display.gd
-#Y  Copyright (C) 2014                                   James D. Mitchell
+#Y  Copyright (C) 2017                                   James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
 #############################################################################
 ##
 
-DeclareAttribute("DotDigraph", IsDigraph, "mutable");
-DeclareAttribute("DotSymmetricDigraph", IsDigraph, "mutable");
+DeclareAttribute("DotDigraph", IsDigraph);
+DeclareOperation("DotVertexLabelledDigraph", [IsDigraph]);
+DeclareAttribute("DotSymmetricDigraph", IsDigraph);

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -36,6 +36,34 @@ function(graph)
   return str;
 end);
 
+InstallMethod(DotVertexLabelledDigraph, "for a digraph", [IsDigraph],
+function(digraph)
+  local verts, out, m, str, i, j;
+
+  verts := DigraphVertices(digraph);
+  out   := OutNeighbours(digraph);
+  m     := DigraphNrVertices(digraph);
+  str   := "//dot\n";
+
+  Append(str, "digraph hgn{\n");
+  Append(str, "node [shape=circle]\n");
+
+  for i in verts do
+    Append(str, String(i));
+    Append(str, " [label=\"");
+    Append(str, String(DigraphVertexLabel(digraph, i)));
+    Append(str, "\"]\n");
+  od;
+
+  for i in verts do
+    for j in out[i] do
+      Append(str, Concatenation(String(i), " -> ", String(j), "\n"));
+    od;
+  od;
+  Append(str, "}\n");
+  return str;
+end);
+
 #
 
 InstallMethod(DotSymmetricDigraph, "for an 'undirected' digraph",

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -71,6 +71,19 @@ gap> DotSymmetricDigraph(gr1);
 Error, Digraphs: DotSymmetricDigraph: usage,
 the argument <graph> should be symmetric,
 
+# DotVertexLabelledDigraph
+gap> r := rec(vertices := [1 .. 3], source := [1, 1, 1, 1],
+> range := [1, 2, 2, 3]);;
+gap> gr := Digraph(r);
+<multidigraph with 3 vertices, 4 edges>
+gap> dot := DotVertexLabelledDigraph(gr);;
+gap> dot{[1 .. 50]};
+"//dot\ndigraph hgn{\nnode [shape=circle]\n1 [label=\"1"
+gap> SetDigraphVertexLabel(gr, 1, 2);
+gap> dot := DotVertexLabelledDigraph(gr);;
+gap> dot{[1 .. 50]};
+"//dot\ndigraph hgn{\nnode [shape=circle]\n1 [label=\"2"
+
 # The following tests can't be run because they fail if Semigroups is loaded
 # first
 #T# Splash 


### PR DESCRIPTION
This commit changes `DotDigraph` from a mutable attribute to an attribute,
and introduces `DotVertexLabelledDigraph`. I don't know why `DotDigraph` was a mutable
attribute since it was never used as such. I guess the original intention was that this could be recomputed after something about the digraph changed, but this was not implemented and so it makes more sense if it is an attribute. Since vertex labels can change `DotVertexLabelledDigraph` must be an operation. 