### PR TITLE
Resolve Issue #114

### DIFF
--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -103,11 +103,16 @@ if DIGRAPHS_NautyAvailable then
                                                  calling_function_name);
       colors := NautyColorData(colors);
     fi;
+    if DigraphNrVertices(digraph) = 0 then
+      # This circumvents Issue #17 in NautyTracesInterface, whereby a graph
+      # with 0 vertices causes a seg fault.
+      return [Group(()), ()];
+    fi;
     data := NautyDense(DigraphSource(digraph),
-            DigraphRange(digraph),
-            DigraphNrVertices(digraph),
-            not IsSymmetricDigraph(digraph),
-            colors);
+                       DigraphRange(digraph),
+                       DigraphNrVertices(digraph),
+                       not IsSymmetricDigraph(digraph),
+                       colors);
     if IsEmpty(data[1]) then
       data[1] := [()];
     fi;
@@ -232,6 +237,7 @@ function(digraph)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
+
   data := NAUTY_DATA_NO_COLORS(digraph);
   SetNautyCanonicalLabelling(digraph, data[2]);
   if not HasDigraphGroup(digraph) then

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -313,6 +313,20 @@ gap> gr := EmptyDigraph(0);;
 gap> DigraphSymmetricClosure(gr);
 <digraph with 0 vertices, 0 edges>
 
+# Issue 114: Bug in NautyTracesInterface for graphs with 0 vertices
+gap> not DIGRAPHS_NautyAvailable or 
+> NautyAutomorphismGroup(NullDigraph(0)) = Group(());
+true
+gap> not DIGRAPHS_NautyAvailable or 
+> NautyAutomorphismGroup(NullDigraph(0), []) = Group(());
+true
+gap> not DIGRAPHS_NautyAvailable or 
+> NautyCanonicalLabelling(NullDigraph(0)) = ();
+true
+gap> not DIGRAPHS_NautyAvailable or 
+> NautyCanonicalLabelling(NullDigraph(0), []) = ();
+true
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);


### PR DESCRIPTION
It seems that NautyTracesInterface does not handle graphs with 0 vertices, and so we put a special case for this into `isomorph.gi`. 