### PR TITLE
Add CliqueNumber and use it to improve ChromaticNumber

### DIFF
--- a/doc/cliques.xml
+++ b/doc/cliques.xml
@@ -8,15 +8,40 @@
 #############################################################################
 ##
 
+<#GAPDoc Label="CliqueNumber">
+<ManSection>
+  <Attr Name="CliqueNumber" Arg="digraph"/>
+  <Returns>A non-negative integer.</Returns>
+  <Description>
+    If <A>digraph</A> is a digraph, then <C>CliqueNumber(<A>digraph</A>)</C>
+    returns the largest integer <C>n</C> such that <A>digraph</A> contains a
+    clique with <C>n</C> vertices as an induced subdigraph.
+    <P/>
+
+    A <E>clique</E> of a digraph is a set of mutually adjacent vertices of the
+    digraph. Loops and multiple edges are ignored for the purpose of
+    determining the clique number of a digraph. 
+    <Example><![CDATA[
+gap> gr := CompleteDigraph(4);;
+gap> CliqueNumber(gr); 
+4
+gap> gr := Digraph([[1, 2, 4, 4], [1, 3, 4], [2, 1], [1, 2]]);
+<multidigraph with 4 vertices, 11 edges>
+gap> CliqueNumber(gr); 
+3]]></Example>
+</Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IsClique">
 <ManSection>
-  <Oper Name="IsClique" Arg="digraph, l"/>
-  <Oper Name="IsMaximalClique" Arg="digraph, l"/>
-  <Returns><K>true</K> or <K>false</K>.</Returns>
-  <Description>
-    If <A>digraph</A> is a digraph and <A>l</A> is a duplicate-free list of
-    vertices of <A>digraph</A>, then
-    <C>IsClique(</C><A>digraph</A><C>,</C><A>l</A><C>)</C> returns <K>true</K>
+<Oper Name="IsClique" Arg="digraph, l"/>
+<Oper Name="IsMaximalClique" Arg="digraph, l"/>
+<Returns><K>true</K> or <K>false</K>.</Returns>
+<Description>
+  If <A>digraph</A> is a digraph and <A>l</A> is a duplicate-free list of
+  vertices of <A>digraph</A>, then
+  <C>IsClique(</C><A>digraph</A><C>,</C><A>l</A><C>)</C> returns <K>true</K>
     if <A>l</A> is a <E>clique</E> of <A>digraph</A> and <K>false</K> if it is
     not.  Similarly,
     <C>IsMaximalClique(</C><A>digraph</A><C>,</C><A>l</A><C>)</C> returns

--- a/doc/z-chap8.xml
+++ b/doc/z-chap8.xml
@@ -96,6 +96,7 @@
     <#Include Label="CliquesFinder">
     <#Include Label="DigraphClique">
     <#Include Label="DigraphMaximalCliques">
+    <#Include Label="CliqueNumber">
   </Section>
 
   <Section><Heading>Finding independent sets</Heading>

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -117,16 +117,17 @@ function(digraph)
 
   # The chromatic number of <digraph> is at least 3 and at most nr - 1
 
+  # The variable <chrom> is the current best known lower bound for the
+  # chromatic number of <digraph>.
+  chrom := 3;
+
   # Prepare a list of connected components of digraph whose chromatic number we
   # do not yet know.
   if IsConnectedDigraph(digraph) then
     comps := [digraph];
     upper := [RankOfTransformation(DigraphColoring(digraph), nr)];
-    # The variable <chrom> is the current best known lower bound for the
-    # chromatic number of <digraph>.
-    chrom := CliqueNumber(digraph);
+    chrom := Maximum(CliqueNumber(digraph), chrom);
   else
-    chrom := 3;
     tmp_comps := [];
     tmp_upper := [];
     for comp in DigraphConnectedComponents(digraph).comps do

--- a/gap/cliques.gd
+++ b/gap/cliques.gd
@@ -40,3 +40,5 @@ DeclareGlobalFunction("DigraphMaximalIndependentSets");
 DeclareGlobalFunction("DigraphMaximalIndependentSetsReps");
 DeclareAttribute("DigraphMaximalIndependentSetsAttr", IsDigraph);
 DeclareAttribute("DigraphMaximalIndependentSetsRepsAttr", IsDigraph);
+
+DeclareAttribute("CliqueNumber", IsDigraph);

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -10,7 +10,7 @@
 #############################################################################
 ##
 
