### PR TITLE
Change the way that digraphs are objectified

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -345,13 +345,7 @@ end);
 
 #
 
-InstallMethod(DigraphNrEdges, "for a digraph", [IsDigraph],
-function(gr)
-  if IsBound(gr!.DigraphNrEdges) then
-    return gr!.DigraphNrEdges;
-  fi;
-  return DIGRAPH_NREDGES(gr);
-end);
+InstallMethod(DigraphNrEdges, "for a digraph", [IsDigraph], DIGRAPH_NREDGES);
 
 #
 

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -345,8 +345,13 @@ end);
 
 #
 
-InstallMethod(DigraphNrEdges, "for a digraph",
-[IsDigraph], DIGRAPH_NREDGES);
+InstallMethod(DigraphNrEdges, "for a digraph", [IsDigraph],
+function(gr)
+  if IsBound(gr!.DigraphNrEdges) then
+    return gr!.DigraphNrEdges;
+  fi;
+  return DIGRAPH_NREDGES(gr);
+end);
 
 #
 
@@ -384,16 +389,16 @@ InstallMethod(DigraphRange, "for a digraph",
 [IsDigraph],
 function(digraph)
   DIGRAPH_SOURCE_RANGE(digraph);
-  SetDigraphSource(digraph, digraph!.source);
-  return digraph!.range;
+  SetDigraphSource(digraph, digraph!.DigraphSource);
+  return digraph!.DigraphRange;
 end);
 
 InstallMethod(DigraphSource, "for a digraph",
 [IsDigraph],
 function(digraph)
   DIGRAPH_SOURCE_RANGE(digraph);
-  SetDigraphRange(digraph, digraph!.range);
-  return digraph!.source;
+  SetDigraphRange(digraph, digraph!.DigraphRange);
+  return digraph!.DigraphSource;
 end);
 
 #

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -23,10 +23,6 @@ DeclareProperty("IsMultiDigraph", IsDigraph);
 
 BindGlobal("DigraphFamily", NewFamily("DigraphFamily", IsDigraph));
 
-BindGlobal("DigraphType", NewType(DigraphFamily,
-                                  IsDigraph and IsComponentObjectRep
-                                  and IsAttributeStoringRep));
-
 # constructors . . .
 
 DeclareOperation("Digraph", [IsRecord]);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -8,6 +8,11 @@
 #############################################################################
 ##
 
