### PR TITLE
Replace LEN_LIST by Length

### DIFF
--- a/gap/io.gi
+++ b/gap/io.gi
@@ -793,8 +793,8 @@ function(s)
         i := i / 2;
       else
         edge := FindCoord(pos + 6 - bpos, 0);
-        out[edge[1]][LEN_LIST(out[edge[1]]) + 1] := edge[2];
-        out[edge[2]][LEN_LIST(out[edge[2]]) + 1] := edge[1];
+        out[edge[1]][Length(out[edge[1]]) + 1] := edge[2];
+        out[edge[2]][Length(out[edge[2]]) + 1] := edge[1];
         nredges := nredges + 1;
         i := (i - 1) / 2;
       fi;


### PR DESCRIPTION
The former is an undocumented internal low-level function (and as far as I
can tell, it has little reason to exist, other than historical). Much better
to use the documented high level counterpart.