### PR TITLE
Add DigraphShortestPath method

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1203,6 +1203,38 @@ fail
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphShortestPath">
+<ManSection>
+  <Oper Name="DigraphShortestPath" Arg="digraph, u, v"/>
+  <Returns>A pair of lists, or <K>fail</K>.</Returns>
+  <Description>
+    Returns the shortest directed path in the digraph digraph from the vertex u to the vertex v, if such a path exists. If u = v, then the shortest non-trivial cycle is returned, again, if it exists. Otherwise, this operation returns
+    <K>fail</K>.  See Section <Ref Subsect="Definitions" Style="Text"/> for the
+    definition of a directed path and a directed cycle.
+    <P/>
+
+    See <Ref Oper="DigraphPath"/> for details on the output.
+
+    The method for <C>DigraphShortestPath</C> has worst case complexity of <M>O(m +
+      n)</M> where <M>m</M> is the number of edges and <M>n</M> the number of
+    vertices in <A>digraph</A>.
+
+<Example><![CDATA[
+gap> gr := Digraph([[1, 2], [3], [2, 4], [1], [2, 4]]);
+<digraph with 5 vertices, 8 edges>
+gap> DigraphShortestPath(gr, 5, 1);
+[ [ 5, 4, 1 ], [ 2, 1 ] ]
+gap> DigraphShortestPath(gr, 3, 3);
+[ [ 3, 2, 3 ], [ 1, 1 ] ]
+gap> DigraphShortestPath(gr, 5, 5);
+fail
+gap> DigraphShortestPath(gr, 1, 1);
+[ [ 1, 1 ], [ 1 ] ]
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IteratorOfPaths">
 <ManSection>
   <Oper Name="IteratorOfPaths" Arg="digraph, u, v"/>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -52,6 +52,7 @@
     <#Include Label="DigraphFloydWarshall">
     <#Include Label="IsReachable">
     <#Include Label="DigraphPath">
+    <#Include Label="DigraphShortestPath">
     <#Include Label="IteratorOfPaths">
     <#Include Label="DigraphAllSimpleCircuits">
     <#Include Label="DigraphLongestSimpleCircuit">

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -106,3 +106,4 @@ DeclareOperation("IsMaximalMatching", [IsDigraph, IsHomogeneousList]);
 
 DeclareOperation("AsSemigroup", [IsFunction, IsDigraph]);
 DeclareOperation("AsMonoid", [IsFunction, IsDigraph]);
+DeclareOperation("DigraphShortestPath", [IsDigraph, IsPosInt, IsPosInt]);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -2047,7 +2047,33 @@ gap> S := AsMonoid(IsTransformation, di);;
 Error, Digraphs: AsMonoid usage,
 the first argument must be IsPartialPermMonoid or IsPartialPermSemigroup,
 
-#  DIGRAPHS_UnbindVariables
+# DigraphShortestPath
+gap> gr := Digraph([[1], [3, 4], [5, 6], [4, 2, 3], [4, 5], [1]]);;
+gap> DigraphShortestPath(gr, 1, 6);
+fail
+gap> DigraphShortestPath(gr, 2, 5);
+[ [ 2, 3, 5 ], [ 1, 1 ] ]
+gap> DigraphShortestPath(gr, 3, 3);
+[ [ 3, 5, 4, 3 ], [ 1, 1, 3 ] ]
+gap> DigraphShortestPath(gr, 6, 6);
+fail
+gap> DigraphShortestPath(gr, 5, 5);
+[ [ 5, 5 ], [ 2 ] ]
+gap> gr := Digraph([[]]);;
+gap> DigraphShortestPath(gr, 1, 1);
+fail
+gap> gr := Digraph([[], []]);;
+gap> DigraphShortestPath(gr, 2, 1);
+fail
+gap> gr := Digraph([[2], [1], [3]]);;
+gap> DigraphShortestPath(gr, 1, 2);
+[ [ 1, 2 ], [ 1 ] ]
+gap> gr := CayleyDigraph(SymmetricGroup(7));;
+gap> DigraphShortestPath(gr, 12, 5014);
+[ [ 12, 912, 1919, 3595, 4915, 3433, 4153, 3242, 2522, 2886, 23, 743, 238, 
+      1558, 713, 5014 ], [ 2, 2, 2, 1, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 2 ] ]
+
+# DIGRAPHS_UnbindVariables
 gap> Unbind(a);
 gap> Unbind(adj);
 gap> Unbind(b);


### PR DESCRIPTION
This pull request implements a `DigraphShortestPath` method, which takes a digraphs and two positive integers, and returns a list in the same format as `DigraphPath`.

The shortest path is found using a breadth-first search.