-InstallMethod(CliqueNumber, "for a digraph", [IsDigraph], 
+InstallMethod(CliqueNumber, "for a digraph", [IsDigraph],
 function(digraph)
   return Maximum(List(DigraphMaximalCliquesReps(digraph), Length));
 end);

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -10,6 +10,11 @@
 #############################################################################
 ##
 
+InstallMethod(CliqueNumber, "for a digraph", [IsDigraph], 
+function(digraph)
+  return Maximum(List(DigraphMaximalCliquesReps(digraph), Length));
+end);
+
 # IsIndependentSet: Check that the set is a duplicate-free subset of vertices
 #                   and that no vertex is an out-neighbour of another.
 

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1313,6 +1313,78 @@ gap> gr := CompleteDigraph(4);;
 gap> gr := DigraphAddVertex(gr);;
 gap> ChromaticNumber(gr);
 4
+gap> gr := DigraphFromDiSparse6String(Concatenation(
+> ".~?C?_O?WF?MD?L`[DgX?}@oX`o?W^?}Fgb@mHOTa_?Od`ODOd`}EGnA?HW]`?IGfaULOLak",
+> "LGA?sBoYAiMOt`[Lw_AGJWP`WHGs_gNWSBIMGF@oKhCASIWxc[BWUAgLGY@uFhKAY?OBBuRp",
+> "EdGH_i_cDOaDEHGf_{COdcQNw|DEV?MCuPG`ASUhH`[I@ADqKOqEAHOiCiTgT`gNPSaWSgNB",
+> "iSGTAeLpIcwS@SD[YGeE]L@UbGVGNBwSGE@_M@^`SHotBi[oBBOXH^_SEou_oG?sB[UGeA{\\",
+> "Gq_CBo`AgK@WDeHPNE_[wXeq@oXDuGP\\aSIo{bK^hC`WJp`fMC_bEW\\G`AOK`[E_^iFF}IOy",
+> "CMapZ_?BoWAw[@vGeN?~CKZGNBcPPwaOH_rD{ax?DKXAD_[P`u_CLISCsUgaAkbwKAKMGTAK",
+> "O`BCgZQO_oT@T_oB_kB?[YTHaCoYA?OPkF?dGKEk\\ACHmAodAcL`RHiJPYDmW`jFYFpba_Pq",
+> "MH[gGE@CJovE[aH}HUXa^e?ZWFA_I`jb?PpOF}?OODwXqRa?MGQCSRq___CoiCoVgOAcKOvE",
+> "qQGBA{UQh`gG@YEkZh|akU@XGofaeIaYpsF{fwB?wCPKC{^q]_I@piJAMphEk_aB_KF`[D{X",
+> "PngMJaCjkL`FHcgAw`{MPMDWkghB_W@sIAH`oH{jAzc{TPwHOjA|_WD_yC?TQ^ew[AQHwhap",
+> "bKda`JUDo_G[hw[@{_aMc?P@JGOewPECXq[IGobB_cNbBa[XQBICjqs_gO`NDWhqoJMC_SAM",
+> "CoYAWKpUIYFqj_?BpXEG[q?JCoycdygw|FGgqpaKK_vCC]A@Gskr@ao^AP_sG@EEwZqZISjw",
+> "CIU?_iDOXP}JCogsKKpBEdKdxWE]V`gJksbS_?@_JGGaaxLiGOcBWTAt_KJ_tBoeXzG{oI?H",
+> "[iRTL]GwK@STqLIoqG\\AwKp`ESfwaCOVPyGK`BK_GHowFoabPc[YPuGkmbR`?ZrIm_BOOFIA",
+> "_\\HGjgKBGP`QEGWqjJ_nBSdwYrXMeK@mGweg?CCPG?FobrDMaEPUFo`bl`sQ`qHMU@^EC[aT",
+> "HsrWFCCQ@IDSbROLWugPKOsW?Akhr[akL`\\FK`aFKmGQq`wS`dF_]apKeCp`Fg`qRL_yRl`S",
+> "|goGG`h@JOlrnaSXq_LWwrs_oJ`?CKSqMIu^ry_WOqGHWtk?_G?GF?EB?B_{AgB_MD?A`MDo",
+> "U`kAgG@KEwK?sCOR`]AOQaW?gU_kBGiAaDOX_CH_gawD_hb???SbGEGWbMCgG@cE__AaM?v_",
+> "oE_paSHwV_SDw}?sHgF@]OOW@cLgCcOCOdAaC?kc_JhJByBgec{F_i_cD_l_ARwI?kDpPawK",
+> "@J`?TG??SEomd_NxY?C@h[A?KgcASI`Yce?OF?cFOgbWSGi_gIPPDYQGdacI_yEINpWcGPPK",
+> "__AO^BsRwL?{MwmB?QPR`yR`QEiRxH`SE?^`CC_l`oPgMA?Uhs?}A`j`KD?bCOXW`Ck[@ueA",
+> "B?vDMJ_vEeM@kEyNp@fwCpi`OD`beYKPlFeK@WEk^IC?gBoRBoWHiFaKqBfmMpCDOVg`CORg",
+> "KB?Xa@_SYP{fC`x`EW]GbaeYiQAaHhVEq[AOh[M@PF[]QF_WBogB?NpoFUA?pBOYgMD_VaP_",
+> "WGpFE?`HGEmV``aCKpLDmPpjGmgPDDGUPz_oD`CHY?PK`cF@CaC`GRCOS@~bcW@xF}B?mGKa",
+> "WK@oNO~CWU`wdKV@kGAB_VASKpgFoeWC?sD@gEkaAa_sEO~EW]`}IUK?{H{hH?D_^qHGkbQf",
+> "_oJ@kGCdQdf[_wpBwRpRE?Z`x`GGpXDg^gL?wL@FGOiWRAOXAUJEIPgFQI@rGiN`OFcex|HW",
+> "eqv`WE?_AsU`}fi@oZAOSa@__]QQJ]C@LGocWbA[RPMDO^qBa[O@NDUVQBGWhGZF?`aHIsjw",
+> "HCGdXkFKaQwa?L@hGWjwqC?Yq[KUAPyGK`aqe[cyw_oH@GD{\\xjF}C`]EkbaPJAI?tC?YQ@_",
+> "KO@bKm??RE_^Q}_WRAAHULpCC_\\AGKm?PeFS\\qyKmBoOIopBEKqAQCHSsi^LEMgF@olQuLQC",
+> "@OHotwUEEuoPA{^A_K?pw`CG[@tHYH`a_sO`BCo`a__SCp]IspxGI?nrSdCdbILiCOsJStiZ",
+> "JeDOqC?PaPHYC?jDSXR^hOpwTA_UQOHggG?@yK@@C_\\rEbwRQHKYG?aA[N`HK}A?gCKVwSAQ",
+> "??mFEIpLFoiHZGWgqiLaK`wFsrILLmSQ[KC{XhGyVPnHoubdaoS`]D{lrl`WG?nB?QPPEwyg",
+> "JD?Ta@Io|GX@wG@lHkkbYaCHOoJgrWqGkmRCL_wWIBo[AFIgpbZ_kQ`~IKlrD`GD_sGoewiB",
+> "?QaKJr"));
+<digraph with 256 vertices, 1371 edges>
+gap> gr := DigraphDisjointUnion(gr, CompleteDigraph(5));
+<digraph with 261 vertices, 1391 edges>
+gap> ChromaticNumber(gr);
+5
+gap> gr := Digraph([[2, 4, 7, 3], [3, 5, 8, 1], [1, 6, 9, 2], 
+> [5, 7, 1, 6], [6, 8, 2, 4], [4, 9, 3, 5], [8, 1, 4, 9], [9, 2, 5, 7], 
+> [7, 3, 6, 8]]);;
+gap> ChromaticNumber(gr);
+3
+gap> gr := DigraphSymmetricClosure(ChainDigraph(5));
+<digraph with 5 vertices, 8 edges>
+gap> DigraphColoring(gr);;
+gap> ChromaticNumber(gr);
+2
+gap> gr := DigraphFromGraph6String("KmKk~K??G@_@");
+<digraph with 12 vertices, 42 edges>
+gap> ChromaticNumber(gr);
+4
+gap> gr := CycleDigraph(7);
+<digraph with 7 vertices, 7 edges>
+gap> ChromaticNumber(gr);
+3
+gap> gr := CycleDigraph(71);
+<digraph with 71 vertices, 71 edges>
+gap> ChromaticNumber(gr);
+3
+gap> gr := CycleDigraph(1001);
+<digraph with 1001 vertices, 1001 edges>
+gap> ChromaticNumber(gr);
+3
+gap> a := DigraphRemoveEdges(CompleteDigraph(50), [[1, 2], [2, 1]]);;
+gap> b := DigraphAddVertex(a);;
+gap> ChromaticNumber(a);
+49
+gap> ChromaticNumber(b);
+49
 
 #T# UndirectedSpanningTree and UndirectedSpanningForest
 gap> gr := EmptyDigraph(0);

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -521,6 +521,28 @@ gap> DigraphMaximalCliques(gr);
   [ 86 ], [ 87 ], [ 88 ], [ 89 ], [ 90 ], [ 91 ], [ 92 ], [ 93 ], [ 94 ], 
   [ 95 ], [ 96 ], [ 97 ], [ 98 ], [ 99 ], [ 100 ], [ 2, 3, 5 ] ]
 
