### PR TITLE
homos.h: fix Issue #147 (remove x86intrin.h)

### DIFF
--- a/src/homos.h
+++ b/src/homos.h
@@ -14,7 +14,6 @@
 
 #include <limits.h>
 #include <setjmp.h>
-#include <x86intrin.h>
 
 #include "bliss-0.73/bliss_C.h"
 #include "src/schreier-sims.h"


### PR DESCRIPTION
This PR removes `#include <x86intrin.h>` from `src/homos.h` which may be unnecessary. If the CI tests pass, then I propose to merge this PR. This works on my computer using Clang.