+BindGlobal("DigraphType", NewType(DigraphFamily,
+                                  IsDigraph and IsComponentObjectRep
+                                  and IsAttributeStoringRep
+                                  and HasDigraphNrVertices));
+
 BindGlobal("DIGRAPHS_InitEdgeLabels",
 function(graph)
   if not IsBound(graph!.edgelabels) then

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -226,10 +226,10 @@ function(digraph)
   #if DigraphGroup is set, a subgroup of the automoraphism group
   #of the bipartite double is computed and set.
   out := OutNeighbours(digraph);
-  vertices := [1 .. digraph!.nrvertices];
-  shift := Length(vertices);
-  newvertices := [shift + 1 .. 2 * digraph!.nrvertices];
-  allvertices := [1 .. 2 * digraph!.nrvertices];
+  vertices := DigraphVertices(digraph);
+  shift := DigraphNrVertices(digraph);
+  newvertices := [shift + 1 .. 2 * DigraphNrVertices(digraph)];
+  allvertices := [1 .. 2 * DigraphNrVertices(digraph)];
   #"duplicate" of the outs for the new vertices:
   shiftedout := List(out, x -> List(x, y -> y + shift));
   newout1 := List(vertices, x -> List(out[x], y -> y + shift));
@@ -272,10 +272,10 @@ function(digraph)
   #if DigraphGroup is set, a subgroup of the automoraphism group
   #of the bipartite double is computed and set.
   out := OutNeighbours(digraph);
-  vertices := [1 .. digraph!.nrvertices];
-  shift := Length(vertices);
-  newvertices := [shift + 1 .. 2 * digraph!.nrvertices];
-  allvertices := [1 .. 2 * digraph!.nrvertices];
+  vertices := DigraphVertices(digraph);
+  shift := DigraphNrVertices(digraph);
+  newvertices := [shift + 1 .. 2 * DigraphNrVertices(digraph)];
+  allvertices := [1 .. 2 * DigraphNrVertices(digraph)];
   newout1 := List(vertices, x -> List(out[x], y -> y + shift));
   newout2 := List(newvertices, x -> out[x - shift]);
   crossedouts := Concatenation(newout1, newout2);
@@ -298,7 +298,7 @@ InstallMethod(DistanceDigraph,
 function(digraph, distances)
   local n, orbitreps, group, sch, g, rep, rem, gens,
     record, new, x, out, vertices;
-  n := digraph!.nrvertices;
+  n := DigraphNrVertices(digraph);
   new := EmptyDigraph(n);
   vertices := [1 .. n];
   out := [];

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -927,14 +927,20 @@ end);
 
 InstallMethod(DigraphNC, "for a record", [IsRecord],
 function(graph)
-  ObjectifyWithAttributes(graph, DigraphType,
+  local new;
+
+  new := rec();
+  ObjectifyWithAttributes(new, DigraphType,
                           DigraphRange, graph.range,
                           DigraphSource, graph.source,
                           DigraphNrVertices, graph.nrvertices);
   if IsBound(graph!.nredges) then
-    SetDigraphNrEdges(graph, graph!.nredges);
+    SetDigraphNrEdges(new, graph!.nredges);
   fi;
-  return graph;
+  if IsBound(graph!.vertexlabels) then
+    SetDigraphVertexLabels(new, graph!.vertexlabels);
+  fi;
+  return new;
 end);
 
 #
@@ -969,33 +975,23 @@ end);
 
 InstallMethod(DigraphNC, "for a dense list", [IsDenseList],
 function(adj)
-  local adj_copy, graph;
+  local graph, adj_copy;
 
+  graph := rec();
   adj_copy := StructuralCopy(adj);
-  graph := rec(adj := adj_copy, nrvertices := Length(adj));
   Perform(adj_copy, IsSet);
-
   ObjectifyWithAttributes(graph, DigraphType,
                           OutNeighbours, adj_copy,
-                          DigraphNrVertices, graph.nrvertices);
+                          DigraphNrVertices, Length(adj_copy));
   return graph;
 end);
 
 InstallMethod(DigraphNC, "for a dense list and an integer",
 [IsDenseList, IsInt],
 function(adj, nredges)
-  local adj_copy, graph;
-
-  adj_copy := StructuralCopy(adj);
-  graph := rec(adj        := adj_copy,
-               nredges    := nredges,
-               nrvertices := Length(adj));
-  Perform(adj_copy, IsSet);
-
-  ObjectifyWithAttributes(graph, DigraphType,
-                          OutNeighbours, adj_copy,
-                          DigraphNrVertices, graph.nrvertices,
-                          DigraphNrEdges, graph.nredges);
+  local graph;
+  graph := DigraphNC(adj);
+  SetDigraphNrEdges(graph, nredges);
   return graph;
 end);
 

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -44,12 +44,13 @@ static Obj FuncDIGRAPH_SOURCE_RANGE(Obj self, Obj digraph);
 /*************************************************************************/
 
 Int DigraphNrVertices(Obj digraph) {
-  if (IsbPRec(digraph, RNamName("nrvertices"))) {
-    return INT_INTOBJ(ElmPRec(digraph, RNamName("nrvertices")));
+  if (IsbPRec(digraph, RNamName("DigraphNrVertices"))) {
+    return INT_INTOBJ(ElmPRec(digraph, RNamName("DigraphNrVertices")));
   }
   // The record comp should always be set so this should never be triggered
   ErrorQuit(
-      "Digraphs: DigraphNrVertices (C):\nrec comp <nrvertices> is not set,",
+      "Digraphs: DigraphNrVertices (C):\nrec comp <DigraphNrVertices> is not "
+      "set,",
       0L,
       0L);
   return 0;
@@ -58,8 +59,8 @@ Int DigraphNrVertices(Obj digraph) {
 Int DigraphNrEdges(Obj digraph) {
   Obj adj;
   Int nr, i, n;
-  if (IsbPRec(digraph, RNamName("nredges"))) {
-    return INT_INTOBJ(ElmPRec(digraph, RNamName("nredges")));
+  if (IsbPRec(digraph, RNamName("DigraphNrEdges"))) {
+    return INT_INTOBJ(ElmPRec(digraph, RNamName("DigraphNrEdges")));
   }
   n   = DigraphNrVertices(digraph);
   adj = OutNeighbours(digraph);
@@ -67,7 +68,7 @@ Int DigraphNrEdges(Obj digraph) {
   for (i = 1; i <= n; i++) {
     nr += LEN_PLIST(ELM_PLIST(adj, i));
   }
-  AssPRec(digraph, RNamName("nredges"), INTOBJ_INT(nr));
+  AssPRec(digraph, RNamName("DigraphNrEdges"), INTOBJ_INT(nr));
   return nr;
 }
 
@@ -79,15 +80,15 @@ static Obj FuncDIGRAPH_NREDGES(Obj self, Obj digraph) {
 Obj OutNeighbours(Obj digraph) {
   Obj adj;
 
-  if (IsbPRec(digraph, RNamName("adj"))) {
-    return ElmPRec(digraph, RNamName("adj"));
-  } else if (IsbPRec(digraph, RNamName("source"))
-             && IsbPRec(digraph, RNamName("range"))) {
+  if (IsbPRec(digraph, RNamName("OutNeighbours"))) {
+    return ElmPRec(digraph, RNamName("OutNeighbours"));
+  } else if (IsbPRec(digraph, RNamName("DigraphSource"))
+             && IsbPRec(digraph, RNamName("DigraphRange"))) {
     adj = FuncDIGRAPH_OUT_NBS(NULL,
-                              ElmPRec(digraph, RNamName("nrvertices")),
-                              ElmPRec(digraph, RNamName("source")),
-                              ElmPRec(digraph, RNamName("range")));
-    AssPRec(digraph, RNamName("adj"), adj);
+                              ElmPRec(digraph, RNamName("DigraphNrVertices")),
+                              ElmPRec(digraph, RNamName("DigraphSource")),
+                              ElmPRec(digraph, RNamName("DigraphRange")));
+    AssPRec(digraph, RNamName("OutNeighbours"), adj);
     return adj;
   }
   ErrorQuit(
@@ -981,8 +982,8 @@ static Obj FuncDIGRAPH_SOURCE_RANGE(Obj self, Obj digraph) {
 
   SET_LEN_PLIST(source, m);
   SET_LEN_PLIST(range, m);
-  AssPRec(digraph, RNamName("source"), source);
-  AssPRec(digraph, RNamName("range"), range);
+  AssPRec(digraph, RNamName("DigraphSource"), source);
+  AssPRec(digraph, RNamName("DigraphRange"), range);
   return True;
 }
 
@@ -1031,7 +1032,7 @@ FuncDIGRAPH_OUT_NBS(Obj self, Obj nrvertices, Obj source, Obj range) {
     }
   }
 
-  // AssPRec(digraph, RNamName("adj"), adj);
+  // AssPRec(digraph, RNamName("OutNeighbours"), adj);
   return adj;
 }
 

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -216,10 +216,14 @@ true
 #T# DIGRAPH_IN_OUT_NBS: for a list containing ranges
 # A segfault was caused by assuming that an element of OutNeighbours was a
 # PLIST. This is solved by using PLAIN_LIST on each entry of OutNeighbours.
-gap> gr := Digraph(List([1 .. 5], x -> [1 .. 5]));
-<digraph with 5 vertices, 25 edges>
+gap> gr := Digraph(List([1 .. 5], x -> [1 .. 5]));;
 gap> out := OutNeighbours(gr);
 [ [ 1 .. 5 ], [ 1 .. 5 ], [ 1 .. 5 ], [ 1 .. 5 ], [ 1 .. 5 ] ]
+gap> IsMultiDigraph(gr);
+false
+gap> out;
+[ [ 1, 2, 3, 4, 5 ], [ 1, 2, 3, 4, 5 ], [ 1, 2, 3, 4, 5 ], [ 1, 2, 3, 4, 5 ], 
+  [ 1, 2, 3, 4, 5 ] ]
 gap> InNeighbours(gr) = out;
 true
 


### PR DESCRIPTION
In this PR, I change the names of the record components of digraphs to match their attribute names. eg `nrvertices -> DigraphNrVertices`. This change makes the code nicer, and combined with a change to how we objectify digraphs, it leads to reduced memory usage. Previously, if you had a mutable list of out-neighbours, and you called `Digraph` on that list, then the record components `!.OutNeighbours` and `!.nbs` were *not* identical objects, and hence we were using twice as much memory as necessary. There is now just the one copy.

I've also changed `DigraphType` to include the filter `HasDigraphNrVertices`, since every digraph does have its number of vertices. If you look at the documentation in GAP for `ObjectifyWithAttributes`, you can see why including this filter would be desirable in the long run.