### PR TITLE
Add DigraphDijkstraS and DigraphDijkstraST (WORK IN PROGRESS)

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -212,7 +212,8 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">=4.8.2",
   NeededOtherPackages := [["io", ">=4.5.1"],
-                          ["orb", ">=4.7.5"]],
+                          ["orb", ">=4.7.5"],
+                          ["datastructures", ">=0.2.1"]],
   SuggestedOtherPackages := [["gapdoc", ">=1.5.1"],
                              ["grape", ">=4.5"],
                              ["nautytracesinterface", ">=0.2"]],

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -956,6 +956,17 @@ gap> Display(shortest_distances);
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphDijkstraS">
+<ManSection>
+  <Oper Name="DigraphDijkstraS" Arg="digraph, source"/>
+  <Oper Name="DigraphDijkstraST" Arg="digraph, source, target"/>
+  <Returns></Returns>
+  <Description>
+
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="AsBinaryRelation">
 <ManSection>
   <Oper Name="AsBinaryRelation" Arg="digraph"/>

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -37,6 +37,10 @@ DeclareOperation("DigraphAddVerticesNC", [IsDigraph, IsInt, IsList]);
 
 DeclareOperation("DigraphFloydWarshall",
                  [IsDigraph, IsFunction, IsObject, IsObject]);
+DeclareOperation("DigraphDijkstraS",
+                 [IsDigraph, IsPosInt]);
+DeclareOperation("DigraphDijkstraST",
+                 [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("DigraphReflexiveTransitiveReduction", [IsDigraph]);
 DeclareOperation("DigraphTransitiveReduction", [IsDigraph]);
 DeclareOperation("DigraphTransitiveReductionNC", [IsDigraph, IsBool]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -158,6 +158,51 @@ end);
 
 #
 
+InstallMethod(DigraphDijkstraS, "for a digraph, and a vertex",
+[IsDigraph, IsPosInt],
+{digraph, source} -> DigraphDijkstraST(digraph, source, fail));
+
+#
+
+InstallMethod(DigraphDijkstraST, "for a digraph, a vertex, and a vertex",
+[IsDigraph, IsPosInt, IsPosInt],
+function(digraph, source, target)
+    local vertices, dist, prev, queue, u, v, alt;
+
+    dist := [];
+    prev := [];
+    queue := BinaryHeap({x,y} -> x[1] < y[1]);
+
+    for v in DigraphVertices(digraph) do
+        dist[v] := infinity;
+        prev[v] := -1;
+    od;
+
+    dist[source] := 0;
+    Push(queue, [0, source]);
+
+    while not IsEmpty(queue) do
+        u := Pop(queue);
+        u := u[2];
+        # TODO: this has a small performance impact for DigraphDijkstraS,
+        #       but do we care?
+        if u = target then
+            return [dist, prev];
+        fi;
+        for v in OutNeighbours(digraph)[u] do
+            alt := dist[u] + DigraphEdgeLabel(digraph, u, v);
+            if alt < dist[v] then
+                dist[v] := alt;
+                prev[v] := u;
+                Push(queue, [dist[v], v]);
+            fi;
+        od;
+    od;
+    return [dist, prev];
+end);
+
+#
+
 InstallMethod(DigraphReverse, "for a digraph",
 [IsDigraph],
 function(digraph)


### PR DESCRIPTION
These compute shortest (weighted) distances in a digraph.

 * `DigraphDijkstraS` computes least cost distances and paths
   to all vertices reachable from a source vertex
 * `DigraphDijkstraST` computes the least cost distance between a source
   vertex and a target vertex. The only difference between this function
   and `DigraphDijkstraS` is that `DigraphDijkstraST` breaks early when the
   target vertex is found