### PR TITLE
Make Graphviz engine configurable

### DIFF
--- a/doc/display.xml
+++ b/doc/display.xml
@@ -69,6 +69,17 @@
           option must be specified in <A>str</A> or in <A>opt.type</A>.
         </Item>
 
+        <Mark>engine</Mark>
+        <Item>
+          this option can be used to specify the GraphViz engine to use
+          to render a <C>dot</C> document. The valid choices are <C>"dot"</C>,
+          <C>"neato"</C>, <C>"circo"</C>, <C>"twopi"</C>, <C>"fdp"</C>,
+          <C>"sfdp"</C>, and <C>"patchwork"</C>. Please refer to the
+          GraphViz documentation for details on these engines.
+          The default value for this option is <C>"dot"</C>, and it
+          must be specified in <A>opt.engine</A>.
+        </Item>
+
         <Mark>filetype</Mark>
         <Item>
           this should be a string representing the type of file which

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -109,7 +109,7 @@ if not IsBound(Splash) then  # This function is written by A. Egri-Nagy
 
   BindGlobal("Splash",
   function(arg)
-    local opt, path, dir, tdir, file, viewer, type, filetype;
+    local opt, path, dir, tdir, file, engine, viewer, type, filetype;
 
     if not IsString(arg[1]) then
       ErrorNoReturn("Digraphs: Splash: usage,\n",
@@ -184,6 +184,21 @@ if not IsBound(Splash) then  # This function is written by A. Egri-Nagy
       filetype := "pdf";
     fi;
 
+    # engine
+    if IsBound(opt.engine) then
+      if opt.engine in ["dot", "neato", "twopi", "circo",
+                        "fdp", "sfdp", "patchwork"] then
+        engine := opt.engine;
+      else
+        ErrorNoReturn("Digraphs: Splash: usage,\n",
+                      "the option <engine> must be \"dot\", \"neato\", ",
+                      "\"twopi\", \"circo\", \"fdp\", \"sfdp\", ",
+                      "or \"patchwork\"");
+      fi;
+    else
+      engine := "dot";
+    fi;
+
     #
 
     if type = "latex" then
@@ -194,9 +209,9 @@ if not IsBound(Splash) then  # This function is written by A. Egri-Nagy
                          ".pdf 2>/dev/null 1>/dev/null &"));
     elif type = "dot" then
       FileString(Concatenation(dir, file, ".dot"), arg[1]);
-      Exec(Concatenation("dot -T", filetype, " ", dir, file, ".dot", " -o ",
+      Exec(Concatenation(engine, " -T", filetype, " ", dir, file, ".dot", " -o ",
                          dir, file, ".", filetype));
-      Exec (Concatenation(viewer, " ", dir, file, ".", filetype,
+      Exec(Concatenation(viewer, " ", dir, file, ".", filetype,
                           " 2>/dev/null 1>/dev/null &"));
     fi;
     return;

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -102,6 +102,9 @@ gap> dot{[1 .. 50]};
 #gap> Splash("string", rec(viewer := "xpdf"));
 #Error, Digraphs: Splash: usage,
 #the option <type> must be "dot" or "latex",
+#gap> Splash("string", rec(type := "dot", engine := "dott"));
+#Error, Digraphs: Splash: usage,
+#the option <engine> must be "dot", "neato", "twopi", "circo", "fdp", "sfdp", or "patchwork"
 
 #T# DIGRAPHS_UnbindVariables
 gap> Unbind(adj);


### PR DESCRIPTION
I recently found myself wanting to use a different GraphViz renderer for `Splash`, so I added this option. Might be useful for others.