### PR TITLE
Use IS_CONSTRUCTOR instead of CONSTRUCTORS

### DIFF
--- a/gap/utils.gi
+++ b/gap/utils.gi
@@ -327,7 +327,7 @@ DIGRAPHS_ManSectionType := function(op)
     class := "Oper";
     if IS_IDENTICAL_OBJ(op, IS_OBJECT) then
       class := "Filt";
-    elif op in CONSTRUCTORS then
+    elif IS_CONSTRUCTOR(op) then
       class := "Constructor";
       # seem to never get one
     elif IsFilter(op) then


### PR DESCRIPTION
CONSTRUCTORS has been removed from the GAP master branch: see https://github.com/gap-system/gap/pull/2114/commits/b597f5cbf18b89e9264d2fff4362c0c652d22270