+# Test CliqueNumber
+gap> CliqueNumber(NullDigraph(10));
+1
+gap> CliqueNumber(NullDigraph(0));
+0
+gap> CliqueNumber(CompleteDigraph(10));
+10
+gap> CliqueNumber(DigraphRemoveEdge(CompleteDigraph(10), [1, 2]));
+9
+gap> CliqueNumber(JohnsonDigraph(10, 2));
+9
+gap> CliqueNumber(ChainDigraph(10));
+1
+gap> CliqueNumber(ChainDigraph(9));
+1
+gap> CliqueNumber(CycleDigraph(9));
+1
+gap> CliqueNumber(CycleDigraph(8));
+1
+gap> CliqueNumber(DigraphSymmetricClosure(CycleDigraph(8)));
+2
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(f);
 gap> Unbind(c);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -337,6 +337,14 @@ gap> DigraphColouring(gr);
 Transformation( [ 1, 2, 1, 2 ] )
 gap> HasDigraphColoring(gr) and HasDigraphColouring(gr);
 true
+gap> DigraphColoring(ChainDigraph(10));;
+gap> DigraphColoring(CompleteDigraph(10));;
+gap> gr := DigraphFromSparse6String(
+> ":]nA?LcB@_EDfEB`GIaHGdJIgEKcLK`?MdCHiFLaBJhFMkJM");
+<digraph with 30 vertices, 90 edges>
+gap> DigraphColoring(gr);;
+gap> DigraphColoring(EmptyDigraph(0));
+IdentityTransformation
 
 #T# HomomorphismDigraphsFinder 1
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);;

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1704,20 +1704,6 @@ gap> DigraphDistanceSet(gr, 2, -1);
 Error, Digraphs: DigraphDistanceSet: usage,
 the third argument must be a non-negative integer,
 
