### PR TITLE
add VertexConnectivity

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1352,3 +1352,38 @@ gap> HamiltonianPath(g);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="VertexConnectivity">
+<ManSection>
+  <Attr Name="VertexConnectivity" Arg="digraph"/>
+  <Returns>An non-negative integer.</Returns>
+  <Description>
+    For a digraph <A>digraph</A> with set of vertices <C>V</C>, the attribute
+    <C>VertexConnectivity(<A>digraph</A>)</C> returns the least cardinality
+    <C>|S|</C> of a subset <C>S</C> of <C>V</C> such that their removal either
+    disconnects <A>digraph</A>, makes it trivial, or makes it have no vertices.
+    The alrorithm makes <C>O(n - d - 1 + d * (d - 1) / 2)</C> calls to a
+    max-flow algorithm wich itself has complexity <C>O(n ^ 2 * e)</C>, where
+    <C>n</C> is the number of vertices of <A>digraph</A>, and <C>e, d</C> are
+    the number of edges and the degree (respectively) of the symmetric closure
+    of the digraph that results by removing all multiple edges of
+    <A>digraph</A>.
+
+    <Example><![CDATA[
+gap> J := JohnsonDigraph(9, 2);
+<digraph with 36 vertices, 504 edges>
+gap> VertexConnectivity(J);
+14
+gap> D := Digraph([[2, 4, 5], [1, 4], [4, 7], [1, 2, 3, 5, 6, 7], [1, 4],
+>                  [4, 7], [3, 4, 6]]);
+<digraph with 7 vertices, 20 edges>
+gap> VertexConnectivity(D);
+1
+gap> T := Digraph([]);
+<digraph with 0 vertices, 0 edges>
+gap> VertexConnectivity(T);
+0
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -59,6 +59,7 @@
     <#Include Label="DigraphDegeneracy">
     <#Include Label="DigraphDegeneracyOrdering">
     <#Include Label="HamiltonianPath">
+    <#Include Label="VertexConnectivity">
   </Section>
   
   <Section><Heading>Cayley graphs of groups</Heading>

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -70,6 +70,7 @@ DeclareOperation("DIGRAPHS_MaximalSymmetricSubdigraph", [IsDigraph, IsBool]);
 DeclareAttribute("UndirectedSpanningTree", IsDigraph);
 DeclareAttribute("UndirectedSpanningForest", IsDigraph);
 DeclareAttribute("HamiltonianPath", IsDigraph);
+DeclareAttribute("VertexConnectivity", IsDigraph);
 
 # AsGraph must be mutable for grape to function properly
 DeclareAttribute("AsGraph", IsDigraph, "mutable");

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1656,6 +1656,38 @@ gap> gr := DigraphAddEdges(DigraphAddVertex(CycleDigraph(600)),
 gap> HamiltonianPath(gr);
 fail
 
+#T# VertexConnectivity
+gap> D := CompleteDigraph(10);
+<digraph with 10 vertices, 90 edges>
+gap> VertexConnectivity(D);
+9
+gap> D := JohnsonDigraph(9, 2);
+<digraph with 36 vertices, 504 edges>
+gap> VertexConnectivity(D);
+14
+gap> D := Digraph([]);
+<digraph with 0 vertices, 0 edges>
+gap> VertexConnectivity(D);
+0
+gap> D := Digraph([[]]);
+<digraph with 1 vertex, 0 edges>
+gap> VertexConnectivity(D);
+0
+gap> D := Digraph([[2, 4, 5], [1, 4], [4, 7], [1, 2, 3, 5, 6, 7], [1, 4],
+>                  [4, 7], [3, 4, 6]]);
+<digraph with 7 vertices, 20 edges>
+gap> VertexConnectivity(D);
+1
+gap> D := Digraph([[2, 4, 5], [1, 3, 4], [4, 7], [1, 2, 3, 5, 6, 7], [1, 4],
+>                  [4, 7], [3, 4, 6]]);
+<digraph with 7 vertices, 21 edges>
+gap> VertexConnectivity(D);
+2
+gap> D := Digraph([[2, 3], [3, 5], [1, 2, 4], [2, 3], [3]]);
+<digraph with 5 vertices, 10 edges>
+gap> VertexConnectivity(D);
+2
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);


### PR DESCRIPTION
This pull request adds an attribute called `VertexConnectivity` which for a graph G = (V, E) computes the least cardinality |S| of a subset S of V, such that G - S is either disconnected, is trivial, or has no vertices. Documentation and tests are included.