### PR TITLE
display: add dot methods for preorder and partial order digraphs

### DIFF
--- a/doc/display.xml
+++ b/doc/display.xml
@@ -170,3 +170,77 @@ gap> FileString("dot/star.dot", DotSymmetricDigraph(gr));
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="DotPartialOrderDigraph">
+  <ManSection>
+    <Attr Name="DotPartialOrderDigraph" Arg="digraph"/>
+    <Returns>A string.</Returns>
+    <Description>
+      This function produces a graphical representation of a partial order
+      digraph <A>digraph</A>. <C>DotPartialOrderDigraph</C> will return an error
+      if <A>digraph</A> is not a partial order digraph. See <Ref
+        Prop="IsPartialOrderDigraph"/>.<P/>
+
+      Since <A>digraph</A> is a partial order, it is both reflexive and
+      transitive. The output of <C>DotPartialOrderDigraph</C> is the
+      <Ref Attr="DotDigraph"/> of the
+      <Ref Oper="DigraphReflexiveTransitiveReduction"/> of <A>digraph</A>.<P/>
+
+      The output is in <C>dot</C> format (also known as <C>GraphViz</C>)
+      format. For details about this file format, and information about how
+      to display or edit this format see
+      <URL>http://www.graphviz.org</URL>. <P/>
+
+      The string returned by <C>DotPartialOrderDigraph</C> can be written to a
+      file using the command <Ref Func="FileString" BookName="GAPDoc"/>.<P/>
+
+      <Log><![CDATA[
+gap> poset := Digraph([[1, 4], [2], [2, 3, 4], [4]);
+gap> IsPartialOrderDigraph(gr);
+true
+gap> FileString("dot/poset.dot", DotPartialOrderDigraph(gr));
+83]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DotPreorderDigraph">
+  <ManSection>
+    <Attr Name="DotPreorderDigraph" Arg="digraph"/>
+    <Attr Name="DotQuasiorderDigraph" Arg="digraph"/>
+    <Returns>A string.</Returns>
+    <Description>
+      This function produces a graphical representation of a preorder
+      digraph <A>digraph</A>. <C>DotPreorderDigraph</C> will return an error
+      if <A>digraph</A> is not a preorder digraph. See <Ref
+        Prop="IsPreorderDigraph"/>.<P/>
+
+      A preorder digraph is reflexive and transitive but in general it is
+      not anti-symmetric and may have strongly connected components
+      containing more than one vertex. The <Ref Oper="QuotientDigraph"/>
+      <A>Q</A> obtained by forming the quotient of <A>digraph</A> by the
+      partition of its vertices into the strongly connected components
+      satisfies <Ref Prop="IsPartialOrderDigraph"/>. Thus every vertex of
+      <A>Q</A> corresponds to a strongly connected component of <A>digraph</A>.
+      The output of <C>DotPreorderDigraph</C> displays the 
+      <Ref Oper="DigraphReflexiveTransitiveReduction"/> of <A>Q</A> with
+      vertices displayed as rounded rectangles labelled by all of the vertices
+      of <A>digraph</A> in the corresponding strongly connected component. <P/>
+
+      The output is in <C>dot</C> format (also known as <C>GraphViz</C>)
+      format. For details about this file format, and information about how
+      to display or edit this format see
+      <URL>http://www.graphviz.org</URL>. <P/>
+
+      The string returned by <C>DotPreorderDigraph</C> can be written to a
+      file using the command <Ref Func="FileString" BookName="GAPDoc"/>.<P/>
+
+      <Log><![CDATA[
+gap> preset := Digraph([[1, 2, 4, 5], [1, 2, 4, 5], [3, 4], [4], [1, 2, 4, 5]);
+gap> IsPreorderDigraph(gr);
+true
+gap> FileString("dot/preset.dot", DotProrderDigraph(gr));
+83]]></Log>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -107,11 +107,12 @@ false]]></Example>
   <Prop Name="IsPartialOrderDigraph" Arg="digraph"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
-    This is a synonym for <Ref Prop="IsReflexiveDigraph"/> and
+    A digraph is a partial order digraph if and only if the digraph satisifies
+    all of <Ref Prop="IsReflexiveDigraph"/>,
     <Ref Prop="IsAntisymmetricDigraph"/> and <Ref Prop="IsTransitiveDigraph"/>.
-    For a partial order digraph <A>digraph</A>, the corresponding partial order
-    is the relation <M>\leq</M>, defined by <M>x \leq y</M> if and only if
-    <C>[x, y]</C> is an edge of <A>digraph</A>.    
+    A partial order <A>digraph</A> corresponds
+    to the partial order relation <M>\leq</M> defined by <M>x \leq y</M> if and
+    only if <C>[x, y]</C> is an edge of <A>digraph</A>.
 
 <Example><![CDATA[
 gap> gr := Digraph([[1, 3], [2, 3], [3]]);
@@ -126,6 +127,40 @@ gap> gr := Digraph([[1, 1], [1, 1, 2], [3], [3, 3, 4, 4]]);
 <multidigraph with 4 vertices, 10 edges>
 gap> IsPartialOrderDigraph(gr);
 true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="IsPreorderDigraph">
+<ManSection>
+  <Prop Name="IsPreorderDigraph" Arg="digraph"/>
+  <Prop Name="IsQuasiorderDigraph" Arg="digraph"/>  
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    A digraph is a preorder digraph if and only if the digraph satisifies both
+    <Ref Prop="IsReflexiveDigraph"/> and <Ref Prop="IsTransitiveDigraph"/>.
+    A preorder digraph (or quasiorder digraph) <A>digraph</A> corresponds to
+    the preorder relation <M>\leq</M> defined by <M>x \leq y</M> if and only
+    if <C>[x, y]</C> is an edge of <A>digraph</A>.
+
+<Example><![CDATA[
+gap> gr := Digraph([[1], [2, 3], [2, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> IsPreorderDigraph(gr);
+true
+gap> gr := Digraph([[1 .. 4], [1 .. 4], [1 .. 4], [1 .. 4]]);
+<digraph with 4 vertices, 16 edges>
+gap> IsPreorderDigraph(gr);
+true
+gap> gr := Digraph([[2], [3], [4], [5], [1]]);
+<digraph with 5 vertices, 5 edges>
+gap> IsPreorderDigraph(gr);
+false
+gap> gr := Digraph([[1], [1, 2], [2, 3]]);
+<digraph with 3 vertices, 5 edges>
+gap> IsPreorderDigraph(gr);
+false
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -13,6 +13,7 @@
     <#Include Label="IsSymmetricDigraph">
     <#Include Label="IsTournament">
     <#Include Label="IsTransitiveDigraph">
+    <#Include Label="IsPreorderDigraph">
     <#Include Label="IsPartialOrderDigraph">
     <#Include Label="IsMeetSemilatticeDigraph">
   </Section>

--- a/doc/z-chap9.xml
+++ b/doc/z-chap9.xml
@@ -4,6 +4,9 @@
     <#Include Label="Splash">
     <#Include Label="DotDigraph">
     <#Include Label="DotSymmetricDigraph">
+    <#Include Label="DotPartialOrderDigraph">
+    <#Include Label="DotPreorderDigraph">
+    
   </Section>
 
   <Section><Heading>Reading and writing graphs to a file</Heading>

--- a/gap/display.gd
+++ b/gap/display.gd
@@ -11,3 +11,6 @@
 DeclareAttribute("DotDigraph", IsDigraph);
 DeclareOperation("DotVertexLabelledDigraph", [IsDigraph]);
 DeclareAttribute("DotSymmetricDigraph", IsDigraph);
+DeclareAttribute("DotPartialOrderDigraph", IsDigraph);
+DeclareAttribute("DotPreorderDigraph", IsDigraph);
+DeclareSynonym("DotQuasiorderDigraph", DotPreorderDigraph);

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -217,3 +217,59 @@ if not IsBound(Splash) then  # This function is written by A. Egri-Nagy
     return;
   end);
 fi;
+
+# CR's code
+
+InstallMethod(DotPartialOrderDigraph, "for a partial order digraph",
+[IsDigraph],
+function(digraph)
+  if not IsPartialOrderDigraph(digraph) then
+    ErrorNoReturn("Digraphs: DotPartialOrderDigraph: usage,\n",
+                  "the argument <digraph> should be a partial order digraph,");
+  fi;
+  return DotDigraph(DigraphReflexiveTransitiveReduction(digraph));
+end);
+
+InstallMethod(DotPreorderDigraph, "for a preorder digraph",
+[IsDigraph],
+function(digraph)
+  local comps, quo, red, str, c, x, e;
+
+  if not IsPreorderDigraph(digraph) then
+    ErrorNoReturn("Digraphs: DotPreorderDigraph: usage,\n",
+                  "the argument <digraph> should be a preorder digraph,");
+  fi;
+
+  # Quotient by the strongly connected components to get a partial order
+  # digraph and draw this without loops or edges implied by transitivity.
+  comps  := DigraphStronglyConnectedComponents(digraph).comps;
+  quo    := DigraphRemoveAllMultipleEdges(QuotientDigraph(digraph, comps));
+  red    := DigraphReflexiveTransitiveReduction(quo);
+
+  str   := "//dot\n";
+  Append(str, "digraph graphname {\n");
+  Append(str, "node [shape=Mrecord, height=0.5, fixedsize=true]");
+  Append(str, "ranksep=1;\n");
+
+  # Each vertex of the quotient digraph is labelled by its preimage.
+  for c in [1 .. Length(comps)] do
+    Append(str, String(c));
+    Append(str, " [label=\"");
+    Append(str, String(comps[c][1]));
+    for x in comps[c]{[2 .. Length(comps[c])]} do
+      Append(str, "|");
+      Append(str, String(x));
+    od;
+    Append(str, "\", width=");
+    Append(str, String(Float(Length(comps[c]) / 2)));
+    Append(str, "]\n");
+  od;
+
+  # Add the edges of the quotient digraph.
+  for e in DigraphEdges(red) do
+    Append(str, Concatenation(String(e[1]), " -> ", String(e[2]), "\n"));
+  od;
+
+  Append(str, "}");
+  return str;
+end);

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -60,3 +60,6 @@ DeclareSynonymAttr("IsPartialOrderDigraph",
                    and IsTransitiveDigraph);
 DeclareSynonymAttr("IsLatticeDigraph",
                     IsMeetSemilatticeDigraph and IsJoinSemilatticeDigraph);
+DeclareSynonymAttr("IsPreorderDigraph",
+                   IsReflexiveDigraph and IsTransitiveDigraph);
+DeclareSynonymAttr("IsQuasiorderDigraph", IsPreorderDigraph);

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -106,6 +106,101 @@ gap> dot{[1 .. 50]};
 #Error, Digraphs: Splash: usage,
 #the option <engine> must be "dot", "neato", "twopi", "circo", "fdp", "sfdp", or "patchwork"
 
+# DotPartialOrderDigraph
+gap> gr := Digraph([[1], [1, 2], [1, 3], [1, 4], [1 .. 5], [1 .. 6],
+> [1, 2, 3, 4, 5, 7], [1, 8]]);;
+gap> Print(DotPartialOrderDigraph(gr));
+//dot
+digraph hgn{
+node [shape=circle]
+1
+2
+3
+4
+5
+6
+7
+8
+2 -> 1
+3 -> 1
+4 -> 1
+5 -> 2
+5 -> 3
+5 -> 4
+6 -> 5
+7 -> 5
+8 -> 1
+}
+gap> gr := Digraph([[1], [2], [1, 3], [2, 4], [1, 2, 3, 4, 5], [1, 2, 3, 6]]);;
+gap> Print(DotPartialOrderDigraph(gr));
+//dot
+digraph hgn{
+node [shape=circle]
+1
+2
+3
+4
+5
+6
+3 -> 1
+4 -> 2
+5 -> 3
+5 -> 4
+6 -> 3
+6 -> 2
+}
+gap> gr := Digraph([[1], []]);;
+gap> DotPartialOrderDigraph(gr);
+Error, Digraphs: DotPartialOrderDigraph: usage,
+the argument <digraph> should be a partial order digraph,
+
+# DotPreorderDigraph and DotQuasiorderDigraph
+gap> gr := Digraph([[1], [1, 2], [1, 3], [1, 4], [1 .. 5], [1 .. 6],
+> [1, 2, 3, 4, 5, 7], [1, 8]]);;
+gap> Print(DotPreorderDigraph(gr), "\n");
+//dot
+digraph graphname {
+node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
+1 [label="1", width=0.5]
+2 [label="2", width=0.5]
+3 [label="3", width=0.5]
+4 [label="4", width=0.5]
+5 [label="5", width=0.5]
+6 [label="6", width=0.5]
+7 [label="7", width=0.5]
+8 [label="8", width=0.5]
+2 -> 1
+3 -> 1
+4 -> 1
+5 -> 2
+5 -> 3
+5 -> 4
+6 -> 5
+7 -> 5
+8 -> 1
+}
+gap> gr := Concatenation("+XqD?OG???FbueZpzRKGC@?}]sr]nYXnNl[saOEGOgA@w|he?A?",
+> "?}NyxnFlKvbueZpzrLGcHa??A?]NYx_?_GC??AJpzrnw~jm{]srO???_");;
+gap> gr := DigraphFromDigraph6String(gr);;
+gap> Print(DotPreorderDigraph(gr){[1 .. 94]}, "\n");
+//dot
+digraph graphname {
+node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
+1 [label=
+gap> gr := DigraphDisjointUnion(CompleteDigraph(10), CompleteDigraph(5), CycleDigraph(2));;
+gap> gr := DigraphReflexiveTransitiveClosure(DigraphAddEdge(gr, [10, 11]));;
+gap> IsPreorderDigraph(gr);
+true
+gap> Print(DotPreorderDigraph(gr), "\n");
+//dot
+digraph graphname {
+node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
+1 [label="11|12|13|14|15", width=2.5]
+2 [label="1|2|3|4|5|6|7|8|9|10", width=5.]
+3 [label="16|17", width=1.]
+2 -> 1
+}
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(dot);

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1319,6 +1319,29 @@ gap> gr := Digraph([[2, 2], [1, 1]]);;
 gap> IsMultiDigraph(gr) and IsHamiltonianDigraph(gr);
 true
 
+# IsPreorderDigraph and IsQuasiorderDigraph
+gap> gr := Digraph([[1], [1, 2], [1, 3], [1, 4], [1 .. 5], [1 .. 6],
+> [1, 2, 3, 4, 5, 7], [1, 8]]);;
+gap> IsPreorderDigraph(gr) and IsQuasiorderDigraph(gr);
+true
+gap> gr := Concatenation("+XqD?OG???FbueZpzRKGC@?}]sr]nYXnNl[saOEGOgA@w|he?A?",
+> "?}NyxnFlKvbueZpzrLGcHa??A?]NYx_?_GC??AJpzrnw~jm{]srO???_");;
+gap> gr := DigraphFromDigraph6String(gr);;
+gap> IsPreorderDigraph(gr) and IsQuasiorderDigraph(gr);
+true
+gap> gr := Concatenation("+]KO??G_CP??G?A?AGGC?_Di_H__O?gT?E@A`a@?O?D@?ACCA_?",
+> "PAOg@O?CHe?G__gK?_??__Oa???QGC@?AG???`O@??O?@??O?W?U_I?A_?DOOOBoG@P_CGp?Cw",
+> "?A??C_W?_??P_?s@??Bi?G@?O?a");;
+gap> gr := DigraphFromDigraph6String(gr);;
+gap> IsPreorderDigraph(gr) or IsQuasiorderDigraph(gr);
+false
+gap> gr := Digraph([[], [2], [1, 2, 3]]);;
+gap> IsPreorderDigraph(gr) or IsQuasiorderDigraph(gr);
+false
+gap> gr := Digraph([[1], [1, 2], [2, 3]]);;
+gap> IsPreorderDigraph(gr) or IsQuasiorderDigraph(gr);
+false
+
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(circuit);


### PR DESCRIPTION
This commit also adds the property `IsPreorderDigraph` and its synonym `IsQuasiorderDigraph`. A preorder is a reflexive and transitive relation. It need not be anti-symmetric and thus can have strongly connected components containing multiple vertices. The components will be complete subdigraphs (due to reflexivity) and I chose to avoid drawing these edges and merge all these vertices. Essentially this is drawing the quotient digraph (quotienting by strongly connected components). For both preorders and partial orders these dot methods avoid drawing loops and edges implied by transitivity
(i.e. don't draw [a,c] if there are edges [a,b] and [b,c]).

The methods added are:
`IsPreorderDigraph`
`IsQuasiorderDigraph`
`DotPartialOrderDigraph`
`DotPreorderDigraph`
`DotQuasiorderDigraph`