### PR TITLE
Enable DigraphSymmetricClosure for digraphs with no vertices

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1046,7 +1046,7 @@ InstallMethod(DigraphSymmetricClosure, "for a digraph",
 function(digraph)
   local n, m, verts, mat, new, x, i, j, k;
   n := DigraphNrVertices(digraph);
-  if n = 1
+  if n <= 1
       or (HasIsSymmetricDigraph(digraph) and IsSymmetricDigraph(digraph)) then
     return digraph;
   fi;

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -308,6 +308,11 @@ Error, Digraphs: Digraph: usage,
 the argument must be a list of lists of positive integers not exceeding the
 length of the argument,
 
+#T# Symmetric closure of a digraph with no vertices
+gap> gr := EmptyDigraph(0);;
+gap> DigraphSymmetricClosure(gr);
+<digraph with 0 vertices, 0 edges>
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);


### PR DESCRIPTION
A very simple change.  Previously `DigraphSymmetricClosure(EmptyDigraph(0));` produced an error.