### PR TITLE
Add IsDigraphHomomorphism and related operations

### DIFF
--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  grahom.xml
-#Y  Copyright (C) 2014-17
+#Y  Copyright (C) 2014-18
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -433,6 +433,111 @@ fail
 gap> DigraphEmbedding(gr, Digraph([[3], [1, 4], [1], [3]]));
 Transformation( [ 2, 4, 3, 4 ] )
 ]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsDigraphHomomorphism">
+<ManSection>
+  <Oper Name="IsDigraphHomomorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphEpimorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphMonomorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphEndomorphism" Arg="digraph, x"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description> 
+    <C>IsDigraphHomomorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>x</A> is a homomorphism from the digraph
+    <A>src</A> to the digraph <A>ran</A>.
+    <P/>
+    
+    <C>IsDigraphEpimorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>x</A> is a surjective homomorphism from the digraph
+    <A>src</A> to the digraph <A>ran</A>.
+    <P/>
+    
+    <C>IsDigraphMonomorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>x</A> is an injective homomorphism from the digraph
+    <A>src</A> to the digraph <A>ran</A>.
+    <P/>
+
+    <C>IsDigraphEndomorphism</C> returns <K>true</K> if the permutation
+    or transformation <A>x</A> is an endomorphism of the digraph
+    <A>digraph</A>.
+    <P/>
+
+    A permutation or transformation <A>x</A> is a <E>homomorphism</E> from a
+    digraph <A>src</A> to a digraph <A>ran</A> if the following hold:
+    <List>
+      <Item>
+        <C>[u ^ <A>x</A>, v ^ <A>x</A>]</C> is an edge of
+        <A>ran</A> whenever <C>[u, v]</C> is an
+        edge of <A>src</A>; and </Item>
+      <Item> 
+        <A>x</A> fixes every <C>i</C> which is not a vertex of <A>src</A>.
+      </Item>
+    </List>
+    See also <Ref Attr="GeneratorsOfEndomorphismMonoid"/>.<P/>
+
+    <Example><![CDATA[
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphHomomorphism(src, ran, Transformation([1, 2, 2]));
+true
+gap> IsDigraphHomomorphism(src, ran, Transformation([2, 1, 2]));
+false
+gap> IsDigraphHomomorphism(src, ran, Transformation([3, 3, 3]));
+false
+gap> IsDigraphHomomorphism(src, src, Transformation([3, 3, 3]));
+true
+gap> IsDigraphEndomorphism(src, Transformation([3, 3, 3]));
+true
+gap> IsDigraphEpimorphism(src, ran, Transformation([3, 3, 3]));
+false
+gap> IsDigraphMonomorphism(src, ran, Transformation([1, 2, 2]));
+false
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]));
+true
+gap> IsDigraphMonomorphism(ran, src, ());
+true]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsDigraphEmbedding">
+<ManSection>
+  <Oper Name="IsDigraphEmbedding" Arg="src, ran, x"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description> 
+    <C>IsDigraphEmbedding</C> returns <K>true</K> if the permutation
+    or transformation <A>x</A> is a embedding of the digraph
+    <A>src</A> into the digraph <A>ran</A>.
+    <P/>
+    
+    A permutation or transformation <A>x</A> is a <E>embedding</E> of a digraph
+    <A>src</A> into a digraph <A>ran</A> if <A>x</A> is a monomorphism from
+    <A>src</A> to <A>ran</A> and the inverse of <A>x</A> is a monomorphism from
+    the subdigraph of <A>ran</A> induced by the image of <A>x</A> to
+    <A>src</A>.
+    
+    See also <Ref Oper="IsDigraphHomomorphism"/>.<P/>
+
+    <Example><![CDATA[
+gap> src := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> ran := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> IsDigraphMonomorphism(src, ran, ());
+true
+gap> IsDigraphEmbedding(src, ran, ());
+true
+gap> ran := Digraph([[1, 2], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 6 edges>
+gap> IsDigraphMonomorphism(src, ran, IdentityTransformation);
+true
+gap> IsDigraphEmbedding(src, ran, IdentityTransformation);
+false]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  isomorph.xml                                        James D. Mitchell
-#Y  Copyright (C) 2014-17                                  Wilf A. Wilson 
+#Y  Copyright (C) 2014-18                                  Wilf A. Wilson 
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -814,33 +814,64 @@ gap> OutNeighbours(canon);
 
 <#GAPDoc Label="IsDigraphAutomorphism">
 <ManSection>
-  <Oper Name="IsDigraphAutomorphism" Label="for a digraph and permutation"
-    Arg="digraph, x"/>
+  <Oper Name="IsDigraphIsomorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphAutomorphism" Arg="digraph, x"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description> 
-    This operation returns <K>true</K> if the permutation <A>x</A> is an
-    automorphism of the digraph <A>digraph</A>. <P/>
+    <C>IsDigraphIsomorphism</C> returns <K>true</K> if the permutation or
+    transformation <A>x</A> is an isomorphism from the digraph <A>src</A> to
+    the digraph <A>ran</A>.
+    <P/>
     
-    A permutation <A>x</A> on the vertices of a digraph <A>digraph</A> is an
-    <E>automorphism</E> if: <C>[u, v]</C> is an edge of <A>digraph</A> if and
-    only if <C>[u ^ <A>x</A>, v ^ <A>x</A>]</C> is also an edge
-    for all vertices <C>u</C> and <C>v</C> in <A>digraph</A>. See also <Ref
-      Attr="AutomorphismGroup" Label="for a digraph" />.<P/>
+    <C>IsDigraphAutomorphism</C> returns <K>true</K> if the permutation or
+    transformation <A>x</A> is an automorphism of the digraph <A>digraph</A>.
+    <P/>
+    
+    A permutation or transformation <A>x</A> is an <E>isomorphism</E> from a
+    digraph <A>src</A> to a digraph <A>ran</A> if the following hold:
+    <List>
+      <Item>
+        <A>x</A> is a bijection from the vertices of <A>src</A> to those of
+        <A>ran</A>; 
+      </Item>
+      <Item>
+        <C>[u ^ <A>x</A>, v ^ <A>x</A>]</C> is an edge of
+        <A>ran</A> if and only if <C>[u, v]</C> is an
+        edge of <A>src</A>; and 
+      </Item>
+      <Item> 
+        <A>x</A> fixes every <C>i</C> which is not a vertex of <A>src</A>.
+      </Item>
+    </List>
+    See also <Ref Attr="AutomorphismGroup" Label="for a digraph"
+      />.<P/>
 
     For some digraphs, it can be faster to use <C>IsDigraphAutomorphism</C>
     than to test membership in the automorphism group of <A>digraph</A>. 
 
     <Example><![CDATA[
-gap> digraph := Digraph([[1], [1, 2], [1, 3]]);
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
 <digraph with 3 vertices, 5 edges>
-gap> IsDigraphAutomorphism(digraph, (1, 2, 3));
+gap> IsDigraphAutomorphism(src, (1, 2, 3));
 false
-gap> IsDigraphAutomorphism(digraph, (2, 3));
+gap> IsDigraphAutomorphism(src, (2, 3));
 true
-gap> IsDigraphAutomorphism(digraph, (1, 4));
+gap> IsDigraphAutomorphism(src, (2, 3)(4, 5));
 false
-gap> IsDigraphAutomorphism(digraph, ());
+gap> IsDigraphAutomorphism(src, (1, 4));
+false
+gap> IsDigraphAutomorphism(src, ());
 true
+gap> ran := Digraph([[2, 1], [2], [2, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> IsDigraphIsomorphism(src, ran, (1, 2));
+true
+gap> IsDigraphIsomorphism(ran, src, (1, 2));
+true
+gap> IsDigraphIsomorphism(ran, src, (1, 2));
+true
+gap> IsDigraphIsomorphism(src, Digraph([[3], [1, 3], [2]]), (1, 2, 3));
+false
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -818,12 +818,18 @@ gap> OutNeighbours(canon);
     Arg="digraph, x"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description> 
-    This operation returns true if the permutation <A>x</A> is an automorphism
-    of the digraph <A>digraph</A>. An permutation <C>g</C> on the vertices of a
-    digraph <C>gr</C> is an automorphism if it satisfies: <C>(u, v)</C> is an
-    edge of <C>gr</C> if and only if <C>(g(u), g(v))</C> is an edge of <C>gr</C>
-    for all vertices <C>u</C> and <C>v</C> in <C>gr</C>. See also <Ref
-      Attr="AutomorphismGroup" Label="for a digraph" />.
+    This operation returns <K>true</K> if the permutation <A>x</A> is an
+    automorphism of the digraph <A>digraph</A>. <P/>
+    
+    A permutation <A>x</A> on the vertices of a digraph <A>digraph</A> is an
+    <E>automorphism</E> if: <C>[u, v]</C> is an edge of <A>digraph</A> if and
+    only if <C>[u ^ <A>x</A>, v ^ <A>x</A>]</C> is also an edge
+    for all vertices <C>u</C> and <C>v</C> in <A>digraph</A>. See also <Ref
+      Attr="AutomorphismGroup" Label="for a digraph" />.<P/>
+
+    For some digraphs, it can be faster to use <C>IsDigraphAutomorphism</C>
+    than to test membership in the automorphism group of <A>digraph</A>. 
+
     <Example><![CDATA[
 gap> digraph := Digraph([[1], [1, 2], [1, 3]]);
 <digraph with 3 vertices, 5 edges>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -61,6 +61,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="DigraphEmbedding">
     <#Include Label="ChromaticNumber">
     <#Include Label="IsDigraphHomomorphism">
+    <#Include Label="IsDigraphEmbedding">
   </Section>
 
 </Chapter>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -60,6 +60,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="DigraphColouring">
     <#Include Label="DigraphEmbedding">
     <#Include Label="ChromaticNumber">
+    <#Include Label="IsDigraphHomomorphism">
   </Section>
 
 </Chapter>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -39,6 +39,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="IsomorphismDigraphs">
     <#Include Label="IsomorphismDigraphsColours">
     <#Include Label="RepresentativeOutNeighbours">
+    <#Include Label="IsDigraphAutomorphism">
   </Section>
 
   <Section><Heading>Homomorphisms of digraphs</Heading>

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -40,3 +40,17 @@ DeclareOperation("IsDigraphHomomorphism",
 DeclareOperation("IsDigraphEndomorphism", [IsDigraph, IsPerm]);
 DeclareOperation("IsDigraphHomomorphism",
                  [IsDigraph, IsDigraph, IsPerm]);
+
+DeclareOperation("IsDigraphEpimorphism",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsDigraphMonomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsDigraphEmbedding",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+
+DeclareOperation("IsDigraphEpimorphism",
+                 [IsDigraph, IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphMonomorphism",
+                 [IsDigraph, IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphEmbedding",
+                 [IsDigraph, IsDigraph, IsPerm]);

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  grahom.gd
-##  Copyright (C) 2014-17                                James D. Mitchell
+##  Copyright (C) 2014-18                                James D. Mitchell
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -32,3 +32,11 @@ DeclareAttribute("DigraphColouring", IsDigraph);
 DeclareSynonymAttr("DigraphColoring", DigraphColouring);
 
 DeclareGlobalFunction("HomomorphismDigraphsFinder");
+
+DeclareOperation("IsDigraphEndomorphism", [IsDigraph, IsTransformation]);
+DeclareOperation("IsDigraphHomomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation]);
+
+DeclareOperation("IsDigraphEndomorphism", [IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphHomomorphism",
+                 [IsDigraph, IsDigraph, IsPerm]);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -480,3 +480,72 @@ InstallMethod(IsDigraphEndomorphism, "for a digraph and a transformation",
 function(gr, x)
   return IsDigraphHomomorphism(gr, gr, x);
 end);
+
+InstallMethod(IsDigraphEpimorphism, "for digraph, digraph, and transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(src, ran, x)
+  return IsDigraphHomomorphism(src, ran, x)
+    and OnSets(DigraphVertices(src), x) = DigraphVertices(ran);
+end);
+
+InstallMethod(IsDigraphEpimorphism, "for digraph, digraph, and perm",
+[IsDigraph, IsDigraph, IsPerm],
+function(src, ran, x)
+  return IsDigraphHomomorphism(src, ran, x)
+    and OnSets(DigraphVertices(src), x) = DigraphVertices(ran);
+end);
+
+InstallMethod(IsDigraphMonomorphism,
+"for digraph, digraph, and transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(src, ran, x)
+  return IsDigraphHomomorphism(src, ran, x)
+    and IsInjectiveListTrans(DigraphVertices(src), x);
+end);
+
+InstallMethod(IsDigraphMonomorphism, "for digraph, digraph, and perm",
+[IsDigraph, IsDigraph, IsPerm], IsDigraphHomomorphism);
+
+InstallMethod(IsDigraphEmbedding,
+"for digraph, digraph, and transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(src, ran, x)
+  local y, induced, i, j;
+  if not IsDigraphMonomorphism(src, ran, x) then
+    return false;
+  fi;
+  y := MappingPermListList(OnTuples(DigraphVertices(src), x),
+                           DigraphVertices(src));
+  induced := BlistList(DigraphVertices(ran), OnSets(DigraphVertices(src), x));
+  for i in DigraphVertices(ran) do
+    if induced[i] then
+      for j in OutNeighbours(ran)[i] do
+        if induced[j] and not IsDigraphEdge(src, i ^ y, j ^ y) then
+          return false;
+        fi;
+      od;
+    fi;
+  od;
+  return true;
+end);
+
+InstallMethod(IsDigraphEmbedding, "for digraph, digraph, and perm",
+[IsDigraph, IsDigraph, IsPerm],
+function(src, ran, x)
+  local y, induced, i, j;
+  if not IsDigraphHomomorphism(src, ran, x) then
+    return false;
+  fi;
+  y := x ^ -1;
+  induced := BlistList(DigraphVertices(ran), OnSets(DigraphVertices(src), x));
+  for i in DigraphVertices(ran) do
+    if induced[i] then
+      for j in OutNeighbours(ran)[i] do
+        if induced[j] and not IsDigraphEdge(src, i ^ y, j ^ y) then
+          return false;
+        fi;
+      od;
+    fi;
+  od;
+  return true;
+end);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  grahom.gi
-##  Copyright (C) 2014-17                                  Julius Jonusas
+##  Copyright (C) 2014-18                                  Julius Jonusas
 ##                                                         James Mitchell
 ##                                                         Wilf A. Wilson
 ##
@@ -429,4 +429,54 @@ function(gr1, gr2)
     fi;
   od;
   return fail;
+end);
+
+InstallMethod(IsDigraphHomomorphism, "for digraph, digraph, and perm",
+[IsDigraph, IsDigraph, IsPerm],
+function(src, ran, x)
+  local i, j;
+  if IsMultiDigraph(src) or IsMultiDigraph(ran) then
+    ErrorNoReturn("Digraphs: IsDigraphHomomorphism: usage,\n",
+                  "the first 2 arguments must not have multiple edges,");
+  elif LargestMovedPoint(x) > DigraphNrVertices(src) then
+    return false;
+  fi;
+  for i in DigraphVertices(src) do
+    for j in OutNeighbours(src)[i] do
+      if not IsDigraphEdge(ran, i ^ x, j ^ x) then
+        return false;
+      fi;
+    od;
+  od;
+  return true;
+end);
+
+InstallMethod(IsDigraphEndomorphism, "for a digraph and a perm",
+[IsDigraph, IsPerm], IsDigraphAutomorphism);
+
+InstallMethod(IsDigraphHomomorphism,
+"for digraph, digraph, and transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(src, ran, x)
+  local i, j;
+  if IsMultiDigraph(src) or IsMultiDigraph(ran) then
+    ErrorNoReturn("Digraphs: IsDigraphHomomorphism: usage,\n",
+                  "the first 2 arguments must not have multiple edges,");
+  elif LargestMovedPoint(x) > DigraphNrVertices(src) then
+    return false;
+  fi;
+  for i in DigraphVertices(src) do
+    for j in OutNeighbours(src)[i] do
+      if not IsDigraphEdge(ran, i ^ x, j ^ x) then
+        return false;
+      fi;
+    od;
+  od;
+  return true;
+end);
+
+InstallMethod(IsDigraphEndomorphism, "for a digraph and a transformation",
+[IsDigraph, IsTransformation],
+function(gr, x)
+  return IsDigraphHomomorphism(gr, gr, x);
 end);

--- a/gap/isomorph.gd
+++ b/gap/isomorph.gd
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  isomorph.gd
-##  Copyright (C) 2014-17                                James D. Mitchell
+##  Copyright (C) 2014-18                                James D. Mitchell
 ##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
@@ -45,3 +45,7 @@ BindGlobal("DIGRAPHS_UsingBliss", true);
 DeclareGlobalFunction("DIGRAPHS_ValidateVertexColouring");
 
 DeclareOperation("IsDigraphAutomorphism", [IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphIsomorphism", [IsDigraph, IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphAutomorphism", [IsDigraph, IsTransformation]);
+DeclareOperation("IsDigraphIsomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation]);

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 ##  isomorph.gi
-##  Copyright (C) 2014-17                                James D. Mitchell
+##  Copyright (C) 2014-18                                James D. Mitchell
 ##                                                          Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
@@ -561,13 +561,37 @@ function(n, partition, method)
                 "form, <partition[i]> is the list of vertices with colour i,");
 end);
 
-InstallMethod(IsDigraphAutomorphism,
-"for a digraph and a permutation",
+InstallMethod(IsDigraphIsomorphism, "for digraph, digraph, and permutation",
+[IsDigraph, IsDigraph, IsPerm],
+function(src, ran, x)
+  if IsMultiDigraph(src) or IsMultiDigraph(ran) then
+    ErrorNoReturn("Digraphs: IsDigraphIsomorphism: usage,\n",
+                  "the first 2 arguments must not have multiple edges,");
+  fi;
+  return IsDigraphHomomorphism(src, ran, x)
+    and IsDigraphHomomorphism(ran, src, x ^ -1);
+end);
+
+InstallMethod(IsDigraphAutomorphism, "for a digraph and a permutation",
 [IsDigraph, IsPerm],
 function(gr, x)
-  if IsMultiDigraph(gr) then
-    ErrorNoReturn("Digraphs: IsDigraphAutomorphism: usage,\n",
-                  "the first argument <gr> must not have multiple edges,");
-  fi;
-  return OnDigraphs(gr, x) = gr;
+  return IsDigraphIsomorphism(gr, gr, x);
 end);
+
+InstallMethod(IsDigraphIsomorphism, "for digraph, digraph, and transformation",
+[IsDigraph, IsDigraph, IsTransformation],
+function(src, ran, x)
+  local y;
+  y := AsPermutation(RestrictedTransformation(x, DigraphVertices(src)));
+  if y = fail then
+    return false;
+  fi;
+  return IsDigraphIsomorphism(src, ran, y);
+end);
+
+InstallMethod(IsDigraphAutomorphism, "for a digraph and a transformation",
+[IsDigraph, IsTransformation],
+function(gr, x)
+  return IsDigraphIsomorphism(gr, gr, x);
+end);
+

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -1,7 +1,7 @@
 #############################################################################
 ##
 #W  standard/grahom.tst
-#Y  Copyright (C) 2015-17                                   Wilf A. Wilson
+#Y  Copyright (C) 2015-18                                   Wilf A. Wilson
 ##
 ##  Licensing information can be found in the README file of this package.
 ##
@@ -915,6 +915,55 @@ gap> t := HomomorphismDigraphsFinder(gr, gr, fail, [], 1, fail, false,
 Transformation( [ 2, 13, 20, 19, 21, 19, 14, 13, 15, 14, 20, 6, 15, 21, 11,
   12, 6, 7, 7, 12, 2, 11 ] )
 gap> ForAll(DigraphEdges(gr), e -> IsDigraphEdge(gr, e[1] ^ t, e[2] ^ t));
+true
+
+# IsDigraphEndomorphism and IsDigraphHomomorphism
+gap> gr := Digraph([[3, 4], [1, 3], [4], [1, 2, 3, 5], [2]]);
+<digraph with 5 vertices, 10 edges>
+gap> ForAll(GeneratorsOfEndomorphismMonoid(gr),
+>           x -> IsDigraphEndomorphism(gr, x));
+true
+gap> x := Transformation([3, 3, 4, 4]);
+Transformation( [ 3, 3, 4, 4 ] )
+gap> IsDigraphEndomorphism(gr, x);
+false
+gap> IsDigraphHomomorphism(gr, gr, (1, 2));
+false
+gap> gr := Digraph([[1, 1]]);
+<multidigraph with 1 vertex, 2 edges>
+gap> x := Transformation([3, 3, 4, 4]);
+Transformation( [ 3, 3, 4, 4 ] )
+gap> IsDigraphEndomorphism(gr, x);
+Error, Digraphs: IsDigraphHomomorphism: usage,
+the first 2 arguments must not have multiple edges,
+gap> IsDigraphEndomorphism(gr, ());
+Error, Digraphs: IsDigraphIsomorphism: usage,
+the first 2 arguments must not have multiple edges,
+gap> IsDigraphHomomorphism(gr, gr, ());
+Error, Digraphs: IsDigraphHomomorphism: usage,
+the first 2 arguments must not have multiple edges,
+gap> gr := DigraphTransitiveClosure(CompleteDigraph(2));
+<digraph with 2 vertices, 4 edges>
+gap> ForAll(GeneratorsOfEndomorphismMonoid(gr),
+>           x -> IsDigraphEndomorphism(gr, x));
+true
+gap> x := Transformation([2, 1, 3, 3]);;
+gap> IsDigraphEndomorphism(gr, x);
+false
+gap> x := Transformation([3, 1, 3, 3]);;
+gap> IsDigraphEndomorphism(gr, x);
+false
+gap> IsDigraphEndomorphism(gr, ());
+true
+gap> IsDigraphEndomorphism(gr, (1, 2));
+true
+gap> IsDigraphEndomorphism(gr, (1, 2)(3, 4));
+false
+gap> IsDigraphEndomorphism(gr, (1, 2, 3, 4));
+false
+gap> IsDigraphHomomorphism(NullDigraph(1), 
+>                          NullDigraph(3), 
+>                          Transformation([2, 2]));
 true
 
 #T# DIGRAPHS_UnbindVariables

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -966,6 +966,126 @@ gap> IsDigraphHomomorphism(NullDigraph(1),
 >                          Transformation([2, 2]));
 true
 
+# IsDigraphEpimorphism, for transformations
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]));
+true
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 3]));
+false
+gap> IsDigraphEpimorphism(src, src, Transformation([1, 2, 3]));
+true
+gap> IsDigraphEpimorphism(src, src, Transformation([2, 2, 2]));
+false
+gap> IsDigraphEpimorphism(src, ran, Transformation([2, 2, 2]));
+false
+
+# IsDigraphEpimorphism, for perms
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphEpimorphism(src, ran, ());
+false
+gap> IsDigraphEpimorphism(src, ran, (1, 2));
+false
+gap> IsDigraphEpimorphism(src, src, ());
+true
+gap> IsDigraphEpimorphism(src, src, (2, 3));
+true
+gap> IsDigraphEpimorphism(ran, src, ());
+false
+
+# IsDigraphMonomorphism, for transformations
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphMonomorphism(src, ran, Transformation([1, 2, 2]));
+false
+gap> IsDigraphMonomorphism(src, ran, Transformation([1, 2, 3]));
+false
+gap> IsDigraphMonomorphism(src, src, Transformation([1, 2, 3]));
+true
+gap> IsDigraphMonomorphism(src, src, Transformation([2, 2, 2]));
+false
+gap> IsDigraphMonomorphism(src, ran, Transformation([2, 2, 2]));
+false
+gap> IsDigraphMonomorphism(ran, src, Transformation([2, 1]));
+false
+gap> IsDigraphMonomorphism(ran, src, Transformation([1, 2]));
+true
+
+# IsDigraphMonomorphism, for perms
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphMonomorphism(src, ran, (1, 2));
+false
+gap> IsDigraphMonomorphism(src, ran, ());
+false
+gap> IsDigraphMonomorphism(src, src, ());
+true
+gap> IsDigraphMonomorphism(ran, src, (1, 2));
+false
+gap> IsDigraphMonomorphism(ran, src, ());
+true
+
+# IsDigraphEmbedding, for transformations
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphEmbedding(src, ran, Transformation([1, 2, 2]));
+false
+gap> IsDigraphEmbedding(src, ran, Transformation([1, 2, 3]));
+false
+gap> IsDigraphEmbedding(src, src, Transformation([1, 2, 3]));
+true
+gap> IsDigraphEmbedding(src, src, Transformation([2, 2, 2]));
+false
+gap> IsDigraphEmbedding(src, ran, Transformation([2, 2, 2]));
+false
+gap> IsDigraphEmbedding(ran, src, Transformation([2, 1]));
+false
+gap> IsDigraphEmbedding(ran, src, Transformation([1, 2]));
+true
+gap> src := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> ran := Digraph([[1, 2], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 6 edges>
+gap> IsDigraphMonomorphism(src, ran, Transformation([1, 2]));
+true
+gap> IsDigraphEmbedding(src, ran, Transformation([1, 2]));
+false
+
+# IsDigraphEmbedding, for perms
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> IsDigraphEmbedding(src, ran, (1, 2));
+false
+gap> IsDigraphEmbedding(src, ran, ());
+false
+gap> IsDigraphEmbedding(src, src, ());
+true
+gap> IsDigraphEmbedding(ran, src, (1, 2));
+false
+gap> IsDigraphEmbedding(ran, src, ());
+true
+gap> src := Digraph([[1], [1, 2]]);
+<digraph with 2 vertices, 3 edges>
+gap> ran := Digraph([[1, 2], [1, 2], [1, 3]]);
+<digraph with 3 vertices, 6 edges>
+gap> IsDigraphMonomorphism(src, ran, ());
+true
+gap> IsDigraphEmbedding(src, ran, ());
+false
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(edges);
 gap> Unbind(epis);

--- a/tst/standard/isomorph.tst
+++ b/tst/standard/isomorph.tst
@@ -802,6 +802,11 @@ fail
 gap> gr5 := NautyCanonicalDigraph(gr4, [1, 2, 3, 4]);
 fail
 
+# Issue 111
+gap> not DIGRAPHS_NautyAvailable or 
+> NautyAutomorphismGroup(NullDigraph(0)) = Group(());
+true
+
 # DigraphsUseBliss/Nauty
 gap> nauty := not DIGRAPHS_UsingBliss;;
 gap> DigraphsUseNauty();
@@ -816,7 +821,7 @@ gap> if not nauty then
 >      DigraphsUseBliss();
 >    fi;
 
-# IsDigraphAutomorphism
+# IsDigraphAutomorphism, for digraph and permutation
 gap> gr1 := Digraph([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1]]);
 <digraph with 4 vertices, 13 edges>
 gap> IsDigraphAutomorphism(gr1, (1, 2, 3));
@@ -834,8 +839,32 @@ false
 gap> IsDigraphAutomorphism(gr2, (2, 3, 6));
 false
 gap> IsDigraphAutomorphism(Digraph([[1, 1], [1, 1, 2], [1, 2, 2, 3]]), ());
-Error, Digraphs: IsDigraphAutomorphism: usage,
-the first argument <gr> must not have multiple edges,
+Error, Digraphs: IsDigraphIsomorphism: usage,
+the first 2 arguments must not have multiple edges,
+
+# IsDigraphAutomorphism, for digraph and transformation
+gap> gr1 := Digraph([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1]]);
+<digraph with 4 vertices, 13 edges>
+gap> IsDigraphAutomorphism(gr1, AsTransformation((1, 2, 3)));
+false
+gap> IsDigraphAutomorphism(gr1, AsTransformation((2, 3)));
+true
+gap> IsDigraphAutomorphism(gr1, AsTransformation(()));
+true
+gap> gr2 := Digraph([[1], [1, 2], [1, 3], [1, 4], [1, 5], [1, 2, 3, 4, 5, 6]]);
+<digraph with 6 vertices, 15 edges>
+gap> IsDigraphAutomorphism(gr2, AsTransformation((2, 3, 4, 5)));
+true
+gap> IsDigraphAutomorphism(gr2, AsTransformation((1, 6)));
+false
+gap> IsDigraphAutomorphism(gr2, AsTransformation((2, 3, 6)));
+false
+gap> IsDigraphAutomorphism(gr2, Transformation([1, 1, 2, 3]));
+false
+gap> IsDigraphAutomorphism(Digraph([[1, 1], [1, 1, 2], [1, 2, 2, 3]]),
+> AsTransformation(()));
+Error, Digraphs: IsDigraphIsomorphism: usage,
+the first 2 arguments must not have multiple edges,
 
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(G);


### PR DESCRIPTION
This PR adds new operations `IsDigraphHomomorphism`, `IsDigraphIsomorphism`, `IsDigraphMonomorphism`, `IsDigraphEpimorphism`, and `IsDigraphEndomorphism`. Also refactors `IsDigraphAutomorphism` and links the doc for `IsDigraphAutomorphism` into the manual for the first time. The arguments of any of these operations are digraph (or digraphs) and a perm or transformation. 

This breaks backwards compatibility with `IsDigraphAutomorphism`, which previously returned `true` for permutations that did not fix non-vertices. With this PR, the `IsDigraphAutomorphism` will return `true` if and only if the permutation belongs to the automorphism group, or the permutation defined by the transformation does. 