-#T# DigraphColoring
-gap> DigraphColoring(ChainDigraph(10));
-Transformation( [ 1, 2, 1, 2, 1, 2, 1, 2, 1, 2 ] )
-gap> DigraphColoring(CompleteDigraph(10));
-IdentityTransformation
-gap> gr := DigraphFromSparse6String(
-> ":]nA?LcB@_EDfEB`GIaHGdJIgEKcLK`?MdCHiFLaBJhFMkJM");
-<digraph with 30 vertices, 90 edges>
-gap> DigraphColoring(gr);
-Transformation( [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ] )
-gap> DigraphColoring(EmptyDigraph(0));
-IdentityTransformation
-
 #T# IsSubdigraph: Issue #46
 gap> gr1 := Digraph([[2], []]);;
 gap> gr2 := Digraph([[2, 2], []]);;


### PR DESCRIPTION
This PR adds the attribute `CliqueNumber` and uses it to improve `ChromaticNumber`. Several further minor modifications are made to improve the performance of `ChromaticNumber`, these include 

* sorting the connected components by size from smallest to largest, since colouring smaller digraphs is quicker than larger ones, and information about the colourings of the smaller components can be used to determine the overall chromatic number more quickly

* using `DigraphColouring` to obtain an upper bound for the chromatic number

* only trying to colour the digraph with a number of colours between the clique number plus one, and the number of colours used by `DigraphColouring` minus 1, instead of all values from `3` to the number of vertices minus 1

* using the chromatic number of smaller connected components as a lower bound for the other connected components.

The added test took 30 seconds before this PR and only about 300ms after. 

This PR depends on PR #75.