### PR TITLE
CanonicalDigraph: Add the function CanonicalDigraph with doc & tests

### DIFF
--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -1155,3 +1155,36 @@ gap> JohnsonDigraph(1, 0);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="CanonicalDigraph">
+<ManSection>
+  <Attr Name="CanonicalDigraph" Arg="digraph"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    This returns the canonical representative found by applying
+    <Ref Attr="DigraphCanonicalLabelling"/>. The digraph returned is canonical
+    in the sense that
+
+    <List>
+      <Item>
+        <C>CanonicalDigraph(<A>digraph</A>)</C> and <A>digraph</A> are isomorphic
+        as digraphs; and
+      </Item>
+      <Item>
+        If <C>gr</C> is any digraph then <C>CanonicalDigraph(gr)</C>
+        and <C>CanonicalDigraph(<A>digraph</A>)</C> are equal if and only if
+        <C>gr</C> and <A>digraph</A> are isomorphic as digraphs.
+      </Item>
+    </List>
+
+    <Example><![CDATA[
+gap> digraph := Digraph([[1], [2, 3], [3], [1, 2, 3]]);
+<digraph with 4 vertices, 7 edges>
+gap> canon := CanonicalDigraph(digraph);
+<digraph with 4 vertices, 7 edges>
+gap> Print(canon);
+Digraph( [ [ 1 ], [ 2, 4 ], [ 1, 2, 4 ], [ 4 ] ] )
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -17,6 +17,7 @@ DeclareCategory("IsCayleyDigraph", IsDigraph);
 DeclareAttribute("GroupOfCayleyDigraph", IsCayleyDigraph);
 DeclareAttribute("SemigroupOfCayleyDigraph", IsCayleyDigraph);
 DeclareAttribute("GeneratorsOfCayleyDigraph", IsCayleyDigraph);
+DeclareAttribute("CanonicalDigraph", IsDigraph);
 
 # meaning it really has multiple edges!!
 DeclareProperty("IsMultiDigraph", IsDigraph);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -1627,6 +1627,17 @@ function(n, k)
   return digraph;
 end);
 
+#
+
+InstallMethod(CanonicalDigraph, "for a digraph",
+[IsDigraph],
+function(digraph)
+  if IsMultiDigraph(digraph) then
+    return OnMultiDigraphs(digraph, DigraphCanonicalLabelling(digraph));
+  fi;
+  return OnDigraphs(digraph, DigraphCanonicalLabelling(digraph));
+end);
+
 #############################################################################
 ##
 ##  CompleteMultipartiteDigraph(<sizes>)

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1714,6 +1714,31 @@ gap> SetDigraphEdgeLabel(gr, 2, 2, "a");
 Error, Digraphs: SetDigraphEdgeLabel:
 [2, 2] is not an edge of <graph>,
 
+#T# CanonicalDigraph
+gap> gr1 := Digraph([[1, 2], [1, 2], [2, 3], [1, 2, 3], [5]]);;
+gap> gr2 := Digraph([[1, 3], [2, 3], [2, 3], [1, 2, 3], [5]]);;
+gap> CanonicalDigraph(gr1) = CanonicalDigraph(gr2);
+true
+gap> gr3 := Digraph([[2, 3], [2, 3], [1, 3], [1, 2, 3], [5]]);;
+gap> CanonicalDigraph(gr1) = CanonicalDigraph(gr3);
+false
+gap> CanonicalDigraph(Digraph([[1], [2], [3], [3], [2], [1]])) 
+> = Digraph([[1], [2], [3], [1], [2], [3]]);
+true
+gap> gr4 := Digraph([[3, 4], [2, 2, 3], [2, 2, 4], [2, 2, 3]]);;
+gap> gr5 := CanonicalDigraph(gr4);;
+gap> gr5 = gr4;
+false
+gap> IsIsomorphicDigraph(gr4, gr5);
+true
+gap> gr5 = CanonicalDigraph(gr5);
+true
+gap> gr6 := OnMultiDigraphs(gr4, [(1, 2), (5, 6)]);;
+gap> IsIsomorphicDigraph(gr4, gr6);
+true
+gap> gr5 = CanonicalDigraph(gr6);
+true
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(adj);
@@ -1736,6 +1761,7 @@ gap> Unbind(gr2);
 gap> Unbind(gr3);
 gap> Unbind(gr4);
 gap> Unbind(gr5);
+gap> Unbind(gr6);
 gap> Unbind(graph1);
 gap> Unbind(graph2);
 gap> Unbind(grnc);


### PR DESCRIPTION
This function returns the canonical digraph formed by applying
`CanonicalDigraphLabelling` to the input digraph.