### PR TITLE
Fix issue 81

### DIFF
--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -939,8 +939,7 @@ end);
 
 #
 
-InstallMethod(Digraph, "for a list of lists of pos ints",
-[IsList],
+InstallMethod(Digraph, "for a dense list", [IsDenseList],
 function(adj)
   local nrvertices, nredges, x, y;
 
@@ -948,12 +947,16 @@ function(adj)
   nredges := 0;
 
   for x in adj do
+    if not IsHomogeneousList(x) then
+      ErrorNoReturn("Digraphs: Digraph: usage,\n",
+                    "the argument must be a list of lists of positive ",
+                    "integers not exceeding the\nlength of the argument,");
+    fi;
     for y in x do
       if not IsPosInt(y) or y > nrvertices then
         ErrorNoReturn("Digraphs: Digraph: usage,\n",
                       "the argument must be a list of lists of positive ",
-                      "integers\n",
-                      "not exceeding the length of the argument,");
+                      "integers not exceeding the\nlength of the argument,");
       fi;
       nredges := nredges + 1;
     od;
@@ -964,7 +967,7 @@ end);
 
 #
 
-InstallMethod(DigraphNC, "for a list", [IsList],
+InstallMethod(DigraphNC, "for a dense list", [IsDenseList],
 function(adj)
   local adj_copy, graph;
 
@@ -978,8 +981,8 @@ function(adj)
   return graph;
 end);
 
-InstallMethod(DigraphNC, "for a list and an integer",
-[IsList, IsInt],
+InstallMethod(DigraphNC, "for a dense list and an integer",
+[IsDenseList, IsInt],
 function(adj, nredges)
   local adj_copy, graph;
 
@@ -1036,8 +1039,8 @@ function(nrvertices, source, range)
                        nredges := m));
 end);
 
-InstallMethod(Digraph, "for three lists",
-[IsList, IsList, IsList],
+InstallMethod(Digraph, "for three dense lists",
+[IsDenseList, IsDenseList, IsDenseList],
 function(vertices, source, range)
   local m, n, i;
 

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -134,12 +134,19 @@ gap> if DIGRAPHS_IsGrapeLoaded then
 #T# Digraph (by OutNeighbours)
 gap> Digraph([[0, 1]]);
 Error, Digraphs: Digraph: usage,
-the argument must be a list of lists of positive integers
-not exceeding the length of the argument,
+the argument must be a list of lists of positive integers not exceeding the
+length of the argument,
 gap> Digraph([[2], [3]]);
 Error, Digraphs: Digraph: usage,
-the argument must be a list of lists of positive integers
-not exceeding the length of the argument,
+the argument must be a list of lists of positive integers not exceeding the
+length of the argument,
+gap> Digraph([[1],, [2]]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Digraph' on 1 arguments
+gap> Digraph([[1], 2, [3]]);
+Error, Digraphs: Digraph: usage,
+the argument must be a list of lists of positive integers not exceeding the
+length of the argument,
 
 #T# Digraph (by record)
 gap> n := 3;;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -295,6 +295,15 @@ gap> gr := Digraph([[1 .. 4], [2, 4], [3, 4], [4]]);
 gap> DigraphTopologicalSort(gr);
 [ 4, 2, 3, 1 ]
 
+#T# Issue 81: Bug in Digraph for a malformed list of out-neighbours
+gap> gr := Digraph([[1],, [2]]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `Digraph' on 1 arguments
+gap> gr := Digraph([[1], 2, [2]]);
+Error, Digraphs: Digraph: usage,
+the argument must be a list of lists of positive integers not exceeding the
+length of the argument,
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);


### PR DESCRIPTION
This PR resolves issue #81 

A segfault would happen if you called `Digraph` on a list with holes. We weren't checking for this. I've added `IsDenseList` to the filters for digraph creation methods, where appropriate. I've made it more robust in another way too.