### PR TITLE
Cleanup comments

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -240,8 +240,6 @@ end);
 #   return out;
 # end);
 
-#
-
 InstallMethod(DigraphAdjacencyFunction, "for a digraph", [IsDigraph],
 function(digraph)
   local func;
@@ -253,8 +251,6 @@ function(digraph)
   return func;
 end);
 
-#
-
 InstallMethod(AsTransformation, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -263,8 +259,6 @@ function(digraph)
   fi;
   return Transformation(Concatenation(OutNeighbours(digraph)));
 end);
-
-#
 
 InstallMethod(ReducedDigraph, "for a digraph",
 [IsDigraph],
@@ -319,8 +313,6 @@ function(digraph)
   return gr;
 end);
 
-#
-
 InstallMethod(DigraphDual, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -346,11 +338,7 @@ function(digraph)
   return gr;
 end);
 
-#
-
 InstallMethod(DigraphNrEdges, "for a digraph", [IsDigraph], DIGRAPH_NREDGES);
-
-#
 
 InstallMethod(DigraphEdges, "for a digraph",
 [IsDigraph],
@@ -374,8 +362,6 @@ end);
 
 InstallMethod(AsGraph, "for a digraph", [IsDigraph], Graph);
 
-#
-
 InstallMethod(DigraphVertices, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -398,8 +384,6 @@ function(digraph)
   return digraph!.DigraphSource;
 end);
 
-#
-
 InstallMethod(OutNeighbours, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -415,20 +399,14 @@ function(digraph)
   return out;
 end);
 
-#
-
 InstallMethod(InNeighbours, "for a digraph",
 [IsDigraph],
 function(digraph)
   return DIGRAPH_IN_OUT_NBS(OutNeighbours(digraph));
 end);
 
-#
-
 InstallMethod(AdjacencyMatrix, "for a digraph",
 [IsDigraph], ADJACENCY_MATRIX);
-
-#
 
 InstallMethod(BooleanAdjacencyMatrix,
 "for a digraph",
@@ -446,8 +424,6 @@ function(gr)
   od;
   return mat;
 end);
-
-#
 
 InstallMethod(DigraphShortestDistances, "for a digraph",
 [IsDigraph],
@@ -490,8 +466,6 @@ InstallMethod(DigraphTopologicalSort, "for a digraph",
   return DIGRAPH_TOPO_SORT(OutNeighbours(graph));
 end);
 
-#
-
 InstallMethod(DigraphStronglyConnectedComponents, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -510,13 +484,9 @@ function(digraph)
   return GABOW_SCC(OutNeighbours(digraph));
 end);
 
-#
-
 InstallMethod(DigraphConnectedComponents, "for a digraph",
 [IsDigraph],
 DIGRAPH_CONNECTED_COMPONENTS);
-
-#
 
 InstallMethod(OutDegrees, "for a digraph",
 [IsDigraph],
@@ -531,8 +501,6 @@ function(digraph)
   return degs;
 end);
 
-#
-
 InstallMethod(InDegrees, "for a digraph with in neighbours",
 [IsDigraph and HasInNeighbours],
 function(digraph)
@@ -545,8 +513,6 @@ function(digraph)
   od;
   return degs;
 end);
-
-#
 
 InstallMethod(InDegrees, "for a digraph",
 [IsDigraph],
@@ -563,8 +529,6 @@ function(digraph)
   return degs;
 end);
 
-#
-
 InstallMethod(OutDegreeSequence, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -577,8 +541,6 @@ function(digraph)
        end);
   return out;
 end);
-
-#
 
 InstallMethod(OutDegreeSequence, "for a digraph with known digraph group",
 [IsDigraph and HasDigraphGroup],
@@ -598,8 +560,6 @@ function(digraph)
   return out;
 end);
 
-#
-
 InstallMethod(OutDegreeSet, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -608,8 +568,6 @@ function(digraph)
   out := ShallowCopy(OutDegrees(digraph));
   return Set(out);
 end);
-
-#
 
 InstallMethod(InDegreeSequence, "for a digraph",
 [IsDigraph],
@@ -623,8 +581,6 @@ function(digraph)
        end);
   return out;
 end);
-
-#
 
 InstallMethod(InDegreeSequence,
 "for a digraph with known digraph group and in-neighbours",
@@ -645,8 +601,6 @@ function(digraph)
   return out;
 end);
 
-#
-
 InstallMethod(InDegreeSet, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -655,8 +609,6 @@ function(digraph)
   out := ShallowCopy(InDegrees(digraph));
   return Set(out);
 end);
-
-#
 
 InstallMethod(DigraphSources, "for a digraph with in-degrees",
 [IsDigraph and HasInDegrees], 3,
@@ -701,8 +653,6 @@ function(digraph)
   return Filtered(verts, x -> not seen[x]);
 end);
 
-#
-
 InstallMethod(DigraphSinks, "for a digraph with out-degrees",
 [IsDigraph and HasOutDegrees],
 function(digraph)
@@ -728,8 +678,6 @@ function(digraph)
   od;
   return sinks;
 end);
-
-#
 
 InstallMethod(DigraphPeriod, "for a digraph",
 [IsDigraph],
@@ -781,15 +729,11 @@ function(digraph)
   return period;
 end);
 
-#
-
 InstallMethod(DIGRAPHS_ConnectivityData, "for a digraph",
 [IsDigraph],
 function(digraph)
   return [];
 end);
-
-#
 
 BindGlobal("DIGRAPH_ConnectivityDataForVertex",
 function(digraph, v)
@@ -898,8 +842,6 @@ function(digraph, v)
                  layers := layers);
   return data[v];
 end);
-#
-
 BindGlobal("DIGRAPHS_DiameterAndUndirectedGirth",
 function(digraph)
   local outer_reps, diameter, girth, v, record, localGirth,
@@ -957,8 +899,6 @@ function(digraph)
   return rec(diameter := diameter, girth := girth);
 end);
 
-#
-
 InstallMethod(DigraphDiameter, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -972,8 +912,6 @@ function(digraph)
   # Use the C function
   return DIGRAPH_DIAMETER(digraph);
 end);
-
-#
 
 InstallMethod(DigraphUndirectedGirth, "for a digraph",
 [IsDigraph],
@@ -993,8 +931,6 @@ function(digraph)
   # Otherwise digraph is simple
   return DIGRAPHS_DiameterAndUndirectedGirth(digraph).girth;
 end);
-
-#
 
 InstallMethod(DigraphGirth, "for a digraph",
 [IsDigraph],
@@ -1026,8 +962,6 @@ function(digraph)
   return girth;
 end);
 
-#
-
 InstallMethod(DigraphLongestSimpleCircuit, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -1040,8 +974,6 @@ function(digraph)
   max := Maximum(lens);
   return circs[Position(lens, max)];
 end);
-
-#
 
 InstallMethod(DigraphSymmetricClosure, "for a digraph",
 [IsDigraph],
@@ -1115,8 +1047,6 @@ function(digraph)
   return digraph;
 end);
 
-#
-
 InstallMethod(DigraphTransitiveClosure, "for a digraph",
 [IsDigraph],
 function(graph)
@@ -1127,8 +1057,6 @@ function(graph)
   return DigraphTransitiveClosureNC(graph, false);
 end);
 
-#
-
 InstallMethod(DigraphReflexiveTransitiveClosure, "for a digraph",
 [IsDigraph],
 function(graph)
@@ -1138,8 +1066,6 @@ function(graph)
   fi;
   return DigraphTransitiveClosureNC(graph, true);
 end);
-
-#
 
 InstallGlobalFunction(DigraphTransitiveClosureNC,
 function(graph, reflexive)
@@ -1354,8 +1280,6 @@ function(digraph)
   return [true, Transformation(colour)];
 end);
 
-#
-
 InstallMethod(DigraphBicomponents, "for a digraph", [IsDigraph],
 function(digraph)
   local b;
@@ -1369,8 +1293,6 @@ function(digraph)
   return b;
 end);
 
-#
-
 InstallMethod(DigraphLoops, "for a digraph", [IsDigraph],
 function(gr)
   if HasDigraphHasLoops(gr) and not DigraphHasLoops(gr) then
@@ -1378,8 +1300,6 @@ function(gr)
   fi;
   return Filtered(DigraphVertices(gr), x -> x in OutNeighboursOfVertex(gr, x));
 end);
-
-#
 
 InstallMethod(DigraphDegeneracy,
 "for a digraph",
@@ -1452,8 +1372,6 @@ function(gr)
   return [k, out];
 end);
 
-#
-
 InstallMethod(MaximalSymmetricSubdigraphWithoutLoops, "for a digraph",
 [IsDigraph],
 function(gr)
@@ -1469,8 +1387,6 @@ function(gr)
   return DIGRAPHS_MaximalSymmetricSubdigraph(gr, false);
 end);
 
-#
-
 InstallMethod(MaximalSymmetricSubdigraph, "for a digraph",
 [IsDigraph],
 function(gr)
@@ -1482,8 +1398,6 @@ function(gr)
   fi;
   return DIGRAPHS_MaximalSymmetricSubdigraph(gr, true);
 end);
-
-#
 
 InstallMethod(DIGRAPHS_MaximalSymmetricSubdigraph,
 "for a digraph and a bool",
@@ -1512,8 +1426,6 @@ function(gr, loops)
   return new_gr;
 end);
 
-#
-
 InstallMethod(UndirectedSpanningForest,
 "for a digraph",
 [IsDigraph],
@@ -1531,8 +1443,6 @@ function(gr)
   return out;
 end);
 
-#
-
 InstallMethod(UndirectedSpanningTree,
 "for a digraph",
 [IsDigraph],
@@ -1546,8 +1456,6 @@ function(gr)
   SetIsUndirectedTree(out, true);
   return out;
 end);
-
-#
 
 InstallMethod(HamiltonianPath,
 "for a digraph",

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -195,8 +195,6 @@ function(gr)
   return DigraphMaximalIndependentSetsReps(gr);
 end);
 
-#
-
 InstallGlobalFunction(DigraphMaximalIndependentSetsReps,
 function(arg)
   local digraph, out;
@@ -234,8 +232,6 @@ InstallMethod(DigraphMaximalIndependentSetsAttr,
 function(gr)
   return DigraphMaximalIndependentSets(gr);
 end);
-
-#
 
 InstallGlobalFunction(DigraphMaximalIndependentSets,
 function(arg)
@@ -278,8 +274,6 @@ function(arg)
   return CallFuncList(DIGRAPHS_Clique, Concatenation([true], arg));
 end);
 
-#
-
 InstallGlobalFunction(DigraphClique,
 function(arg)
   if IsEmpty(arg) then
@@ -288,8 +282,6 @@ function(arg)
   fi;
   return CallFuncList(DIGRAPHS_Clique, Concatenation([false], arg));
 end);
-
-#
 
 InstallGlobalFunction(DIGRAPHS_Clique,
 function(arg)
@@ -479,8 +471,6 @@ function(gr)
   return DigraphMaximalCliquesReps(gr);
 end);
 
-#
-
 InstallGlobalFunction(DigraphMaximalCliquesReps,
 function(arg)
   local digraph, include, exclude, limit, size, out;
@@ -541,8 +531,6 @@ InstallMethod(DigraphMaximalCliquesAttr,
 function(gr)
   return DigraphMaximalCliques(gr);
 end);
-
-#
 
 InstallGlobalFunction(DigraphMaximalCliques,
 function(arg)

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -62,8 +62,6 @@ function(digraph)
   return str;
 end);
 
-#
-
 InstallMethod(DotSymmetricDigraph, "for an 'undirected' digraph",
 [IsDigraph],
 function(graph)

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -111,8 +111,6 @@ function(gr1, gr2, hook, user_param, limit, hint, inj, image, map, list1, list2)
                 "vertices,");
 end);
 
-#
-
 InstallGlobalFunction(GeneratorsOfEndomorphismMonoid,
 function(arg)
   local digraph, limit, colours, G, gens, limit_arg, out;
@@ -221,8 +219,6 @@ function(digraph, n)
   # General case for n > 2; works for small graphs
   return DigraphEpimorphism(digraph, CompleteDigraph(n));
 end);
-
-#
 
 InstallMethod(DigraphColouring, "for a digraph", [IsDigraph],
 function(digraph)

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -48,8 +48,6 @@ function(super, sub)
   return true;
 end);
 
-#
-
 InstallMethod(IsUndirectedSpanningForest, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(super, sub)
@@ -75,16 +73,12 @@ function(super, sub)
   return Set(comps1, SortedList) = Set(comps2, SortedList);
 end);
 
-#
-
 InstallMethod(IsUndirectedSpanningTree, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(super, sub)
   return IsConnectedDigraph(MaximalSymmetricSubdigraph(super))
     and IsUndirectedSpanningForest(super, sub);
 end);
-
-#
 
 InstallGlobalFunction(DigraphEdgeUnion,
 function(arg)
@@ -120,8 +114,6 @@ function(arg)
   return new;
 end);
 
-#
-
 InstallMethod(DigraphFloydWarshall, "for a digraph",
 [IsDigraph, IsFunction, IsObject, IsObject],
 function(graph, func, nopath, edge)
@@ -156,8 +148,6 @@ function(graph, func, nopath, edge)
   return mat;
 end);
 
-#
-
 InstallMethod(DigraphReverse, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -172,8 +162,6 @@ function(digraph)
   SetInNeighbours(out, nbs);
   return out;
 end);
-
-#
 
 InstallMethod(DigraphReverseEdges, "for a digraph and a rectangular table",
 [IsDigraph, IsRectangularTable],
@@ -214,8 +202,6 @@ function(digraph, edges)
 
   return DigraphNC(new);
 end);
-
-#
 
 # can we use IsListOf... jj
 InstallMethod(DigraphReverseEdges, "for a digraph and a list",
@@ -283,23 +269,17 @@ function(digraph, edges)
   return DigraphNC(new);
 end);
 
-#
-
 InstallMethod(DigraphReverseEdge, "for a digraph and an edge",
 [IsDigraph, IsList],
 function(digraph, edge)
   return DigraphReverseEdges(digraph, [edge]);
 end);
 
-#
-
 InstallMethod(DigraphReverseEdge, "for a digraph and an edge",
 [IsDigraph, IsPosInt],
 function(digraph, edge)
   return DigraphReverseEdges(digraph, [edge]);
 end);
-
-#
 
 InstallMethod(DigraphRemoveLoops, "for a digraph",
 [IsDigraph],
@@ -333,8 +313,6 @@ function(digraph)
   SetDigraphEdgeLabelsNC(out, new_lbl);
   return out;
 end);
-
-#
 
 InstallMethod(DigraphRemoveEdge, "for a digraph and a list of two pos ints",
 [IsDigraph, IsHomogeneousList],
@@ -466,8 +444,6 @@ function(digraph, edges)
   return gr;
 end);
 
-#
-
 InstallMethod(DigraphAddEdge, "for a digraph and an edge",
 [IsDigraph, IsList],
 function(digraph, edge)
@@ -533,8 +509,6 @@ function(digraph, edges)
   SetDigraphEdgeLabelsNC(gr, new_lbl);
   return gr;
 end);
-#
-
 InstallMethod(DigraphAddVertex, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -546,8 +520,6 @@ InstallMethod(DigraphAddVertex, "for a digraph and an object",
 function(digraph, name)
   return DigraphAddVerticesNC(digraph, 1, [name]);
 end);
-
-#
 
 InstallMethod(DigraphAddVertices, "for a digraph and a pos int",
 [IsDigraph, IsInt],
@@ -576,8 +548,6 @@ function(digraph, m, names)
   return DigraphAddVerticesNC(digraph, m, names);
 end);
 
-#
-
 InstallMethod(DigraphAddVerticesNC, "for a digraph, a pos int and a list",
 [IsDigraph, IsInt, IsList],
 function(digraph, m, names)
@@ -599,8 +569,6 @@ function(digraph, m, names)
   return out;
 end);
 
-#
-
 InstallMethod(DigraphRemoveVertex, "for a digraph and a pos int",
 [IsDigraph, IsPosInt],
 function(digraph, m)
@@ -611,8 +579,6 @@ function(digraph, m)
   fi;
   return DigraphRemoveVerticesNC(digraph, [m]);
 end);
-
-#
 
 InstallMethod(DigraphRemoveVertices, "for a digraph and a list",
 [IsDigraph, IsList],
@@ -631,8 +597,6 @@ function(digraph, verts)
   fi;
   return DigraphRemoveVerticesNC(digraph, verts);
 end);
-
-#
 
 InstallMethod(DigraphRemoveVerticesNC, "for a digraph and a list",
 [IsDigraph, IsList],
@@ -689,8 +653,6 @@ function(digraph, verts)
   return gr;
 end);
 
-#
-
 InstallMethod(OnDigraphs, "for a digraph and a perm",
 [IsDigraph, IsPerm],
 function(graph, perm)
@@ -711,8 +673,6 @@ function(graph, perm)
   return DigraphNC(adj);
 end);
 
-#
-
 InstallMethod(OnDigraphs, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 function(digraph, trans)
@@ -731,8 +691,6 @@ function(digraph, trans)
   od;
   return DigraphNC(List(new, x -> OnTuples(x, trans)));
 end);
-
-#
 
 InstallMethod(OnMultiDigraphs, "for a digraph, perm and perm",
 [IsDigraph, IsPerm, IsPerm],
@@ -757,8 +715,6 @@ function(graph, perms)
 
   return OnDigraphs(graph, perms[1]);
 end);
-
-#
 
 InstallMethod(InducedSubdigraph,
 "for a digraph and a homogeneous list",
@@ -813,8 +769,6 @@ function(digraph, subverts)
   return gr;
 end);
 
-#
-
 InstallMethod(InNeighboursOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -852,8 +806,6 @@ function(digraph, v)
   return inn;
 end);
 
-#
-
 InstallMethod(OutNeighboursOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -870,8 +822,6 @@ InstallMethod(OutNeighboursOfVertexNC, "for a digraph and a vertex",
 function(digraph, v)
   return OutNeighbours(digraph)[v];
 end);
-
-#
 
 InstallMethod(InDegreeOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
@@ -914,8 +864,6 @@ function(digraph, v)
   return count;
 end);
 
-#
-
 InstallMethod(OutDegreeOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -939,8 +887,6 @@ InstallMethod(OutDegreeOfVertexNC, "for a digraph and a vertex",
 function(digraph, v)
   return Length(OutNeighbours(digraph)[v]);
 end);
-
-#
 
 InstallMethod(QuotientDigraph, "for a digraph and a homogeneous list",
 [IsDigraph, IsHomogeneousList],
@@ -997,8 +943,6 @@ function(digraph, partition)
   # Pass on information about <digraph> which might be relevant to gr?
 end);
 
-#
-
 InstallMethod(DigraphOutEdges, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -1010,8 +954,6 @@ function(digraph, v)
   return List(OutNeighboursOfVertex(digraph, v), x -> [v, x]);
 end);
 
-#
-
 InstallMethod(DigraphInEdges, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -1022,8 +964,6 @@ function(digraph, v)
 
   return List(InNeighboursOfVertex(digraph, v), x -> [x, v]);
 end);
-
-#
 
 InstallMethod(DigraphStronglyConnectedComponent, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
@@ -1041,8 +981,6 @@ function(digraph, v)
   return scc.comps[scc.id[v]];
 end);
 
-#
-
 InstallMethod(DigraphConnectedComponent, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -1056,8 +994,6 @@ function(digraph, v)
   wcc := DigraphConnectedComponents(digraph);
   return wcc.comps[wcc.id[v]];
 end);
-
-#
 
 InstallMethod(IsDigraphEdge, "for a digraph and a list",
 [IsDigraph, IsList],
@@ -1085,8 +1021,6 @@ function(digraph, u, v)
 
   return v in OutNeighboursOfVertex(digraph, u);
 end);
-
-#
 
 InstallMethod(AsBinaryRelation, "for a digraph",
 [IsDigraph],
@@ -1118,8 +1052,6 @@ function(digraph)
   return rel;
 end);
 
-#
-
 InstallGlobalFunction(DigraphDisjointUnion,
 function(arg)
   local out, offset, n, new, gr;
@@ -1150,8 +1082,6 @@ function(arg)
   fi;
   return new;
 end);
-
-#
 
 InstallGlobalFunction(DigraphJoin,
 function(arg)
@@ -1185,8 +1115,6 @@ function(arg)
   return DigraphNC(out);
 end);
 
-#
-
 InstallMethod(IsReachable, "for a digraph and two pos ints",
 [IsDigraph, IsPosInt, IsPosInt],
 function(digraph, u, v)
@@ -1212,8 +1140,6 @@ function(digraph, u, v)
   fi;
   return DigraphPath(digraph, u, v) <> fail;
 end);
-
-#
 
 InstallMethod(DigraphPath, "for a digraph and two pos ints",
 [IsDigraph, IsPosInt, IsPosInt],
@@ -1391,8 +1317,6 @@ function(digraph, u, v)
   return IteratorByFunctions(record);
 end);
 
-#
-
 InstallMethod(DigraphRemoveAllMultipleEdges, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -1507,8 +1431,6 @@ function(gr, loops)
   return OnDigraphs(Digraph(out), p);
 end);
 
-#
-
 InstallMethod(DigraphLayers, "for a digraph, and a vertex",
 [IsDigraph, IsPosInt],
 function(digraph, v)
@@ -1560,15 +1482,11 @@ function(digraph, v)
   return layers[v];
 end);
 
-#
-
 InstallMethod(DIGRAPHS_Layers, "for a digraph",
 [IsDigraph],
 function(digraph)
   return [];
 end);
-#
-
 InstallMethod(DigraphDistanceSet,
 "for a digraph, a vertex, and a non-negative integers",
 [IsDigraph, IsPosInt, IsInt],
@@ -1585,8 +1503,6 @@ function(digraph, vertex, distance)
 
   return DigraphDistanceSet(digraph, vertex, [distance]);
 end);
-
-#
 
 InstallMethod(DigraphDistanceSet,
 "for a digraph, a vertex, and a list of non-negative integers",
@@ -1611,8 +1527,6 @@ function(digraph, vertex, distances)
   return Concatenation(layers{distances});
 end);
 
-#
-
 InstallMethod(DigraphShortestDistance,
 "for a digraph, a vertex, and a vertex",
 [IsDigraph, IsPosInt, IsPosInt],
@@ -1636,8 +1550,6 @@ function(digraph, u, v)
   return dist;
 end);
 
-#
-
 InstallMethod(DigraphShortestDistance,
 "for a digraph, a list, and a list",
 [IsDigraph, IsList, IsList],
@@ -1655,8 +1567,6 @@ function(digraph, list1, list2)
   od;
   return shortest;
 end);
-
-#
 
 InstallMethod(DigraphShortestDistance,
 "for a digraph, and a list",
@@ -1724,8 +1634,6 @@ function(digraph, i, j)
 
   return fail;
 end);
-
-#
 
 InstallMethod(DigraphClosure,
 "for a digraph and an integer",

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -100,8 +100,6 @@ function(digraph)
   return IS_STRONGLY_CONNECTED_DIGRAPH(OutNeighbours(digraph));
 end);
 
-#
-
 InstallMethod(IsCompleteDigraph, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -117,8 +115,6 @@ function(digraph)
   fi;
   return not DigraphHasLoops(digraph);
 end);
-
-#
 
 InstallMethod(IsCompleteBipartiteDigraph, "for a digraph",
 [IsDigraph],
@@ -137,8 +133,6 @@ function(digraph)
   return DigraphNrEdges(digraph) = 2 * Length(bicomps[1]) * Length(bicomps[2]);
 end);
 
-#
-
 InstallMethod(IsConnectedDigraph, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -154,8 +148,6 @@ function(digraph)
   # Otherwise use DigraphConnectedComponents method
   return (Length(DigraphConnectedComponents(digraph).comps) = 1);
 end);
-
-#
 
 InstallImmediateMethod(IsAcyclicDigraph, "for a reflexive digraph",
 IsReflexiveDigraph, 0,
@@ -174,8 +166,6 @@ function(digraph)
   fi;
   return true;
 end);
-
-#
 
 InstallMethod(IsAcyclicDigraph, "for a digraph",
 [IsDigraph],
@@ -234,8 +224,6 @@ function(graph)
   return ForAll(OutNeighbours(graph), x -> Length(x) = 1);
 end);
 
-#
-
 InstallMethod(IsTournament, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -269,8 +257,6 @@ function(digraph)
 
   return IsAntisymmetricDigraph(digraph);
 end);
-
-#
 
 InstallMethod(IsEmptyDigraph, "for a digraph with known number of edges",
 [IsDigraph and HasDigraphNrEdges],
@@ -328,8 +314,6 @@ function(digraph)
   return ForAll(DigraphVertices(digraph), x -> x in adj[x]);
 end);
 
-#
-
 InstallImmediateMethod(DigraphHasLoops, "for a reflexive digraph",
 IsReflexiveDigraph, 0,
 function(digraph)
@@ -366,15 +350,11 @@ function(digraph)
   return false;
 end);
 
-#
-
 InstallMethod(IsAperiodicDigraph, "for a digraph",
 [IsDigraph],
 function(digraph)
   return DigraphPeriod(digraph) = 1;
 end);
-
-#
 
 InstallMethod(IsAntisymmetricDigraph, "for a digraph",
 [IsDigraph],
@@ -383,8 +363,6 @@ function(digraph)
   # this can return false if it has too many edges.
   return IS_ANTISYMMETRIC_DIGRAPH(OutNeighbours(digraph));
 end);
-
-#
 
 InstallMethod(IsTransitiveDigraph, "for a digraph",
 [IsDigraph],
@@ -429,8 +407,6 @@ function(digraph)
   return IS_TRANSITIVE_DIGRAPH(digraph);
 end);
 
-#
-
 InstallMethod(IsBipartiteDigraph, "for a digraph",
 [IsDigraph],
 function(digraph)
@@ -440,28 +416,20 @@ function(digraph)
   return DIGRAPHS_Bipartite(digraph)[1];
 end);
 
-#
-
 InstallMethod(IsInRegularDigraph, "for a digraph", [IsDigraph],
 function(digraph)
   return Length(InDegreeSet(digraph)) = 1;
 end);
-
-#
 
 InstallMethod(IsOutRegularDigraph, "for a digraph", [IsDigraph],
 function(digraph)
   return Length(OutDegreeSet(digraph)) = 1;
 end);
 
-#
-
 InstallMethod(IsRegularDigraph, "for a digraph", [IsDigraph],
 function(digraph)
   return IsInRegularDigraph(digraph) and IsOutRegularDigraph(digraph);
 end);
-
-#
 
 InstallMethod(IsUndirectedTree, "for a digraph", [IsDigraph],
 function(gr)
@@ -486,8 +454,6 @@ function(gr)
   od;
   return true;
 end);
-
-#
 
 InstallMethod(IsDistanceRegularDigraph, "for a symmetric digraph",
 [IsDigraph],
@@ -519,8 +485,6 @@ function(graph)
   return true;
 end);
 
-#
-
 InstallMethod(IsDirectedTree, "for a digraph",
 [IsDigraph],
 function(g)
@@ -549,8 +513,6 @@ function(g)
 
   return true;
 end);
-
-#
 
 InstallMethod(IsEulerianDigraph, "for a digraph",
 [IsDigraph],

--- a/gap/utils.gi
+++ b/gap/utils.gi
@@ -311,7 +311,7 @@ end);
 
 # Detect which ManSection should be used to document obj. Returns one of
 # "Func", "Oper", "Meth", "Filt", "Prop", "Attr", "Var", "Fam", "InfoClass"
-#
+
 # See PRINT_OPERATION where some of the code below is borrowed
 
 DIGRAPHS_ManSectionType := function(op)

--- a/tst/extreme/attr.tst
+++ b/tst/extreme/attr.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# ReducedDigraph 1
+#  ReducedDigraph 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
 gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                     "/digraphs-lib/extreme.d6.gz"), 1);
@@ -21,7 +21,7 @@ gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 gap> ReducedDigraph(gr);
 <digraph with 5000 vertices, 4211332 edges>
 
-#T# DigraphSymmetricClosure 1
+#  DigraphSymmetricClosure 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
 gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                     "/digraphs-lib/extreme.d6.gz"), 1);
@@ -36,7 +36,7 @@ gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 gap> DigraphSymmetricClosure(gr);
 <digraph with 46656 vertices, 197930 edges>
 
-#T# DigraphAllSimpleCircuits
+#  DigraphAllSimpleCircuits
 gap> gr := DigraphFromDigraph6String(
 > "+N{MYG?cJOU}MqNJLoVPHC?tDlcxgFACCDWxDMX?");
 <digraph with 15 vertices, 92 edges>
@@ -44,7 +44,7 @@ gap> circs := DigraphAllSimpleCircuits(gr);;
 gap> Length(circs);
 1291792
 
-#T# HamiltonianPath and IsHamiltonianDigraph
+#  HamiltonianPath and IsHamiltonianDigraph
 gap> g := CompleteDigraph(20);
 <digraph with 20 vertices, 380 edges>
 gap> HamiltonianPath(g);
@@ -58,7 +58,7 @@ fail
 gap> IsHamiltonianDigraph(g);
 false
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(circs);
 gap> Unbind(gr);
 

--- a/tst/extreme/grahom.tst
+++ b/tst/extreme/grahom.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# GeneratorsOfEndomorphismMonoid 1
+#  GeneratorsOfEndomorphismMonoid 1
 # PJC example, 45 vertices
 gap> gr := DigraphFromDigraph6String(Concatenation(
 > "+l??O?C?A_@???CE????GAAG?C??M?????@_?OO??G??@?IC???_C?G?o??C?AO???c_??A?A",
@@ -34,7 +34,7 @@ gap> str := HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, false,
 gap> Length(str);
 192
 
-#T# GeneratorsOfEndomorphismMonoid 2
+#  GeneratorsOfEndomorphismMonoid 2
 # PJC example, 153 vertices
 # G = PrimitiveGroup(153, 1);
 gap> G := Group([
@@ -77,7 +77,7 @@ gap> 5 ^ t;
 gap> ForAll(DigraphEdges(gr), e -> IsDigraphEdge(gr, [e[1] ^ t, e[2] ^ t]));
 true
 
-#T# GeneratorsOfEndomorphismMonoid 3
+#  GeneratorsOfEndomorphismMonoid 3
 # Small example
 gap> gr := Digraph([[2], [1, 3], [2]]);
 <digraph with 3 vertices, 4 edges>
@@ -112,7 +112,7 @@ gap> GeneratorsOfEndomorphismMonoid(gr, 4);
 gap> HasGeneratorsOfEndomorphismMonoidAttr(gr);
 false
 
-#T# GeneratorsOfEndomorphismMonoid 4
+#  GeneratorsOfEndomorphismMonoid 4
 # Complete digraph
 
 # CompleteDigraph (with no loops) has no singular endomorphisms
@@ -184,7 +184,7 @@ gap> gens := GeneratorsOfEndomorphismMonoid(gr);
   Transformation( [ 1, 1, 1, 2, 1 ] ), Transformation( [ 1, 1, 1, 2, 2 ] ), 
   Transformation( [ 1, 1, 1, 1, 2 ] ), Transformation( [ 1, 1, 1, 1, 1 ] ) ]
 
-#T# GeneratorsOfEndomorphismMonoid 5
+#  GeneratorsOfEndomorphismMonoid 5
 # Empty digraph
 
 # EmptyDigraph(n) has endomorphism monoid T_n
@@ -194,7 +194,7 @@ gap> gens := GeneratorsOfEndomorphismMonoid(gr);;
 gap> Size(Semigroup(gens)) = 5 ^ 5;
 true
 
-#T# GeneratorsOfEndomorphismMonoid 6
+#  GeneratorsOfEndomorphismMonoid 6
 # Chain digraph: endomorphisms of the chain preserve order
 
 # ChainDigraph (with no loops) has no singular endomorphisms
@@ -13862,7 +13862,7 @@ gap> gens := GeneratorsOfEndomorphismMonoid(gr);
   Transformation( [ 5, 5, 5, 5, 5, 5 ] ), 
   Transformation( [ 6, 6, 6, 6, 6, 6 ] ) ]
 
-#T# GeneratorsOfEndomorphismMonoid 7
+#  GeneratorsOfEndomorphismMonoid 7
 # Cycle digraph: EndomorphismMonoid = AutomorphismGroup = C_n
 
 # CycleDigraph (with no loops) has no singular endomorphisms
@@ -13879,7 +13879,7 @@ true
 gap> gr := Digraph(List([1 .. 20], x -> [x, x mod 20 + 1]));
 <digraph with 20 vertices, 40 edges>
 
-#T# GeneratorsOfEndomorphismMonoid8
+#  GeneratorsOfEndomorphismMonoid8
 # Check endomorphism monoid of all symmetric digraphs with 5 vertices
 gap> graph5 := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                         "/data/graph5.g6.gz"));;
@@ -13901,7 +13901,7 @@ gap> for gr in graph5
 >   fi;
 > od;
 
-#T# GeneratorsOfEndomorphismMonoid9
+#  GeneratorsOfEndomorphismMonoid9
 # Check some symmetric digraphs from digraphs-lib
 gap> gr := ReadDigraphs(
 > Concatenation(DIGRAPHS_Dir(), "/digraphs-lib/sts.g6.gz"), 1);
@@ -13932,7 +13932,7 @@ gap> gr := ReadDigraphs(
 <digraph with 12 vertices, 108 edges>
 gap> GeneratorsOfEndomorphismMonoid(gr);;
 
-#T# HomomorphismDigraphsFinder 1
+#  HomomorphismDigraphsFinder 1
 # Small example: CompleteDigraph(2) to CompleteDigraph(3)
 gap> gr1 := CompleteDigraph(2);
 <digraph with 2 vertices, 2 edges>
@@ -13952,7 +13952,7 @@ gap> homos := HomomorphismDigraphsFinder(gr1, gr2, fail, [], infinity, fail,
 > false, DigraphVertices(gr2), [], fail, fail);
 [ IdentityTransformation ]
 
-#T# HomomorphismDigraphsFinder 2
+#  HomomorphismDigraphsFinder 2
 # Small example: CompleteDigraph(15) to [CompleteDigraph(3) with loops]
 gap> homos := HomomorphismDigraphsFinder(gr1, gr2, func, [], infinity,
 >  fail, false, DigraphVertices(gr2), [], fail, fail);
@@ -13965,7 +13965,7 @@ gap> Length(homos);
 gap> last * 6 = 3 ^ 15 + 3;
 true
 
-#T# HomomorphismDigraphsFinder 3
+#  HomomorphismDigraphsFinder 3
 # Small example: randomly chosen
 gap> gr1 := Digraph([
 >  [15, 3, 6, 7, 8, 16, 19], [5, 17, 18, 13, 19], [1, 7, 19, 4, 15, 17],
@@ -14012,7 +14012,7 @@ gap> HomomorphismDigraphsFinder(gr2, gr1, fail, [], 1, fail, false, [1 .. 20],
 > [], fail, fail);
 [  ]
 
-#T# HomomorphismDigraphsFinder 4
+#  HomomorphismDigraphsFinder 4
 # Large example: randomly chosen
 gap> gr1 := DigraphFromGraph6String(
 > "]b?_?a@I??T_Y?ADcGAACUP@_AOG?C_BoH?Pg?C??gk?AA@?A?CJD?EO?sO`@H?j@S?C?_PG??")
@@ -14063,7 +14063,7 @@ gap> HomomorphismDigraphsFinder(gr2, gr1, fail, [], 1, fail, false, [1 .. 30],
 > [], fail, fail);
 [  ]
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(H);
 gap> Unbind(S);

--- a/tst/extreme/isomorph.tst
+++ b/tst/extreme/isomorph.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# AutomorphismGroup: for a digraph, 1
+#  AutomorphismGroup: for a digraph, 1
 # All graphs of 5 vertices, compare with GRAPE
 gap> graph5 := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                         "/data/graph5.g6.gz"));
@@ -72,7 +72,7 @@ gap> treeAuts := [
 gap> List(trees, AutomorphismGroup) = treeAuts;
 true
 
-#T# AutomorphismGroup: for a digraph, 2
+#  AutomorphismGroup: for a digraph, 2
 # PJC example, 45 vertices.
 # This example is broken if we use Digraphs rather than Graphs in the bliss
 # code
@@ -97,7 +97,7 @@ gap> G := Group([
 gap> IsomorphismGroups(G, H) <> fail;
 true
 
-#T# AutomorphismGroup: for a digraph, 3
+#  AutomorphismGroup: for a digraph, 3
 # Random examples
 gap> AutomorphismGroup(Digraph([]));
 Group(())
@@ -116,7 +116,7 @@ gap> Size(last);
 gap> AutomorphismGroup(CompleteDigraph(6)) = SymmetricGroup(6);
 true
 
-#T# AutomorphismGroup: for a MultiDigraph, 1
+#  AutomorphismGroup: for a MultiDigraph, 1
 gap> gr := DigraphEdgeUnion(CycleDigraph(3), CycleDigraph(3));
 <multidigraph with 3 vertices, 6 edges>
 gap> AutomorphismGroup(gr);
@@ -130,7 +130,7 @@ gap> AutomorphismGroup(gr);
 gap> Size(last);
 56294995342131200
 
-#T# CanonicalLabelling: for a digraph, 1
+#  CanonicalLabelling: for a digraph, 1
 # PJC example, 45 vertices
 gap> gr := DigraphFromDigraph6String(Concatenation(
 > "+l??O?C?A_@???CE????GAAG?C??M?????@_?OO??G??@?IC???_C?G?o??C?AO???c_??A?",
@@ -148,7 +148,7 @@ gap> not DIGRAPHS_NautyAvailable or NautyCanonicalLabelling(gr) =
 > 20, 30, 26)(18, 27);
 true
 
-#T# CanonicalLabelling: for a digraph, 2
+#  CanonicalLabelling: for a digraph, 2
 gap> gr := DigraphFromDiSparse6String(Concatenation(
 > ".~?@caOa??gGEA?e@?oOIb_SIc?MQBhOQCwIV?PY@B@IRDGgL__sYao{ODWCNC@MKBOwUEHG",
 > "TdPmEBwkXFGoV_ogNCGCIBO{ZGGGFD@U?APGUDwW_GWGGFAU??PKUE@eDA`?TFAi?A_{da@G",
@@ -184,7 +184,7 @@ gap> not DIGRAPHS_NautyAvailable or NautyCanonicalLabelling(gr) =
 > 30, 33, 26, 13, 86, 98, 95, 80, 27, 63, 43, 87, 3, 36, 39, 68)(35, 92, 56);
 true
 
-#T# CanonicalLabelling: for a digraph, 3
+#  CanonicalLabelling: for a digraph, 3
 gap> gr := ReadDigraphs(
 > Concatenation(DIGRAPHS_Dir(), "/data/test-1.d6"))[1];
 <digraph with 1000 vertices, 100368 edges>
@@ -297,7 +297,7 @@ gap> not DIGRAPHS_NautyAvailable or NautyCanonicalLabelling(gr) =
 >  315, 756, 518, 652, 123, 552, 288, 441)(77, 413, 94, 323, 813, 725, 142,
 >   449, 675)(102, 776, 893, 260, 870, 824, 828);;
 
-#T# CanonicalLabelling: for a MultiDigraph, 1
+#  CanonicalLabelling: for a MultiDigraph, 1
 gap> gr1 := DigraphEdgeUnion(CycleDigraph(3), CycleDigraph(3));
 <multidigraph with 3 vertices, 6 edges>
 gap> perms := BlissCanonicalLabelling(gr1);
@@ -311,7 +311,7 @@ true
 gap> gr2 = gr1;
 false
 
-#T# IsIsomorphicDigraph: for digraphs, 1
+#  IsIsomorphicDigraph: for digraphs, 1
 gap> p := Random(SymmetricGroup(1000));;
 gap> gr2 := OnDigraphs(gr, p);
 <digraph with 1000 vertices, 100368 edges>
@@ -324,7 +324,7 @@ true
 gap> ForAny(graph5, x -> Number(graph5, y -> IsIsomorphicDigraph(x, y)) <> 1);
 false
 
-#T# IsIsomorphicDigraph: for MultiDigraphs, 1
+#  IsIsomorphicDigraph: for MultiDigraphs, 1
 gap> gr1 := Digraph([[3, 1, 3], [1, 3], [2, 2, 1]]);
 <multidigraph with 3 vertices, 8 edges>
 gap> gr2 := Digraph([[3, 1, 3], [1, 3], [2, 2]]);
@@ -348,7 +348,7 @@ false
 gap> IsIsomorphicDigraph(gr4, gr4);
 true
 
-#T# IsomorphismDigraphs: for digraphs, 1
+#  IsomorphismDigraphs: for digraphs, 1
 gap> gr1 := CompleteBipartiteDigraph(100, 50);
 <digraph with 150 vertices, 10000 edges>
 gap> gr2 := CompleteBipartiteDigraph(50, 100);
@@ -367,7 +367,7 @@ true
 gap> IsomorphismDigraphs(EmptyDigraph(1), gr1);
 fail
 
-#T# IsomorphismDigraphs: for MultiDigraphs, 1
+#  IsomorphismDigraphs: for MultiDigraphs, 1
 gap> gr1 := Digraph([[3, 1, 3], [1, 3], [2, 2, 1]]);
 <multidigraph with 3 vertices, 8 edges>
 gap> gr4 := Digraph([[2, 3, 3], [2, 1, 1], [1, 2]]);
@@ -385,7 +385,7 @@ gap> iso := IsomorphismDigraphs(gr1, gr1);
 gap> OnMultiDigraphs(gr1, iso) = gr1;
 true
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(H);
 gap> Unbind(gr);
 gap> Unbind(gr1);

--- a/tst/extreme/oper.tst
+++ b/tst/extreme/oper.tst
@@ -14,7 +14,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# OutNeighboursMutableCopy 1
+#  OutNeighboursMutableCopy 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
 gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                       "/digraphs-lib/extreme.d6.gz"), 1);
@@ -99,7 +99,7 @@ gap> SortedList(OutNeighbours(gr)[1]);
   4942, 4944, 4945, 4947, 4950, 4953, 4955, 4969, 4970, 4972, 4975, 4982, 
   4983, 4990, 4991, 4997 ]
 
-#T# DigraphReverseEdges 1
+#  DigraphReverseEdges 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
 gap> d := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                      "/digraphs-lib/extreme.ds6.gz"))[1];;
@@ -108,7 +108,7 @@ gap> DigraphReverseEdges(d, [12, 2001, 401000]);
 gap> DigraphReverseEdge(d, [95000, 4067]);
 <digraph with 113082 vertices, 451854 edges>
 
-#T# DigraphLayers
+#  DigraphLayers
 gap> list := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 > "/digraphs-lib/fining.p.gz"));;
 gap> gr := list[4];;
@@ -173,7 +173,7 @@ gap> SortedList(DigraphLayers(gr, 6)[2]);
 gap> SortedList(DigraphLayers(gr, 1500)[2]);
 [ 81, 82, 169, 253, 254 ]
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(d);
 gap> Unbind(gr);
 gap> Unbind(gr2);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -14,7 +14,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# DigraphSource and DigraphRange
+#  DigraphSource and DigraphRange
 gap> nbs := [[12, 22, 17, 1, 10, 11], [23, 21, 21, 16],
 >  [15, 5, 22, 11, 12, 8, 10, 1], [21, 15, 23, 5, 23, 8, 24],
 >  [20, 17, 25, 25], [5, 24, 22, 5, 2], [11, 8, 19],
@@ -70,7 +70,7 @@ gap> DigraphSource(gr);
   15, 15, 16, 17, 17, 17, 17, 18, 18, 18, 18, 18, 19, 20, 20, 21, 21, 22, 22, 
   22, 23, 23, 23, 24, 24, 24, 24, 24, 24, 25, 25, 25 ]
 
-#T# DigraphDual
+#  DigraphDual
 gap> gr := Digraph([[6, 7], [6, 9], [1, 3, 4, 5, 8, 9],
 > [1, 2, 3, 4, 5, 6, 7, 10], [1, 5, 6, 7, 10], [2, 4, 5, 9, 10],
 > [3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 8, 9], [1, 2, 5],
@@ -136,7 +136,7 @@ true
 gap> DigraphGroup(gr2) = DigraphGroup(gr);
 true
 
-#T# AdjacencyMatrix
+#  AdjacencyMatrix
 gap> gr := Digraph(rec(nrvertices := 10,
 > source := [1, 1, 1, 1, 1, 1, 1, 1],
 > range := [2, 2, 3, 3, 4, 4, 5, 5]));
@@ -185,7 +185,7 @@ gap> AdjacencyMatrix(
 > Digraph(rec(nrvertices := 0, source := [], range := [])));
 [  ]
 
-#T# DigraphTopologicalSort
+#  DigraphTopologicalSort
 gap> r := rec(nrvertices := 20000, source := [], range := []);;
 gap> for i in [1 .. 9999] do
 >   Add(r.source, i);
@@ -256,7 +256,7 @@ gap> gr := Digraph([[2], [], []]);
 gap> DigraphTopologicalSort(gr);
 [ 2, 1, 3 ]
 
-#T# DigraphStronglyConnectedComponents
+#  DigraphStronglyConnectedComponents
 
 # <gr> is Digraph(RightCayleyGraphSemigroup) of the gens:
 # [Transformation([1, 3, 3]),
@@ -316,7 +316,7 @@ gap> DigraphStronglyConnectedComponents(gr2);
 rec( comps := [ [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ], 
       [ 9 ], [ 10 ] ], id := [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] )
 
-#T# DigraphConnectedComponents
+#  DigraphConnectedComponents
 gap> gr := Digraph([[1, 2], [1], [2], [5], []]);
 <digraph with 5 vertices, 5 edges>
 gap> wcc := DigraphConnectedComponents(gr);
@@ -368,7 +368,7 @@ rec( comps := [ [ 1 ], [ 2 ], [ 3 ], [ 4, 45 ], [ 5, 40 ], [ 6 ], [ 7 ],
       43, 14, 44, 45, 22, 14, 46, 14, 47, 16, 11, 48, 22, 49, 50, 26, 51, 52, 
       53, 54, 55, 14, 14, 11, 26, 56, 14 ] )
 
-#T# DigraphShortestDistances
+#  DigraphShortestDistances
 gap> adj := Concatenation(List([1 .. 11], x -> [x + 1]), [[1]]);;
 gap> cycle12 := Digraph(adj);
 <digraph with 12 vertices, 12 edges>
@@ -428,7 +428,7 @@ gap> Display(DigraphShortestDistances(gr));
   [  fail,  fail,  fail,  fail,  fail,     0,  fail ],
   [  fail,     1,     3,     2,     4,     2,     0 ] ]
 
-#T# DigraphShortestDistances, using connectivity data
+#  DigraphShortestDistances, using connectivity data
 gap> gr := CycleDigraph(3);;
 gap> DIGRAPHS_ConnectivityData(gr);
 [  ]
@@ -439,7 +439,7 @@ gap> DIGRAPH_ConnectivityDataForVertex(gr, 2);;
 gap> DigraphShortestDistances(gr);
 [ [ 0, 1, 1 ], [ 1, 0, 1 ], [ 1, 1, 0 ] ]
 
-#T# OutNeighbours and InNeighbours
+#  OutNeighbours and InNeighbours
 gap> gr := Digraph(rec(nrvertices := 10, source := [1, 1, 5, 5, 7, 10],
 > range := [3, 3, 1, 10, 7, 1]));
 <multidigraph with 10 vertices, 6 edges>
@@ -454,7 +454,7 @@ gap> InNeighbours(gr);
 gap> OutNeighbours(gr);
 [ [ 1, 1, 4 ], [ 2, 3, 4 ], [ 2, 4, 4, 4 ], [ 2 ] ]
 
-#T# OutDegree and OutDegreeSequence and InDegrees and InDegreeSequence
+#  OutDegree and OutDegreeSequence and InDegrees and InDegreeSequence
 gap> r := rec(nrvertices := 0, source := [], range := []);;
 gap> gr1 := Digraph(r);
 <digraph with 0 vertices, 0 edges>
@@ -534,7 +534,7 @@ gap> gr := EmptyDigraph(5);; OutNeighbours(gr);;
 gap> InDegrees(gr);
 [ 0, 0, 0, 0, 0 ]
 
-#T# DigraphEdges
+#  DigraphEdges
 gap> r := rec(
 > nrvertices := 5,
 > source := [1, 1, 2, 3, 5, 5],
@@ -560,7 +560,7 @@ gap> DigraphEdges(gr);
   [ 4, 7 ], [ 5, 5 ], [ 5, 6 ], [ 5, 5 ], [ 5, 5 ], [ 6, 3 ], [ 6, 2 ], 
   [ 6, 8 ], [ 7, 1 ], [ 7, 5 ], [ 7, 7 ], [ 8, 6 ], [ 8, 7 ] ]
 
-#T# DigraphSources and DigraphSinks
+#  DigraphSources and DigraphSinks
 gap> r := rec(nrvertices := 10,
 > source := [2, 2, 3, 3, 3, 5, 7, 7, 7, 7, 9, 9, 9, 9, 9],
 > range  := [2, 2, 6, 8, 2, 4, 2, 6, 8, 6, 8, 5, 8, 2, 4]);;
@@ -593,7 +593,7 @@ gap> DigraphSinks(gr);
 gap> DigraphSources(gr);
 [ 1, 3, 7, 9, 10 ]
 
-#T# DigraphPeriod
+#  DigraphPeriod
 gap> gr := EmptyDigraph(100);
 <digraph with 100 vertices, 0 edges>
 gap> DigraphPeriod(gr);
@@ -623,7 +623,7 @@ true
 gap> DigraphPeriod(gr);
 0
 
-#T# DigraphDiameter 1
+#  DigraphDiameter 1
 gap> gr := Digraph([[2], []]);;
 gap> DigraphDiameter(gr);
 fail
@@ -648,7 +648,7 @@ gap> gr := EmptyDigraph(1);;
 gap> DigraphDiameter(gr);
 0
 
-#T# DigraphDiameter 2
+#  DigraphDiameter 2
 # For a digraph (not strongly connected) with too many vertices for
 # Floyd-Warshall
 gap> str := Concatenation(
@@ -694,7 +694,7 @@ gap> gr := DigraphFromDiSparse6String(str);
 gap> DigraphDiameter(gr);
 fail
 
-#T# DigraphSymmetricClosure
+#  DigraphSymmetricClosure
 gap> gr1 := Digraph([[2], [1]]);
 <digraph with 2 vertices, 2 edges>
 gap> IsSymmetricDigraph(gr1);
@@ -740,7 +740,7 @@ gap> gr := DigraphCopy(gr);
 gap> IsSymmetricDigraph(gr);
 true
 
-#T# Digraph(Reflexive)TransitiveClosure
+#  Digraph(Reflexive)TransitiveClosure
 gap> gr := Digraph(rec(nrvertices := 2, source := [1, 1], range := [2, 2]));
 <multidigraph with 2 vertices, 2 edges>
 gap> DigraphReflexiveTransitiveClosure(gr);
@@ -820,7 +820,7 @@ true
 gap> IS_TRANSITIVE_DIGRAPH(reflextrans);
 true
 
-#T# ReducedDigraph
+#  ReducedDigraph
 gap> gr := EmptyDigraph(0);;
 gap> ReducedDigraph(gr) = gr;
 true
@@ -858,7 +858,7 @@ gap> DigraphEdgeLabels(gr);
 gap> DigraphEdgeLabels(rd);
 [ [ "a", "b" ], [  ], [ "c" ] ]
 
-#T# DigraphAllSimpleCircuits
+#  DigraphAllSimpleCircuits
 gap> gr := Digraph([]);;
 gap> DigraphAllSimpleCircuits(gr);
 [  ]
@@ -896,7 +896,7 @@ gap> gr := Digraph([[3, 6, 7], [3, 6, 8], [1, 2, 3, 6, 7, 8],
 gap> Length(DigraphAllSimpleCircuits(gr));
 259
 
-#T# DigraphLongestSimpleCircuit
+#  DigraphLongestSimpleCircuit
 gap> gr := Digraph([]);;
 gap> DigraphLongestSimpleCircuit(gr);
 fail
@@ -921,7 +921,7 @@ gap> gr := Digraph([[2, 6, 10], [3], [4], [5], [1],
 gap> DigraphLongestSimpleCircuit(gr);
 [ 1, 10, 11, 12, 13, 14 ]
 
-#T# AsTransformation
+#  AsTransformation
 gap> gr := Digraph([[2], [1, 3], [4], [3]]);;
 gap> AsTransformation(gr);
 fail
@@ -932,7 +932,7 @@ gap> DigraphEdges(gr);
 gap> AsTransformation(gr);
 Transformation( [ 1, 1, 1 ] )
 
-#T# DigraphBicomponents
+#  DigraphBicomponents
 gap> DigraphBicomponents(EmptyDigraph(0));
 fail
 gap> DigraphBicomponents(EmptyDigraph(1));
@@ -950,7 +950,7 @@ gap> DigraphBicomponents(Digraph([[2], [], [], [3]]));
 gap> DigraphBicomponents(CycleDigraph(3));
 fail
 
-#T# DigraphLoops
+#  DigraphLoops
 gap> gr := ChainDigraph(4);;
 gap> DigraphHasLoops(gr);
 false
@@ -965,7 +965,7 @@ gap> gr := Digraph([[1, 5, 6], [1, 3, 4, 5, 6], [1, 3, 4], [2, 4, 6], [2],
 gap> DigraphLoops(gr);
 [ 1, 3, 4 ]
 
-#T# Out/InDegreeSequence with known automorphsims and sets
+#  Out/InDegreeSequence with known automorphsims and sets
 gap> gr := Digraph([[2, 3, 4, 5], [], [], [], []]);;
 gap> OutDegrees(gr);
 [ 4, 0, 0, 0, 0 ]
@@ -991,7 +991,7 @@ true
 gap> OutDegreeSequence(gr);
 [ 2, 2, 1, 1 ]
 
-#T# Diameter and UndirectedGirth with known automorphisms
+#  Diameter and UndirectedGirth with known automorphisms
 gap> gr := Digraph([[2, 3, 4, 5], [], [], [], []]);;
 gap> DigraphGroup(gr);
 Group([ (4,5), (3,4), (2,3) ])
@@ -1042,7 +1042,7 @@ infinity
 gap> DigraphDiameter(gr);
 fail
 
-#T# DigraphBooleanAdjacencyMatrix
+#  DigraphBooleanAdjacencyMatrix
 gap> gr := CompleteDigraph(4);;
 gap> mat := BooleanAdjacencyMatrix(gr);
 [ [ false, true, true, true ], [ true, false, true, true ], 
@@ -1086,7 +1086,7 @@ gap> mat := BooleanAdjacencyMatrix(gr);
 gap> gr = DigraphByAdjacencyMatrix(mat);
 true
 
-#T# DigraphUndirectedGirth: easy cases
+#  DigraphUndirectedGirth: easy cases
 gap> gr := Digraph([[2], [3], []]);;
 gap> DigraphUndirectedGirth(gr);
 Error, Digraphs: DigraphUndirectedGirth: usage,
@@ -1098,7 +1098,7 @@ gap> gr := Digraph([[2, 2], [1, 1, 3], [2]]);;
 gap> DigraphUndirectedGirth(gr);
 2
 
-#T# DigraphGirth
+#  DigraphGirth
 gap> gr := Digraph([[1], [1]]);
 <digraph with 2 vertices, 2 edges>
 gap> DigraphGirth(gr);
@@ -1129,7 +1129,7 @@ gap> DigraphUndirectedGirth(gr);
 Error, Digraphs: DigraphUndirectedGirth: usage,
 <digraph> must be a symmetric digraph,
 
-#T# DigraphDegeneracy and DigraphDegeneracyOrdering
+#  DigraphDegeneracy and DigraphDegeneracyOrdering
 gap> gr := Digraph([[2, 2], [1, 1]]);;
 gap> IsMultiDigraph(gr) and IsSymmetricDigraph(gr);
 true
@@ -1172,7 +1172,7 @@ gap> DigraphDegeneracy(gr);
 gap> DigraphDegeneracyOrdering(gr);
 [ 6, 4, 3, 2, 5, 1 ]
 
-#T# DigraphGirth with known automorphisms
+#  DigraphGirth with known automorphisms
 gap> gr := Digraph([[2, 3, 4, 5], [6, 3], [6, 2], [6], [6], [1]]);;
 gap> DigraphGirth(gr);
 2
@@ -1192,7 +1192,7 @@ Group([ (6,10)(7,11)(8,12)(9,13), (2,6)(3,7)(4,8)(5,9) ])
 gap> DigraphGirth(gr);
 5
 
-#T# MaximalSymmetricSubdigraph and MaximalSymmetricSubdigraphWithoutLoops
+#  MaximalSymmetricSubdigraph and MaximalSymmetricSubdigraphWithoutLoops
 gap> gr := Digraph([[2], [1]]);;
 gap> IsSymmetricDigraph(gr);
 true
@@ -1238,7 +1238,7 @@ gap> gr := MaximalSymmetricSubdigraphWithoutLoops(gr);
 gap> OutNeighbours(gr);
 [ [ 2, 3 ], [ 1 ], [ 1 ] ]
 
-#T# RepresentativeOutNeighbours
+#  RepresentativeOutNeighbours
 gap> gr := CycleDigraph(5);
 <digraph with 5 vertices, 5 edges>
 gap> RepresentativeOutNeighbours(gr);
@@ -1250,7 +1250,7 @@ gap> gr := Digraph([[2], [3], []]);
 gap> RepresentativeOutNeighbours(gr);
 [ [ 2 ], [ 3 ], [  ] ]
 
-#T# DigraphAdjacencyFunction
+#  DigraphAdjacencyFunction
 gap> gr := Digraph([[1, 3], [2], []]);
 <digraph with 3 vertices, 3 edges>
 gap> adj := DigraphAdjacencyFunction(gr);
@@ -1262,7 +1262,7 @@ false
 gap> adj(2, 7);
 false
 
-#T# Test ChromaticNumber
+#  Test ChromaticNumber
 gap> ChromaticNumber(Digraph([[1]]));
 Error, Digraphs: ChromaticNumber: usage,
 the digraph (1st argument) must not have loops,
@@ -1394,7 +1394,7 @@ gap> ChromaticNumber(a);
 gap> ChromaticNumber(b);
 49
 
-#T# UndirectedSpanningTree and UndirectedSpanningForest
+#  UndirectedSpanningTree and UndirectedSpanningForest
 gap> gr := EmptyDigraph(0);
 <digraph with 0 vertices, 0 edges>
 gap> tree := UndirectedSpanningTree(gr);
@@ -1526,7 +1526,7 @@ gap> Set(ArticulationPoints(gr))
 >            x -> not IsConnectedDigraph(DigraphRemoveVertex(gr, x)));
 true
 
-#T# HamiltonianPath
+#  HamiltonianPath
 gap> g := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> HamiltonianPath(g);
@@ -1678,7 +1678,7 @@ gap> gr := DigraphAddEdges(DigraphAddVertex(CycleDigraph(600)),
 gap> HamiltonianPath(gr);
 fail
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);
 gap> Unbind(adj2);

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# IsClique and IsMaximalClique
+#  IsClique and IsMaximalClique
 gap> gr := CompleteDigraph(5);;
 gap> IsClique(gr, [6]);
 Error, Digraphs: IsClique: usage,
@@ -77,7 +77,7 @@ gap> gr := CompleteDigraph(5);;
 gap> IsMaximalClique(gr, [1]);
 false
 
-#T# IsIndependentSet and IsMaximalIndependentSet
+#  IsIndependentSet and IsMaximalIndependentSet
 gap> gr := CycleDigraph(10);;
 gap> IsIndependentSet(gr, []);
 true
@@ -114,7 +114,7 @@ gap> gr := Digraph([[3], [3], [3]]);
 gap> IsMaximalIndependentSet(gr, [1, 2]);
 true
 
-#T# DigraphMaximalIndependentSet and DigraphIndependentSet
+#  DigraphMaximalIndependentSet and DigraphIndependentSet
 gap> gr := Digraph([[3], [3], [3]]);
 <digraph with 3 vertices, 3 edges>
 gap> DigraphMaximalIndependentSet();
@@ -138,7 +138,7 @@ gap> DigraphMaximalIndependentSet(gr, [], [], 2);
 gap> DigraphIndependentSet(gr, [], [], 3);
 fail
 
-#T# DigraphMaximalIndependentSetsReps and DigraphIndependentSetsReps
+#  DigraphMaximalIndependentSetsReps and DigraphIndependentSetsReps
 gap> gr := EmptyDigraph(1);;
 gap> DigraphMaximalIndependentSetsReps();
 Error, Digraphs: DigraphMaximalIndependentSetsReps: usage,
@@ -212,7 +212,7 @@ gap> DigraphMaximalIndependentSetsRepsAttr(gr);
 gap> DigraphMaximalIndependentSetsAttr(gr);
 [ [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ], [ 9 ], [ 10 ] ]
 
-#T# DigraphMaximalIndependentSets and DigraphIndependentSets
+#  DigraphMaximalIndependentSets and DigraphIndependentSets
 gap> gr := ChainDigraph(2);;
 gap> DigraphMaximalIndependentSets(gr);
 [ [ 1 ], [ 2 ] ]
@@ -282,7 +282,7 @@ fail
 gap> DigraphClique(CompleteDigraph(5), [1, 2], []);
 [ 1, 2, 5, 4, 3 ]
 
-#T# DigraphCliquesReps and DigraphMaximalCliquesReps
+#  DigraphCliquesReps and DigraphMaximalCliquesReps
 gap> DigraphCliquesReps();
 Error, Digraphs: DigraphCliquesReps: usage,
 this function requires at least one argument,
@@ -327,7 +327,7 @@ gap> DigraphMaximalCliquesReps(gr);
   [ 4, 16, 17, 22, 23, 24, 25 ], [ 4, 7, 9, 16, 25 ], [ 3, 18, 19, 23, 24 ], 
   [ 5, 16, 18, 22, 24 ], [ 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ] ]
 
-#T# CliquesFinder: error checking
+#  CliquesFinder: error checking
 gap> CliquesFinder(Group(()), fail, fail, fail, fail, fail, fail, fail, fail);
 Error, Digraphs: CliquesFinder: usage,
 the first argument <gr> must be a digraph,
@@ -411,7 +411,7 @@ gap> CliquesFinder(gr, fail, [], infinity, [1 .. 5], [1 .. 5], false, 1, true);
 gap> CliquesFinder(gr, fail, [], infinity, [1], [1], false, 1, false);
 [  ]
 
-#T# DIGRAPHS_BronKerbosch: easy cases
+#  DIGRAPHS_BronKerbosch: easy cases
 gap> gr := ChainDigraph(5);;
 gap> CliquesFinder(gr, fail, [], infinity, [], [1 .. 4], false, 3, false);
 [  ]
@@ -428,7 +428,7 @@ gap> CliquesFinder(gr, fail, [], infinity, [1], [], false, 1, false);
 gap> CliquesFinder(gr, fail, [], infinity, [], [], false, 1, false);
 [ [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ] ]
 
-#T# DIGRAPHS_BronKerbosch: getting code coverage
+#  DIGRAPHS_BronKerbosch: getting code coverage
 gap> gr := CompleteDigraph(5);;
 gap> CliquesFinder(gr, fail, [], infinity, [], [], true, 4, true);
 [  ]
@@ -472,7 +472,7 @@ gap> gr := DigraphSymmetricClosure(ChainDigraph(5));;
 gap> out := CliquesFinder(gr, fail, [], lim, [], [], true, 3, true);
 [  ]
 
-#T# DigraphMaximalCliques: examples that had been giving duplicate results
+#  DigraphMaximalCliques: examples that had been giving duplicate results
 gap> gr := DigraphFromGraph6String(
 > "X~~~~~~~~~~~~~~~~~}EkpJK_vyRUwvH{fL^FFfzdo~tmB~cU^~");
 <digraph with 25 vertices, 440 edges>
@@ -503,7 +503,7 @@ gap> c := DigraphMaximalCliques(gr);;
 gap> Length(c);
 12815
 
-#T# Issue #23: Digraphs with isolated vertices
+#  Issue #23: Digraphs with isolated vertices
 gap> gr := DigraphFromSparse6String(":~?@c__EC?_F");
 <digraph with 100 vertices, 6 edges>
 gap> DigraphMaximalCliquesReps(gr);
@@ -543,7 +543,7 @@ gap> CliqueNumber(CycleDigraph(8));
 gap> CliqueNumber(DigraphSymmetricClosure(CycleDigraph(8)));
 2
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(f);
 gap> Unbind(c);
 gap> Unbind(gr);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# DigraphVertexLabels
+#  DigraphVertexLabels
 gap> gr := RandomDigraph(10);;
 gap> DigraphVertexLabels(gr);
 [ 1 .. 10 ]
@@ -73,7 +73,7 @@ gap> x;
 gap> DigraphVertexLabels(gr);
 [ 1, [  ], 3, 4, 5, 6, 7, 8, 9, 10 ]
 
-#T# DigraphEdgeLabels
+#  DigraphEdgeLabels
 gap> gr := Digraph([[2, 3], [3], [1, 5], [], [4]]);
 <digraph with 5 vertices, 6 edges>
 gap> DigraphEdgeLabels(gr);
@@ -124,14 +124,14 @@ gap> SetDigraphEdgeLabel(gr, 1, 2, infinity);
 Error, Digraphs: SetDigraphEdgeLabel: usage,
 edge labels are not supported on digraphs with multiple edges,
 
-#T# Graph
+#  Graph
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> if DIGRAPHS_IsGrapeLoaded then
 >   Graph(gr);
 > fi;
 
-#T# Digraph (by OutNeighbours)
+#  Digraph (by OutNeighbours)
 gap> Digraph([[0, 1]]);
 Error, Digraphs: Digraph: usage,
 the argument must be a list of lists of positive integers not exceeding the
@@ -148,7 +148,7 @@ Error, Digraphs: Digraph: usage,
 the argument must be a list of lists of positive integers not exceeding the
 length of the argument,
 
-#T# Digraph (by record)
+#  Digraph (by record)
 gap> n := 3;;
 gap> v := [1 .. 3];;
 gap> s := [1, 2, 3];;
@@ -220,7 +220,7 @@ gap> Digraph(rec(
 Error, Digraphs: Digraph: usage,
 the record component 'vertices' must be duplicate-free,
 
-#T# Digraph (by nrvertices, source, and range)
+#  Digraph (by nrvertices, source, and range)
 gap> Digraph(Group(()), [], []);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Digraph' on 3 arguments
@@ -270,7 +270,7 @@ of positive integers no greater than the first argument <nrvertices>,
 gap> Digraph(4, [3, 1, 2, 3], [4, 1, 2, 4]);
 <multidigraph with 4 vertices, 4 edges>
 
-#T# Digraph (by vertices, source, and range)
+#  Digraph (by vertices, source, and range)
 gap> Digraph(Group(()), [], []);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Digraph' on 3 arguments
@@ -335,7 +335,7 @@ gap> if DIGRAPHS_IsGrapeLoaded then
 >   fi;
 > fi;
 
-#T# Digraph (by an integer and a function)
+#  Digraph (by an integer and a function)
 gap> divides := function(a, b)
 >   if b mod a = 0 then
 >     return true;
@@ -345,7 +345,7 @@ gap> divides := function(a, b)
 gap> gr := Digraph([1 .. 12], divides);
 <digraph with 12 vertices, 35 edges>
 
-#T# Digraph (by binary relation)
+#  Digraph (by binary relation)
 gap> g := Group((1, 2, 3));
 Group([ (1,2,3) ])
 gap> elms := [
@@ -401,7 +401,7 @@ gap> gr := Digraph(b);
 gap> HasIsAntisymmetricDigraph(gr);
 true
 
-#T# DigraphByEdges
+#  DigraphByEdges
 gap> gr := Digraph([[1, 2, 3, 5], [1, 5], [2, 3, 6], [1, 3, 4],
 > [1, 4, 6], [3, 4]]);
 <digraph with 6 vertices, 17 edges>
@@ -435,7 +435,7 @@ gap> gr := DigraphByEdges([]);
 gap> gr = EmptyDigraph(0);
 true
 
-#T# DigraphByAdjacencyMatrix (by an integer matrix)
+#  DigraphByAdjacencyMatrix (by an integer matrix)
 
 # for a matrix of integers
 gap> mat := [
@@ -506,7 +506,7 @@ true
 gap> DigraphByAdjacencyMatrix([]);
 <digraph with 0 vertices, 0 edges>
 
-#T# DigraphByAdjacencyMatrix (by a boolean matrix)
+#  DigraphByAdjacencyMatrix (by a boolean matrix)
 gap> mat := List([1 .. 5], x -> BlistList([1 .. 5], []));;
 gap> DigraphByAdjacencyMatrix(mat) = EmptyDigraph(5);
 true
@@ -515,7 +515,7 @@ gap> mat := List([1 .. 5], x -> BlistList([1 .. 5],
 gap> DigraphByAdjacencyMatrix(mat) = CompleteDigraph(5);
 true
 
-#T# DigraphByInNeighbours
+#  DigraphByInNeighbours
 gap> gr1 := RandomMultiDigraph(50, 3000);
 <multidigraph with 50 vertices, 3000 edges>
 gap> inn := InNeighbours(gr1);;
@@ -568,7 +568,7 @@ gap> OutNeighbours(gr);
 gap> InNeighbors(gr) = inn;
 true
 
-#T# AsDigraph
+#  AsDigraph
 gap> f := Transformation([]);
 IdentityTransformation
 gap> gr := AsDigraph(f);
@@ -597,7 +597,7 @@ gap> AsDigraph(h);
 gap> AsDigraph(h, 2);
 fail
 
-#T# RandomDigraph
+#  RandomDigraph
 gap> DigraphNrVertices(RandomDigraph(10));
 10
 gap> DigraphNrVertices(RandomDigraph(200, 0.854));
@@ -620,7 +620,7 @@ gap> RandomDigraph(10, -0.01);
 Error, Digraphs: RandomDigraph: usage,
 the second argument <p> must be a float between 0 and 1,
 
-#T# RandomMultiDigraph
+#  RandomMultiDigraph
 gap> DigraphNrVertices(RandomMultiDigraph(100));
 100
 gap> gr := RandomMultiDigraph(100, 1000);;
@@ -638,7 +638,7 @@ gap> RandomMultiDigraph(1, 0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RandomMultiDigraph' on 2 arguments
 
-#T# RandomTournament
+#  RandomTournament
 gap> RandomTournament(25);
 <digraph with 25 vertices, 300 edges>
 gap> RandomTournament(0);
@@ -647,7 +647,7 @@ gap> RandomTournament(-1);
 Error, Digraphs: RandomTournament: usage,
 the argument <n> must be a non-negative integer,
 
-#T# CompleteDigraph
+#  CompleteDigraph
 gap> gr := CompleteDigraph(5);
 <digraph with 5 vertices, 20 edges>
 gap> AutomorphismGroup(gr) = SymmetricGroup(5);
@@ -660,7 +660,7 @@ gap> CompleteDigraph(-1);
 Error, Digraphs: CompleteDigraph: usage,
 the argument <n> must be a non-negative integer,
 
-#T# EmptyDigraph
+#  EmptyDigraph
 gap> gr := EmptyDigraph(5);
 <digraph with 5 vertices, 0 edges>
 gap> AutomorphismGroup(gr) = SymmetricGroup(5);
@@ -671,7 +671,7 @@ gap> EmptyDigraph(-1);
 Error, Digraphs: EmptyDigraph: usage,
 the argument <n> must be a non-negative integer,
 
-#T# CycleDigraph
+#  CycleDigraph
 gap> gr := CycleDigraph(0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CycleDigraph' on 1 arguments
@@ -687,7 +687,7 @@ gap> DigraphEdges(gr);
 gap> gr := CycleDigraph(1000);
 <digraph with 1000 vertices, 1000 edges>
 
-#T# ChainDigraph
+#  ChainDigraph
 gap> gr := ChainDigraph(0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `ChainDigraph' on 1 arguments
@@ -718,7 +718,7 @@ true
 gap> IsAntisymmetricDigraph(grrt);
 true
 
-#T# CompleteBipartiteDigraph
+#  CompleteBipartiteDigraph
 gap> gr := CompleteBipartiteDigraph(2, 0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CompleteBipartiteDigraph' on 2 argument\
@@ -742,7 +742,7 @@ gap> AutomorphismGroup(gr) = Group((1, 2, 3, 4), (1, 2), (5, 6, 7, 8), (5, 6),
 >                                  (1, 5)(2, 6)(3, 7)(4, 8));
 true
 
-#T# Equals (\=) for two digraphs
+#  Equals (\=) for two digraphs
 gap> r1 := rec(nrvertices := 2, source := [1, 1, 2], range := [1, 2, 2]);;
 gap> r2 := rec(nrvertices := 2, source := [1, 1, 2], range := [2, 1, 2]);;
 gap> gr1 := Digraph(r1);
@@ -988,7 +988,7 @@ gap> gr2 := Digraph(rec(nrvertices := 10, source := s, range := r2));;
 gap> gr1 = gr2;
 true
 
-#T# Less than (\<) for two digraphs
+#  Less than (\<) for two digraphs
 gap> gr1 := RandomMultiDigraph(10, 20);;
 gap> gr2 := RandomMultiDigraph(11, 21);;
 gap> gr1 < gr2;  # Different NrVertices
@@ -1115,7 +1115,7 @@ false
 gap> gr2 < gr1;
 true
 
-#T# DigraphCopy
+#  DigraphCopy
 
 # Tests for DigraphCopy originally located in digraph.tst
 gap> gr1 := CompleteDigraph(6);
@@ -1208,7 +1208,7 @@ true
 gap> HasOutNeighbours(digraph);
 true
 
-#T# Digraphs with known automorphisms
+#  Digraphs with known automorphisms
 gap> gr := Digraph([[], [], [], [], [1, 2, 3, 4, 5]]);;
 gap> adj := function(x, y)
 > return x = 5;
@@ -1220,7 +1220,7 @@ true
 gap> gr = gr3;
 true
 
-#T# LineDigraph
+#  LineDigraph
 gap> gr := LineUndirectedDigraph(CompleteDigraph(3));
 <digraph with 3 vertices, 6 edges>
 gap> gr = CompleteDigraph(3);
@@ -1270,7 +1270,7 @@ gap> LineUndirectedDigraph(gr);
 Error, Digraphs: LineUndirectedDigraph: usage,
 the argument <digraph> must be a symmetric digraph,
 
-#T# CayleyDigraph
+#  CayleyDigraph
 gap> group := DihedralGroup(8);
 <pc group of size 8 with 3 generators>
 gap> digraph := CayleyDigraph(group);
@@ -1297,7 +1297,7 @@ gap> digraph := CayleyDigraph(group);
 Error, Digraphs: CayleyDigraph: usage,
 the first argument <G> must be a finite group,
 
-#T# BipartiteDoubleDigraph
+#  BipartiteDoubleDigraph
 gap> n := 5;
 5
 gap> adj := function(x, y)
@@ -1313,7 +1313,7 @@ gap> bddigraph := BipartiteDoubleDigraph(digraph);
 gap> bdgroup := DigraphGroup(bddigraph);
 Group([ (1,2,3,4,5)(6,7,8,9,10), (1,6)(2,7)(3,8)(4,9)(5,10) ])
 
-#T# DoubleDigraph
+#  DoubleDigraph
 gap> out := [[2, 3, 4], [], [], []];
 [ [ 2, 3, 4 ], [  ], [  ], [  ] ]
 gap> group := Group([(2, 3), (2, 4)]);
@@ -1330,7 +1330,7 @@ gap> ddigraph := DoubleDigraph(digraph);
 gap> DigraphGroup(ddigraph);
 Group([ (2,3)(6,7), (2,4)(6,8), (1,5)(2,6)(3,7)(4,8) ])
 
-#T# (Bipartite)DoubleDigraph with multidigraph
+#  (Bipartite)DoubleDigraph with multidigraph
 gap> gr := Digraph([[2, 3], [1], []]);;
 gap> gr2 := DoubleDigraph(gr);
 <digraph with 6 vertices, 12 edges>
@@ -1350,7 +1350,7 @@ gap> gr2 := BipartiteDoubleDigraph(gr);
 gap> OutNeighbours(gr2);
 [ [ 5, 5, 6 ], [ 4 ], [  ], [ 2, 2, 3 ], [ 1 ], [  ] ]
 
-#T# DistanceDigraph
+#  DistanceDigraph
 gap> out := [[70, 79, 103], [76, 92, 116], [77, 93, 117],
 > [78, 94, 118], [66, 71, 88], [89, 106, 107], [89, 108, 125],
 > [90, 109, 126], [91, 109, 110], [64, 67, 98], [104, 115, 119],
@@ -1403,7 +1403,7 @@ gap> OutNeighbours(DistanceDigraph(gr, 1));
 gap> OutNeighbours(DistanceDigraph(gr, 2));
 [ [ 3 ], [  ], [  ] ]
 
-#T# DistanceDigraph with known automorphisms
+#  DistanceDigraph with known automorphisms
 gap> gr := Digraph([[1, 2], [], [2, 3]]);;
 gap> DigraphGroup(gr) = Group((1, 3));
 true
@@ -1414,7 +1414,7 @@ gap> OutNeighbours(DistanceDigraph(gr, 1));
 gap> OutNeighbours(DistanceDigraph(gr, 2));
 [ [  ], [  ], [  ] ]
 
-#T# DistanceDigraph on multidigraph with known automorphisms
+#  DistanceDigraph on multidigraph with known automorphisms
 gap> gr := Digraph([[1, 2, 2], [], [2, 2, 3]]);;
 gap> DigraphGroup(gr) = Group((1, 3));
 true
@@ -1425,13 +1425,13 @@ gap> OutNeighbours(DistanceDigraph(gr, 1));
 gap> OutNeighbours(DistanceDigraph(gr, 2));
 [ [  ], [  ], [  ] ]
 
-#T# DistanceDigraph: bad input
+#  DistanceDigraph: bad input
 gap> gr := Digraph([[1, 2], [2, 3], [4], [1]]);;
 gap> DistanceDigraph(gr, -2);
 Error, Digraphs: DistanceDigraph: usage,
 second arg <distance> must be a non-negative integer,
 
-#T# DigraphAddEdgeOrbit
+#  DigraphAddEdgeOrbit
 gap> digraph := NullDigraph(4);
 <digraph with 4 vertices, 0 edges>
 gap> HasDigraphGroup(digraph);
@@ -1450,7 +1450,7 @@ rec( adjacencies := [ [ 2, 4 ] ], group := Group([ (1,3), (1,2)(3,4) ]),
 gap> IsNullDigraph(DigraphRemoveEdgeOrbit(digraph, [4, 3]));
 true
 
-#T# DigraphRemoveEdgeOrbit
+#  DigraphRemoveEdgeOrbit
 gap> digraph := CompleteDigraph(4);
 <digraph with 4 vertices, 12 edges>
 gap> HasDigraphGroup(digraph);
@@ -1469,7 +1469,7 @@ rec( adjacencies := [ [ 2, 4 ] ], group := Group([ (1,3), (1,2)(3,4) ]),
   isGraph := true, names := [ 1 .. 4 ], order := 4, representatives := [ 1 ], 
   schreierVector := [ -1, 2, 1, 2 ] )
 
-#T# Digraph: copying group from Grape
+#  Digraph: copying group from Grape
 gap> if DIGRAPHS_IsGrapeLoaded then
 >   gr := Digraph(JohnsonGraph(5, 3));
 > else
@@ -1508,7 +1508,7 @@ Group(())
 gap> HasDigraphGroup(gr);
 true
 
-#T# EdgeOrbitsDigraph
+#  EdgeOrbitsDigraph
 gap> digraph := EdgeOrbitsDigraph(Group((1, 3), (1, 2)(3, 4)),
 >                                 [[1, 2], [4, 5]], 5);
 <digraph with 5 vertices, 12 edges>
@@ -1544,7 +1544,7 @@ gap> digraph := EdgeOrbitsDigraph(Group((1, 2)), [[1, 2], [3, 6]], -1);
 Error, Digraphs: EdgeOrbitsDigraph: usage,
 the third argument must be a non-negative integer,
 
-#T# DigraphAdd/RemoveEdgeOrbit
+#  DigraphAdd/RemoveEdgeOrbit
 gap> gr1 := CayleyDigraph(DihedralGroup(8));
 <digraph with 8 vertices, 24 edges>
 gap> gr2 := DigraphAddEdgeOrbit(gr1, [1, 8]);
@@ -1597,7 +1597,7 @@ gap> gr2 := DigraphRemoveEdgeOrbit(gr1, [1, 8]);
 gap> gr1 = gr2;
 true
 
-#T# Digraph (by list and function)
+#  Digraph (by list and function)
 gap> f := function(i, j) return i < j; end;
 function( i, j ) ... end
 gap> gr := Digraph([1 .. 4], f);
@@ -1609,7 +1609,7 @@ gap> gr := Digraph([4, 3 .. 1], f);
 gap> IsDigraphEdge(gr, [2, 1]);
 true
 
-#T# DigraphAddAllLoops
+#  DigraphAddAllLoops
 gap> gr := CompleteDigraph(10);
 <digraph with 10 vertices, 90 edges>
 gap> OutNeighbours(gr)[1];
@@ -1633,7 +1633,7 @@ gap> gr2 := DigraphAddAllLoops(gr);
 gap> OutNeighbours(gr2);
 [ [ 1, 2, 3 ], [ 2, 2, 2, 2 ], [ 5, 1, 3 ], [ 1, 2, 3, 4 ], [ 5 ] ]
 
-#T# JohnsonDigraph
+#  JohnsonDigraph
 gap> JohnsonDigraph(0, 4);
 <digraph with 0 vertices, 0 edges>
 gap> JohnsonDigraph(0, 0);
@@ -1660,7 +1660,7 @@ gap> JohnsonDigraph(-1, 2);
 Error, Digraphs: JohnsonDigraph: usage,
 both arguments must be non-negative integers,
 
-#T# CompleteMultipartiteDigraph
+#  CompleteMultipartiteDigraph
 gap> CompleteMultipartiteDigraph([5, 4, 2]);
 <digraph with 11 vertices, 76 edges>
 gap> CompleteMultipartiteDigraph([5, 4, 2, 10, 1000]);
@@ -1727,7 +1727,7 @@ gap> SetDigraphEdgeLabel(gr, 2, 2, "a");
 Error, Digraphs: SetDigraphEdgeLabel:
 [2, 2] is not an edge of <graph>,
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(adj);
 gap> Unbind(b);

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# Display and PrintString and String
+#  Display and PrintString and String
 gap> Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> Digraph([[]]);
@@ -42,7 +42,7 @@ gap> PrintString(gr);
 gap> String(gr);
 "Digraph( [ [ 2 ], [ 3 ], [ ] ] )"
 
-#T# DotDigraph and DotSymmetricDigraph
+#  DotDigraph and DotSymmetricDigraph
 gap> r := rec(vertices := [1 .. 3], source := [1, 1, 1, 1],
 > range := [1, 2, 2, 3]);;
 gap> gr := Digraph(r);
@@ -86,7 +86,7 @@ gap> dot{[1 .. 50]};
 
 # The following tests can't be run because they fail if Semigroups is loaded
 # first
-#T# Splash 
+#  Splash 
 #gap> Splash(1);
 #Error, Digraphs: Splash: usage,
 #<arg>[1] must be a string,
@@ -201,7 +201,7 @@ node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
 2 -> 1
 }
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(dot);
 gap> Unbind(gr);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# HomomorphismDigraphsFinder: checking errors and robustness
+#  HomomorphismDigraphsFinder: checking errors and robustness
 gap> HomomorphismDigraphsFinder(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 Error, Digraphs: HomomorphismDigraphsFinder: usage,
 the 1st and 2nd arguments <gr1> and <gr2> must be digraphs,
@@ -231,7 +231,7 @@ gap> GeneratorsOfEndomorphismMonoid(gr, [1, 1, 1, 2, 2], 0);
 Error, Digraphs: GeneratorsOfEndomorphismMonoid: usage,
 <limit> must be a positive integer or infinity,
 
-#T# GeneratorsOfEndomorphismMonoid: digraphs with loops
+#  GeneratorsOfEndomorphismMonoid: digraphs with loops
 
 # loops1
 gap> gr := Digraph([[], [2]]);
@@ -252,7 +252,7 @@ gap> GeneratorsOfEndomorphismMonoid(gr);
 [ Transformation( [ 2, 1 ] ), IdentityTransformation, 
   Transformation( [ 3, 3, 3 ] ) ]
 
-#T# DigraphColouring and DigraphColouring: checking errors and robustness
+#  DigraphColouring and DigraphColouring: checking errors and robustness
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> DigraphColouring(gr, 1);
@@ -300,7 +300,7 @@ IdentityTransformation
 gap> DigraphColouring(CompleteDigraph(1), 0);
 fail
 
-#T# DigraphColouring
+#  DigraphColouring
 gap> DigraphColouring(EmptyDigraph(0));
 IdentityTransformation
 gap> DigraphColouring(Digraph([[]]));
@@ -344,7 +344,7 @@ gap> DigraphColoring(gr);;
 gap> DigraphColoring(EmptyDigraph(0));
 IdentityTransformation
 
-#T# HomomorphismDigraphsFinder 1
+#  HomomorphismDigraphsFinder 1
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);;
 gap> gr := DigraphSymmetricClosure(gr);;
 gap> x := [];;
@@ -602,7 +602,7 @@ gap> Length(x);
 gap> x{[1 .. 100]} = x{[101 .. 200]};
 true
 
-#T# HomomorphismDigraphsFinder 1
+#  HomomorphismDigraphsFinder 1
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);
 <digraph with 6 vertices, 3 edges>
 gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, false,
@@ -649,7 +649,7 @@ gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, false,
 gap> Length(last);
 39
 
-#T# HomomorphismDigraphsFinder 2
+#  HomomorphismDigraphsFinder 2
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);
 <digraph with 6 vertices, 3 edges>
 gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, false,
@@ -696,7 +696,7 @@ gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, false,
 gap> Length(last);
 47
 
-#T# HomomorphismDigraphsFinder 3
+#  HomomorphismDigraphsFinder 3
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);
 <digraph with 6 vertices, 3 edges>
 gap> gr := DigraphSymmetricClosure(gr);
@@ -787,7 +787,7 @@ gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, false,
 gap> Length(last);
 100
 
-#T# HomomorphismDigraphsFinder: finding monomorphisms
+#  HomomorphismDigraphsFinder: finding monomorphisms
 gap> gr1 := Digraph([[], [1]]);;
 gap> gr1 := DigraphSymmetricClosure(gr1);;
 gap> gr2 := Digraph([[], [1], [1, 3]]);;
@@ -797,7 +797,7 @@ gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], infinity, fail, true,
 [ IdentityTransformation, Transformation( [ 1, 3, 3 ] ), 
   Transformation( [ 2, 1 ] ), Transformation( [ 3, 1, 3 ] ) ]
 
-#T# DigraphHomomorphism
+#  DigraphHomomorphism
 gap> gr1 := Digraph([[], [3], []]);;
 gap> gr2 := EmptyDigraph(10);;
 gap> DigraphHomomorphism(gr1, gr2);
@@ -806,7 +806,7 @@ gap> gr2 := Digraph([[], [], [], [], [4], []]);;
 gap> DigraphHomomorphism(gr1, gr2);
 Transformation( [ 1, 5, 4, 4, 5 ] )
 
-#T# HomomorphismsDigraphs and HomomorphismsDigraphsRepresentatives
+#  HomomorphismsDigraphs and HomomorphismsDigraphsRepresentatives
 gap> gr1 := Digraph([[], [3], []]);;
 gap> gr2 := Digraph([[], [], [], [], [4], []]);;
 gap> HomomorphismsDigraphsRepresentatives(gr1, gr2);
@@ -833,7 +833,7 @@ gap> mat := AdjacencyMatrix(gr2);;
 gap> ForAll(homos, t -> ForAll(edges, e -> mat[e[1] ^ t][e[2] ^ t] = 1));
 true
 
-#T# DigraphMonomorphism
+#  DigraphMonomorphism
 gap> gr1 := EmptyDigraph(1);;
 gap> DigraphMonomorphism(gr1, gr1);
 IdentityTransformation
@@ -845,7 +845,7 @@ IdentityTransformation
 gap> DigraphMonomorphism(CompleteDigraph(2), Digraph([[2], [1, 3], [2]]));
 IdentityTransformation
 
-#T# MonomorphismsDigraphs and MonomorphismsDigraphsRepresentatives
+#  MonomorphismsDigraphs and MonomorphismsDigraphsRepresentatives
 gap> gr1 := ChainDigraph(2);;
 gap> MonomorphismsDigraphs(gr1, EmptyDigraph(1));
 [  ]
@@ -861,7 +861,7 @@ true
 gap> monos = HomomorphismsDigraphsRepresentatives(gr1, gr2);
 true
 
-#T# DigraphEpimorphism
+#  DigraphEpimorphism
 gap> gr1 := CycleDigraph(6);;
 gap> gr2 := CycleDigraph(3);;
 gap> DigraphEpimorphism(gr1, gr2);
@@ -869,7 +869,7 @@ Transformation( [ 1, 2, 3, 1, 2, 3 ] )
 gap> DigraphEpimorphism(gr2, gr1);
 fail
 
-#T# EpimorphismsDigraphs and EpimorphismsDigraphsRepresentatives
+#  EpimorphismsDigraphs and EpimorphismsDigraphsRepresentatives
 gap> gr1 := CompleteDigraph(2);;
 gap> gr2 := CompleteDigraph(3);;
 gap> EpimorphismsDigraphs(gr1, gr2);
@@ -886,7 +886,7 @@ gap> Length(epis);
 gap> ForAll(epis, x -> RankOfTransformation(x, DigraphNrVertices(gr1)) = 3);
 true
 
-#T# DigraphEmbedding
+#  DigraphEmbedding
 gap> gr1 := CycleDigraph(3);;
 gap> gr2 := CompleteBipartiteDigraph(4, 3);;
 gap> DigraphEmbedding(gr1, gr2);
@@ -1098,7 +1098,7 @@ false
 gap> IsDigraphColouring(D, IdentityTransformation);
 true
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);
 gap> Unbind(epis);
 gap> Unbind(gens);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# DigraphFromGraph6String and Graph6String
+#  DigraphFromGraph6String and Graph6String
 gap> DigraphFromGraph6String("?");
 <digraph with 0 vertices, 0 edges>
 gap> DigraphFromGraph6String("E?A?");
@@ -80,7 +80,7 @@ gap> ReadDigraphs(badfilename, 3);
 Error, Digraphs: DigraphFile:
 cannot open file path/to/some/madeupfile.g6.gz,
 
-#T# DigraphFromSparse6String and Sparse6String
+#  DigraphFromSparse6String and Sparse6String
 gap> DigraphFromSparse6String(":@");
 <digraph with 1 vertex, 0 edges>
 gap> DigraphFromSparse6String(Concatenation(":[___dCfEcdFjCIideLhIfJ",
@@ -114,7 +114,7 @@ gap> str := Sparse6String(gr);
 gap> DigraphFromSparse6String(str);
 <digraph with 131072 vertices, 6 edges>
 
-#T# DigraphFromDigraph6String and Digraph6String
+#  DigraphFromDigraph6String and Digraph6String
 gap> gr := Digraph([[5], [1, 2, 5], [1], [2], [4]]);
 <digraph with 5 vertices, 7 edges>
 gap> str := Digraph6String(gr);
@@ -127,7 +127,7 @@ gap> str := Digraph6String(gr);;
 gap> DigraphFromDigraph6String(str);
 <digraph with 231 vertices, 100 edges>
 
-#T# DigraphFromDiSparse6String and DiSparse6String
+#  DigraphFromDiSparse6String and DiSparse6String
 gap> gr := Digraph([[1, 4], [2, 3, 4], [2, 4], [2]]);
 <digraph with 4 vertices, 8 edges>
 gap> str := DiSparse6String(gr);
@@ -159,7 +159,7 @@ gap> str := DiSparse6String(gr);;
 gap> gr = DigraphFromDiSparse6String(str);
 true
 
-#T# WriteDigraphs and ReadDigraphs
+#  WriteDigraphs and ReadDigraphs
 gap> gr := [];;
 gap> gr[1] := Digraph(2 ^ 16, [1, 1, 3, 4, 7, 10, 100],
 > [3, 4, 1, 1, 3, 100, 10]);
@@ -267,7 +267,7 @@ gap> rdgr := ReadDigraphs(filename);
 Error, Digraphs: DigraphFile:
 cannot determine the file format,
 
-#T# DigraphFile
+#  DigraphFile
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/helloworld.g6");;
 gap> f := DigraphFile(filename, "w");;
 gap> WriteDigraphs(f, List([1 .. 5], CompleteDigraph));
@@ -359,7 +359,7 @@ the mode of the file must be "r",
 gap> IO_Close(f);
 true
 
-#T# WritePlainTextDigraph and ReadPlainTextDigraph
+#  WritePlainTextDigraph and ReadPlainTextDigraph
 gap> gr := Digraph([[1, 2], [2, 3], []]);
 <digraph with 3 vertices, 4 edges>
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/plain.txt");;
@@ -385,7 +385,7 @@ gap> ReadPlainTextDigraph(filename, ',', 1, 'i');
 Error, Digraphs: ReadPlainTextDigraph:
 cannot open file <name>,
 
-#T# TournamentLineDecoder
+#  TournamentLineDecoder
 gap> gr := TournamentLineDecoder("101001");
 <digraph with 4 vertices, 6 edges>
 gap> OutNeighbours(gr);
@@ -393,7 +393,7 @@ gap> OutNeighbours(gr);
 gap> gr := TournamentLineDecoder("");
 <digraph with 1 vertex, 0 edges>
 
-#T# AdjacencyMatrixUpperTriangleLineDecoder
+#  AdjacencyMatrixUpperTriangleLineDecoder
 gap> gr := AdjacencyMatrixUpperTriangleLineDecoder("100101");
 <digraph with 4 vertices, 3 edges>
 gap> OutNeighbours(gr);
@@ -405,7 +405,7 @@ gap> OutNeighbours(gr);
 gap> gr := AdjacencyMatrixUpperTriangleLineDecoder("");
 <digraph with 1 vertex, 0 edges>
 
-#T# TCodeDecoder
+#  TCodeDecoder
 gap> gr := TCodeDecoder("3 2 0 2 2 1");
 <digraph with 3 vertices, 2 edges>
 gap> OutNeighbours(gr);
@@ -436,7 +436,7 @@ where e is the number of edges (the 2nd entry in <str>),
 gap> gr := TCodeDecoderNC("100 5 0 12 48 49 99 1 54 49 49 49");
 <digraph with 100 vertices, 5 edges>
 
-#T# Empty strings should not create graphs
+#  Empty strings should not create graphs
 gap> DigraphFromGraph6String("");
 Error, Digraphs: DigraphFromGraph6String: usage,
 the input string <s> should be non-empty,
@@ -450,7 +450,7 @@ gap> DigraphFromDiSparse6String("");
 Error, Digraphs: DigraphFromDiSparse6String: usage,
 the input string <s> should be non-empty,
 
-#T# DiSparse6 
+#  DiSparse6 
 gap> DigraphFromDiSparse6String("I'm a string");
 Error, Digraphs: DigraphFromDiSparse6String: usage,
 the input string <s> is not in valid disparse6 format,
@@ -470,7 +470,7 @@ gap> gr := Digraph([[], [], [1, 2]]);;
 gap> DiSparse6String(gr);
 ".BoN"
 
-#T# Plain text encoding  
+#  Plain text encoding  
 gap> gr := CompleteDigraph(3);
 <digraph with 3 vertices, 6 edges>
 gap> str := PlainTextString(gr);
@@ -480,7 +480,7 @@ gap> gr2 := DigraphFromPlainTextString(str);
 gap> gr = gr2;
 true
 
-#T# Invalid sizes
+#  Invalid sizes
 gap> DigraphFromGraph6String("~llk");
 Error, Digraphs: DigraphFromGraph6String: usage,
 the input string <s> is not in valid graph6 format,
@@ -497,7 +497,7 @@ gap> DigraphFromDiSparse6String(".~~l");
 Error, Digraphs: DigraphFromDiSparse6String: usage,
 the input string <s> is not in valid disparse6 format,
 
-#T# Special format characters
+#  Special format characters
 gap> DigraphFromDigraph6String("x");
 Error, Digraphs: DigraphFromDigraph6String: usage,
 the input string <s> is not in valid digraph6 format,
@@ -508,7 +508,7 @@ gap> DigraphFromDiSparse6String("z");
 Error, Digraphs: DigraphFromDiSparse6String: usage,
 the input string <s> is not in valid disparse6 format,
 
-#T# Special format characters
+#  Special format characters
 gap> Sparse6String(ChainDigraph(3));
 Error, Digraphs: Sparse6String: usage,
 the argument <graph> must be a symmetric digraph,
@@ -518,18 +518,18 @@ gap> gr := Digraph([[1], []]);;
 gap> Sparse6String(gr);
 ":AF"
 
-#T# DigraphFromSparse6String: an unusual but valid case
+#  DigraphFromSparse6String: an unusual but valid case
 gap> DigraphFromSparse6String(":TdBkJ`Kq?x");
 <digraph with 21 vertices, 10 edges>
 gap> Sparse6String(last);
 ":TdBkJ`Kq?"
 
-#T# DigraphPlainTextLineDecoder: bad input
+#  DigraphPlainTextLineDecoder: bad input
 gap> DigraphPlainTextLineDecoder(" ", "  ", 1, ".");
 Error, Digraphs: DigraphPlainTextLineDecoder: usage,
 DigraphPlainTextLineDecoder(delimiter, [,delimiter], offset),
 
-#T# WriteDigraphs: bad input
+#  WriteDigraphs: bad input
 gap> list := [CompleteDigraph(4), CycleDigraph(8), "hello world"];;
 gap> WriteDigraphs(72, list, "w");
 Error, Digraphs: WriteDigraphs: usage,
@@ -570,7 +570,7 @@ the mode of the argument <file> must be "w" or "a",
 gap> IO_Close(f);
 true
 
-#T# WriteDigraphs: automatic format selection
+#  WriteDigraphs: automatic format selection
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/choose.gz");;
 gap> list := [CompleteDigraph(5), EmptyDigraph(100), CompleteDigraph(3)];;
 gap> ForAll(list, IsSymmetricDigraph);
@@ -631,7 +631,7 @@ gap> WriteDigraphs(filename, gr, "w");
 Error, Digraphs: DigraphFile:
 cannot open file does/not/exist.d6.gz,
 
-#T# DigraphPlainTextLineDecoder: bad input
+#  DigraphPlainTextLineDecoder: bad input
 gap> Graph6String(ChainDigraph(4));
 Error, Digraphs: Graph6String: usage,
 <graph> must be symmetric and have no loops or multiple edges,
@@ -652,7 +652,7 @@ gap> Sparse6String(EmptyDigraph(2 ^ 20));
 gap> DigraphFromSparse6String(":~~??C???");
 <digraph with 1048576 vertices, 0 edges>
 
-#T# WriteDIMACSFile
+#  WriteDIMACSFile
 # Error testing
 gap> gr := EmptyDigraph(0);;
 gap> filename := "does/not/exist.gz";;
@@ -705,7 +705,7 @@ gap> SetDigraphVertexLabels(gr, Elements(CyclicGroup(3)));
 gap> WriteDIMACSDigraph(filename, gr);
 IO_OK
 
-#T# ReadDIMACSDigraph
+#  ReadDIMACSDigraph
 gap> ReadDIMACSDigraph("does/not/exist.gz");
 Error, Digraphs: ReadDIMACSDigraph:
 cannot open the file <name>,
@@ -885,7 +885,7 @@ true
 gap> DigraphVertexLabels(gr);
 [ 1 .. 3 ]
 
-#T# Test DIGRAPHS_ChooseFileDecoder
+#  Test DIGRAPHS_ChooseFileDecoder
 gap> DIGRAPHS_ChooseFileDecoder(1);
 Error, Digraphs: DIGRAPHS_ChooseFileDecoder: usage,
 the argument must be a string,
@@ -893,7 +893,7 @@ gap> DIGRAPHS_ChooseFileEncoder(1);
 Error, Digraphs: DIGRAPHS_ChooseFileEncoder: usage,
 the argument must be a string,
 
-#T# IO_Pickle
+#  IO_Pickle
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/good.dimacs");;
 gap> file := IO_File(filename, "r");;
 gap> gr := CompleteDigraph(2);
@@ -911,7 +911,7 @@ IO_Error
 gap> IO_Close(file);
 true
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(badfilename);
 gap> Unbind(f);
 gap> Unbind(read);

--- a/tst/standard/isomorph.tst
+++ b/tst/standard/isomorph.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# AutomorphismGroup: for a digraph without multiple edges
+#  AutomorphismGroup: for a digraph without multiple edges
 
 # Complete digraph on n vertices should have automorphism group S_n
 gap> n := 5;;
@@ -84,7 +84,7 @@ gap> not DIGRAPHS_NautyAvailable or
 > NautyAutomorphismGroup(gr) = SymmetricGroup([1, 3, 4]);
 true
 
-#T# AutomorphismGroup: for a digraph with multiple edges
+#  AutomorphismGroup: for a digraph with multiple edges
 
 # An edge union of complete digraphs
 gap> gr := DigraphEdgeUnion(CompleteDigraph(4), CompleteDigraph(4));
@@ -124,7 +124,7 @@ gap> BlissCanonicalLabelling(gr)
 > = BlissCanonicalLabelling(DigraphCopy(gr));
 true
 
-#T# IsIsomorphicDigraph: for digraphs without multiple edges
+#  IsIsomorphicDigraph: for digraphs without multiple edges
 
 # A small example
 gap> gr := Digraph([[2], [], [2], [2]]);
@@ -191,7 +191,7 @@ false
 gap> IsIsomorphicDigraph(gr, gr2);
 false
 
-#T# IsIsomorphicDigraph: for digraphs with multiple edges
+#  IsIsomorphicDigraph: for digraphs with multiple edges
 
 # Different number of vertices
 gap> gr1 := Digraph([[1, 2, 3, 2], [1, 3], [3]]);
@@ -233,7 +233,7 @@ gap> gr2 := OnDigraphs(gr, (3, 9));;
 gap> IsIsomorphicDigraph(gr, gr2);
 true
 
-#T# IsIsomorphicDigraph: for digraphs with colourings and without multiple edges
+#  IsIsomorphicDigraph: for digraphs with colourings and without multiple edges
 gap> gr1 := Digraph([[2, 2], [1]]);
 <multidigraph with 2 vertices, 3 edges>
 gap> gr2 := CompleteDigraph(2);
@@ -282,7 +282,7 @@ false
 gap> IsIsomorphicDigraph(gr1, gr1, [1, 1, 2, 2], [1, 1, 1, 2]);
 false
 
-#T# IsIsomorphicDigraph: for multidigraphs with colourings
+#  IsIsomorphicDigraph: for multidigraphs with colourings
 gap> gr1 := Digraph([[2, 1, 2], []]);;
 gap> gr2 := Digraph([[], [2, 1, 1]]);;
 gap> IsIsomorphicDigraph(gr1, gr1, [1, 1], [1, 1]);
@@ -294,7 +294,7 @@ true
 gap> IsIsomorphicDigraph(gr1, gr2, [1, 2], [1, 2]);
 false
 
-#T# IsomorphismDigraphs: for digraphs without multiple edges
+#  IsomorphismDigraphs: for digraphs without multiple edges
 
 # Non-isomorphic graphs
 gap> gr1 := EmptyDigraph(3);
@@ -354,7 +354,7 @@ gap> not DIGRAPHS_NautyAvailable or not HasNautyCanonicalLabelling(gr2);
 true
 gap> IsomorphismDigraphs(gr1, gr2);;
 
-#T# IsomorphismDigraphs: for digraphs with multiple edges
+#  IsomorphismDigraphs: for digraphs with multiple edges
 
 # An example used in previous tests
 gap> gr := Digraph([
@@ -396,7 +396,7 @@ true
 gap> iso[1] = p;
 true
 
-#T# IsomorphismDigraphs: for digraphs with colourings and without multiple edges
+#  IsomorphismDigraphs: for digraphs with colourings and without multiple edges
 gap> gr1 := Digraph([[2, 2], [1]]);
 <multidigraph with 2 vertices, 3 edges>
 gap> gr2 := CompleteDigraph(2);
@@ -443,7 +443,7 @@ gap> gr1 := CompleteDigraph(3);;
 gap> IsomorphismDigraphs(gr1, gr1, [1, 2, 2], [[1, 3], [2]]);
 fail
 
-#T# IsomorphismDigraphs: for multidigraphs with colourings
+#  IsomorphismDigraphs: for multidigraphs with colourings
 gap> gr1 := Digraph([[2, 1, 2], []]);;
 gap> gr2 := Digraph([[], [2, 1, 1]]);;
 gap> IsomorphismDigraphs(gr1, gr1, [1, 1], [1, 1]);
@@ -457,7 +457,7 @@ fail
 gap> IsomorphismDigraphs(gr1, gr2, [1, 1], [1, 1]);
 [ (1,2), (1,2) ]
 
-#T# CanonicalLabelling: for a digraph without multiple edges
+#  CanonicalLabelling: for a digraph without multiple edges
 
 # A small example: check that all isomorphic copies have same canonical image
 gap> gr := Digraph([[2], [3, 5, 6], [3], [4, 6], [1, 4], [4]]);
@@ -497,7 +497,7 @@ gap> if canon <> fail then
 >   od;
 > fi;
 
-#T# CanonicalLabelling: for a digraph with multiple edges
+#  CanonicalLabelling: for a digraph with multiple edges
 
 # A small example: check that all isomorphic copies have same canonical image
 gap> gr := Digraph([[2, 2], [1, 1], [2]]);
@@ -525,7 +525,7 @@ false
 gap> NautyCanonicalLabelling(gr);
 fail
 
-#T# CanonicalLabelling: with colours
+#  CanonicalLabelling: with colours
 gap> G := Digraph(10, [1, 1, 3, 4, 4, 5, 8, 8], [6, 3, 3, 9, 10, 9, 4, 10]);;
 gap> BlissCanonicalLabelling(G, [[1 .. 5], [6 .. 10]]);
 (1,4,3,5)(6,8)(7,9,10)
@@ -540,7 +540,7 @@ gap> not DIGRAPHS_NautyAvailable or
 > = (1, 5, 3, 4)(6, 8, 10)(7, 9);
 true
 
-#T# AutomorphismGroup: for a digraph with colored vertices
+#  AutomorphismGroup: for a digraph with colored vertices
 gap> gr := CompleteBipartiteDigraph(4, 4);
 <digraph with 8 vertices, 32 edges>
 gap> AutomorphismGroup(gr) = Group([
@@ -551,7 +551,7 @@ Group([ (7,8), (6,7), (5,6), (3,4), (2,3), (1,2) ])
 gap> AutomorphismGroup(gr, [1 .. 8]);
 Group(())
 
-#T# AutomorphismGroup: for a digraph with incorrect colors
+#  AutomorphismGroup: for a digraph with incorrect colors
 gap> gr := CompleteBipartiteDigraph(4, 4);
 <digraph with 8 vertices, 32 edges>
 gap> AutomorphismGroup(gr, [[1 .. 4], [5 .. 9]]);
@@ -583,7 +583,7 @@ The list <partition> must have one of the following forms:
 In the first form, <partition[i]> is the colour of vertex i; in the second
 form, <partition[i]> is the list of vertices with colour i,
 
-#T# AutomorphismGroup: for a multidigraph
+#  AutomorphismGroup: for a multidigraph
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> AutomorphismGroup(gr, [1, 2]);
@@ -593,7 +593,7 @@ fail
 gap> NautyAutomorphismGroup(gr, [1, 2]);
 fail
 
-#T# CanonicalLabelling: for a digraph with colored vertices
+#  CanonicalLabelling: for a digraph with colored vertices
 gap> gr := CompleteBipartiteDigraph(4, 4);
 <digraph with 8 vertices, 32 edges>
 gap> BlissCanonicalLabelling(gr);
@@ -612,7 +612,7 @@ gap> not DIGRAPHS_NautyAvailable
 > or NautyCanonicalLabelling(gr, [[1 .. 4], [5 .. 8]]) = ();
 true
 
-#T# CanonicalLabelling: for a digraph with incorrect colors
+#  CanonicalLabelling: for a digraph with incorrect colors
 gap> gr := CompleteBipartiteDigraph(4, 4);
 <digraph with 8 vertices, 32 edges>
 gap> BlissCanonicalLabelling(gr, [[1 .. 4], [5 .. 9]]);
@@ -644,7 +644,7 @@ The list <partition> must have one of the following forms:
 In the first form, <partition[i]> is the colour of vertex i; in the second
 form, <partition[i]> is the list of vertices with colour i,
 
-#T# CanonicalLabelling: for a multidigraph
+#  CanonicalLabelling: for a multidigraph
 gap> gr := Digraph([[2, 2], []]);
 <multidigraph with 2 vertices, 2 edges>
 gap> BlissCanonicalLabelling(gr, [1, 2]);
@@ -652,7 +652,7 @@ gap> BlissCanonicalLabelling(gr, [1, 2]);
 gap> NautyCanonicalLabelling(gr, [1, 2]);
 fail
 
-#T# DIGRAPHS_ValidateVertexColouring, 1, errors
+#  DIGRAPHS_ValidateVertexColouring, 1, errors
 gap> DIGRAPHS_ValidateVertexColouring();
 Error, Function: number of arguments must be 3 (not 0)
 gap> DIGRAPHS_ValidateVertexColouring(fail);
@@ -670,7 +670,7 @@ gap> DIGRAPHS_ValidateVertexColouring(0, [], fail);
 Error, Digraphs: DIGRAPHS_ValidateVertexColouring: usage,
 the third argument <method> must be a string,
 
-#T# DIGRAPHS_ValidateVertexColouring, 2
+#  DIGRAPHS_ValidateVertexColouring, 2
 gap> DIGRAPHS_ValidateVertexColouring(0, [], "TestFunction");
 [  ]
 gap> DIGRAPHS_ValidateVertexColouring(0, [2], "TestFunction");
@@ -744,7 +744,7 @@ use precisely the colours [1 .. m], for some positive integer m <= 4,
 gap> DIGRAPHS_ValidateVertexColouring(4, [1, 1, 3, 2], "TestFunction");
 [ 1, 1, 3, 2 ]
 
-#T# CanonicalDigraph
+#  CanonicalDigraph
 gap> gr1 := Digraph([[1, 2], [1, 2], [2, 3], [1, 2, 3], [5]]);;
 gap> gr2 := Digraph([[1, 3], [2, 3], [2, 3], [1, 2, 3], [5]]);;
 gap> BlissCanonicalDigraph(gr1) = BlissCanonicalDigraph(gr2);
@@ -776,7 +776,7 @@ true
 gap> gr5 = BlissCanonicalDigraph(gr6);
 true
 
-#T# CanonicalDigraph
+#  CanonicalDigraph
 gap> gr1 := Digraph([[1, 2], [1, 2], [2, 3], [1, 2, 3], [5]]);;
 gap> gr2 := Digraph([[1, 3], [2, 3], [2, 3], [1, 2, 3], [5]]);;
 gap> NautyCanonicalDigraph(gr1) = NautyCanonicalDigraph(gr2);
@@ -866,7 +866,7 @@ gap> IsDigraphAutomorphism(Digraph([[1, 1], [1, 1, 2], [1, 2, 2, 3]]),
 Error, Digraphs: IsDigraphIsomorphism: usage,
 the first 2 arguments must not have multiple edges,
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(canon);
 gap> Unbind(gr);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -14,7 +14,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# DigraphReverse
+#  DigraphReverse
 gap> gr := DigraphFromDigraph6String("+D[NGc_");
 <digraph with 5 vertices, 11 edges>
 gap> rgr := DigraphReverse(gr);
@@ -49,7 +49,7 @@ gap> SetIsSymmetricDigraph(gr, true);
 gap> gr = DigraphReverse(gr);
 true
 
-#T# DigraphRemoveLoops
+#  DigraphRemoveLoops
 gap> gr := DigraphFromDigraph6String("+EhxPC?@");
 <digraph with 6 vertices, 11 edges>
 gap> DigraphRemoveLoops(gr);
@@ -67,7 +67,7 @@ true
 gap> DigraphHasLoops(gr1);
 false
 
-#T# DigraphRemoveEdges: for an index
+#  DigraphRemoveEdges: for an index
 gap> gr := RandomDigraph(10);;
 gap> DigraphRemoveEdges(gr, [Group(())]);
 Error, Digraphs: DigraphRemoveEdges: usage,
@@ -90,7 +90,7 @@ gap> DigraphRemoveEdges(gr1, []);
 gap> last = gr1;
 true
 
-#T# DigraphRemoveEdges: for a list of edges
+#  DigraphRemoveEdges: for a list of edges
 gap> gr := Digraph([[2], []]);
 <digraph with 2 vertices, 1 edge>
 gap> DigraphRemoveEdges(gr, [[2, 1]]);
@@ -116,7 +116,7 @@ Error, Digraphs: DigraphRemoveEdges: usage,
 the first argument <digraph> must not have multiple edges
 when the second argument <edges> is a list of edges,
 
-#T# DigraphRemoveEdge: for an index
+#  DigraphRemoveEdge: for an index
 gap> gr := Digraph([[2, 3], [1], [3]]);
 <digraph with 3 vertices, 4 edges>
 gap> DigraphRemoveEdge(gr, 0);
@@ -130,7 +130,7 @@ gap> gr := DigraphRemoveEdge(gr, 3);
 gap> DigraphEdges(gr);
 [ [ 1, 2 ], [ 1, 3 ], [ 3, 3 ] ]
 
-#T# DigraphRemoveEdge: for an edge
+#  DigraphRemoveEdge: for an edge
 gap> gr := Digraph([[1, 1]]);
 <multidigraph with 1 vertex, 2 edges>
 gap> DigraphRemoveEdge(gr, [1, 1]);
@@ -159,7 +159,7 @@ gap> gr := DigraphRemoveEdge(gr, [2, 1]);
 gap> DigraphEdges(gr);
 [ [ 1, 2 ] ]
 
-#T# OnDigraphs: for a digraph and a perm
+#  OnDigraphs: for a digraph and a perm
 gap> gr := Digraph([[2], [1], [3]]);
 <digraph with 3 vertices, 3 edges>
 gap> DigraphEdges(gr);
@@ -210,7 +210,7 @@ gap> DigraphEdges(last);
 [ [ 1, 4 ], [ 1, 2 ], [ 2, 2 ], [ 3, 4 ], [ 3, 1 ], [ 3, 1 ], [ 4, 3 ], 
   [ 4, 2 ] ]
 
-#T# OnDigraphs: for a digraph and a transformation
+#  OnDigraphs: for a digraph and a transformation
 gap> gr := Digraph([[2], [1, 3], []]);
 <digraph with 3 vertices, 3 edges>
 gap> OutNeighbours(gr);
@@ -226,7 +226,7 @@ gap> gr := OnDigraphs(gr, t);
 gap> OutNeighbours(gr);
 [ [ 2 ], [ 1, 1 ], [  ] ]
 
-#T# OnMultiDigraphs: for a pair of permutations
+#  OnMultiDigraphs: for a pair of permutations
 gap> gr1 := CompleteDigraph(3);
 <digraph with 3 vertices, 6 edges>
 gap> DigraphEdges(gr1);
@@ -240,7 +240,7 @@ gap> OnMultiDigraphs(gr1, [(1, 3), (1, 7)]);
 Error, Digraphs: OnMultiDigraphs: usage,
 the argument <perms[2]> must permute the edges of the 1st argument <graph>,
 
-#T# InNeighboursOfVertex and InDegreeOfVertex
+#  InNeighboursOfVertex and InDegreeOfVertex
 gap> gr := DigraphFromDiSparse6String(".IgBGLQ?Apkc");
 <multidigraph with 10 vertices, 6 edges>
 gap> InNeighborsOfVertex(gr, 7);
@@ -272,7 +272,7 @@ gap> InDegrees(gr);
 gap> InDegreeOfVertex(gr, 2);
 3
 
-#T# OutNeighboursOfVertex and OutDegreeOfVertex
+#  OutNeighboursOfVertex and OutDegreeOfVertex
 gap> gr := DigraphFromDiSparse6String(".Ig??OaDgDQ~");
 <multidigraph with 10 vertices, 8 edges>
 gap> OutNeighborsOfVertex(gr, 2);
@@ -302,7 +302,7 @@ gap> OutDegrees(gr);
 gap> OutDegreeOfVertex(gr, 1);
 4
 
-#T# InducedSubdigraph
+#  InducedSubdigraph
 gap> r := rec(nrvertices := 8,
 > source := [1, 1, 1, 1, 1, 1, 2, 2, 2, 3, 3, 5, 5, 5, 5, 5, 5],
 > range  := [1, 1, 2, 3, 3, 4, 1, 1, 3, 4, 5, 1, 3, 4, 4, 5, 7]);;
@@ -373,7 +373,7 @@ gap> DigraphVertexLabels(gri);
 gap> OutNeighbours(gri);
 [ [ 3, 3 ], [ 1, 3 ], [  ] ]
 
-#T# QuotientDigraph
+#  QuotientDigraph
 gap> gr := CompleteDigraph(2);
 <digraph with 2 vertices, 2 edges>
 gap> DigraphEdges(gr);
@@ -441,7 +441,7 @@ gap> qr := QuotientDigraph(gr, [[1], [2, 3, 5, 7], [4, 6, 8]]);
 gap> OutNeighbours(qr);
 [ [ 3, 2 ], [ 1, 3, 2, 1, 2, 3, 3, 2, 1, 3, 2, 3, 2 ], [ 1, 3, 3, 2, 2, 3 ] ]
 
-#T# DigraphInEdges and DigraphOutEdges: for a vertex
+#  DigraphInEdges and DigraphOutEdges: for a vertex
 gap> gr := Digraph([[2, 2, 2, 2, 2], [1, 1, 1, 1], [1], [3, 2]]);
 <multidigraph with 4 vertices, 12 edges>
 gap> DigraphInEdges(gr, 1);
@@ -464,7 +464,7 @@ gap> DigraphInEdges(gr, 2);
 gap> DigraphOutEdges(gr, 1);
 [ [ 1, 2 ], [ 1, 2 ] ]
 
-#T# DigraphStronglyConnectedComponent
+#  DigraphStronglyConnectedComponent
 gap> gr := Digraph([[2, 4], [], [2, 6], [1, 3], [2, 3], [5]]);
 <digraph with 6 vertices, 9 edges>
 gap> DigraphStronglyConnectedComponent(gr, 1);
@@ -477,7 +477,7 @@ gap> DigraphStronglyConnectedComponent(gr, 7);
 Error, Digraphs: DigraphStronglyConnectedComponent: usage,
 7 is not a vertex of the digraph,
 
-#T# DigraphyConnectedComponent
+#  DigraphyConnectedComponent
 gap> gr := Digraph([[2, 4], [], [2, 6], [1, 3], [2, 3], [5]]);
 <digraph with 6 vertices, 9 edges>
 gap> DigraphConnectedComponent(gr, 3);
@@ -486,7 +486,7 @@ gap> DigraphConnectedComponent(gr, 7);
 Error, Digraphs: DigraphConnectedComponent: usage,
 7 is not a vertex of the digraph,
 
-#T# IsDigraphEdge
+#  IsDigraphEdge
 
 # CycleDigraph with source/range
 gap> gr := CycleDigraph(1000);
@@ -577,7 +577,7 @@ true
 gap> IsDigraphEdge(gr, 26, 13);
 false
 
-#T# DigraphAddEdges
+#  DigraphAddEdges
 gap> gr := RandomDigraph(100);;
 gap> DigraphAddEdges(gr, []);;
 gap> gr = last;
@@ -669,7 +669,7 @@ gap> DigraphEdges(last);
 gap> DigraphEdges(gr);
 [ [ 1, 1 ], [ 1, 2 ], [ 3, 1 ] ]
 
-#T# DigraphAddEdge
+#  DigraphAddEdge
 gap> gr := RandomDigraph(10);;
 gap> DigraphAddEdge(gr, [1, 2, 3]);
 Error, Digraphs: DigraphAddEdge: usage,
@@ -693,7 +693,7 @@ gap> DigraphAddEdge(gr, [1, 2]);
 gap> DigraphEdges(last);
 [ [ 1, 2 ] ]
 
-#T# DigraphAddVertices
+#  DigraphAddVertices
 gap> gr := Digraph([[1]]);;
 gap> gr2 := DigraphAddVertices(gr, 3);
 <digraph with 4 vertices, 1 edge>
@@ -760,7 +760,7 @@ false
 gap> gr2 = gr3;
 true
 
-#T# DigraphAddVertex
+#  DigraphAddVertex
 gap> gr := CompleteDigraph(1);
 <digraph with 1 vertex, 0 edges>
 gap> DigraphVertices(gr);
@@ -792,7 +792,7 @@ gap> DigraphVertexLabels(gr);
 gap> DigraphVertexLabels(gr2);
 [ 1, Sym( [ 1 .. 2 ] ) ]
 
-#T# DigraphRemoveVertex
+#  DigraphRemoveVertex
 gap> gr := DigraphFromDigraph6String("+MW?Gp?GWe?gS?[L?A?f|C@KOCa_gk?F?r_");
 <digraph with 14 vertices, 54 edges>
 gap> DigraphRemoveVertex(gr, "a");
@@ -811,7 +811,7 @@ gap> DigraphNrEdges(gr2) =
 > DigraphNrEdges(gr) - OutDegreeOfVertex(gr, 10) - InDegreeOfVertex(gr, 10);
 true
 
-#T# DigraphRemoveVertices
+#  DigraphRemoveVertices
 gap> gr := CompleteDigraph(4);
 <digraph with 4 vertices, 12 edges>
 gap> gr2 := DigraphRemoveVertices(gr, []);
@@ -871,7 +871,7 @@ gap> DigraphSinks(gr);
 gap> DigraphRemoveVertices(gr, DigraphSinks(gr));
 <digraph with 8 vertices, 10 edges>
 
-#T# AsBinaryRelation
+#  AsBinaryRelation
 gap> gr := EmptyDigraph(0);
 <digraph with 0 vertices, 0 edges>
 gap> AsBinaryRelation(gr);
@@ -938,7 +938,7 @@ true
 gap> HasIsAntisymmetricBinaryRelation(rel3);
 true
 
-#T# DigraphReverseEdge and DigraphReverseEdges
+#  DigraphReverseEdge and DigraphReverseEdges
 gap> gr := Digraph([[1, 1]]);
 <multidigraph with 1 vertex, 2 edges>
 gap> DigraphReverseEdges(gr, [[2, 2]]);
@@ -992,7 +992,7 @@ true
 gap> gr = DigraphReverseEdges(gr, []);
 true
 
-#T# DigraphFloydWarshall
+#  DigraphFloydWarshall
 gap> func := function(mat, i, j, k)
 >   if (i = j) or (mat[i][k] <> 0 and mat[k][j] <> 0) then
 >     mat[i][j] := 1;
@@ -1053,7 +1053,7 @@ gap> grt := DigraphByAdjacencyMatrix(tclosure);
 gap> grt = DigraphTransitiveClosure(gr);
 true
 
-#T# DigraphDisjointUnion
+#  DigraphDisjointUnion
 gap> gr := CycleDigraph(1000);
 <digraph with 1000 vertices, 1000 edges>
 gap> gr2 := CompleteDigraph(100);
@@ -1103,7 +1103,7 @@ gap> gr := DigraphAddEdges(gr, [[2, 3], [5, 6], [9, 10]]);
 gap> gr = ChainDigraph(14);
 true
 
-#T# DigraphEdgeUnion
+#  DigraphEdgeUnion
 gap> gr1 := DigraphFromDigraph6String("+I????O?GO_?C??_OGG");
 <digraph with 10 vertices, 9 edges>
 gap> gr2 := DigraphFromDiSparse6String(".H`OS?aEMC?bneOY`l_?QCJ");
@@ -1150,7 +1150,7 @@ gap> gr := DigraphEdgeUnion(ChainDigraph(2), ChainDigraph(3), ChainDigraph(4));
 gap> OutNeighbours(gr);
 [ [ 2, 2, 2 ], [ 3, 3 ], [ 4 ], [  ] ]
 
-#T# DigraphJoin
+#  DigraphJoin
 gap> gr := CompleteDigraph(20);
 <digraph with 20 vertices, 380 edges>
 gap> gr2 := EmptyDigraph(10);
@@ -1207,7 +1207,7 @@ gap> DigraphJoin(EmptyDigraph(3), EmptyDigraph(2)) =
 > CompleteBipartiteDigraph(3, 2);
 true
 
-#T# OutNeighboursMutableCopy
+#  OutNeighboursMutableCopy
 gap> gr := Digraph([[3], [10], [6], [3], [10], [], [6], [3], [], [3]]);
 <digraph with 10 vertices, 8 edges>
 gap> out1 := OutNeighbours(gr);
@@ -1229,7 +1229,7 @@ true
 gap> IsMutable(out3[1]);
 true
 
-#T# InNeighboursMutableCopy
+#  InNeighboursMutableCopy
 gap> gr := Digraph([[3], [10], [6], [3], [10], [], [6], [3], [], [3]]);
 <digraph with 10 vertices, 8 edges>
 gap> in1 := InNeighbours(gr);
@@ -1254,7 +1254,7 @@ true
 gap> IsMutable(in3[1]);
 true
 
-#T# AdjacencyMatrixMutableCopy
+#  AdjacencyMatrixMutableCopy
 gap> gr := CycleDigraph(3);;
 gap> adj := AdjacencyMatrixMutableCopy(gr);;
 gap> PrintArray(adj);
@@ -1267,7 +1267,7 @@ gap> PrintArray(adj);
   [  0,  0,  1 ],
   [  1,  1,  0 ] ]
 
-#T# BooleanAdjacencyMatrixMutableCopy
+#  BooleanAdjacencyMatrixMutableCopy
 gap> gr := Digraph([[3], [2, 3], [3], [2, 4]]);;
 gap> adj := BooleanAdjacencyMatrixMutableCopy(gr);;
 gap> PrintArray(adj);
@@ -1282,7 +1282,7 @@ gap> PrintArray(adj);
   [   true,  false,   true,  false ],
   [  false,   true,  false,   true ] ]
 
-#T# DigraphRemoveAllMultipleEdges
+#  DigraphRemoveAllMultipleEdges
 gap> gr1 := Digraph([[1, 1, 2, 1], [1]]);
 <multidigraph with 2 vertices, 5 edges>
 gap> gr2 := DigraphRemoveAllMultipleEdges(gr1);
@@ -1296,7 +1296,7 @@ gap> gr4 := DigraphRemoveAllMultipleEdges(gr3);
 gap> gr2 = gr4;
 true
 
-#T# IsReachable
+#  IsReachable
 gap> gr1 := DigraphRemoveEdges(CycleDigraph(100), [[100, 1], [99, 100]]);
 <digraph with 100 vertices, 98 edges>
 gap> IsReachable(gr1, 0, 1);
@@ -1375,7 +1375,7 @@ false
 gap> IsReachable(gr, 1, 4);
 true
 
-#T# DigraphPath
+#  DigraphPath
 gap> gr := ChainDigraph(10);
 <digraph with 10 vertices, 9 edges>
 gap> DigraphPath(gr, 1, 2);
@@ -1399,7 +1399,7 @@ Error, Digraphs: DigraphPath: usage,
 the second and third arguments <u> and <v> must be
 vertices of the first argument <digraph>,
 
-#T# IteratorOfPaths
+#  IteratorOfPaths
 gap> gr := CompleteDigraph(5);;
 gap> iter := IteratorOfPaths(gr, 2, 6);
 Error, Digraphs: IteratorOfPaths: usage,
@@ -1488,7 +1488,7 @@ gap> NextIterator(iter);
 gap> IsDoneIterator(iter);
 true
 
-#T# DigraphLongestDistanceFromVertex
+#  DigraphLongestDistanceFromVertex
 gap> nbs := [[2, 8, 10, 11], [3, 5], [4], [], [6], [7], [], [9], [5], [6],
 > [12], [13], [14], [6], [15, 1]];;
 gap> gr := Digraph(nbs);
@@ -1511,7 +1511,7 @@ gap> DigraphLongestDistanceFromVertex(gr, 16);
 Error, Digraphs: DigraphLongestDistanceFromVertex: usage,
 the second argument <v> must be a vertex of the first argument, <digraph>,
 
-#T# Digraph(Reflexive)TransitiveReduction
+#  Digraph(Reflexive)TransitiveReduction
 
 # Check errors
 gap> gr := Digraph([[2, 2], []]);
@@ -1561,7 +1561,7 @@ true
 gap> DigraphReflexiveTransitiveReduction(EmptyDigraph(0)) = EmptyDigraph(0);
 true
 
-#T# DigraphLayers
+#  DigraphLayers
 gap> gr := CompleteDigraph(4);
 <digraph with 4 vertices, 12 edges>
 gap> DigraphLayers(gr, 1);
@@ -1645,7 +1645,7 @@ gap> DigraphShortestDistance(gr, [1, 3], DigraphLayers(gr, 1)[3]);
 gap> DigraphShortestDistance(gr, [1, 6], DigraphLayers(gr, 1)[3]);
 1
 
-#T# Issue #12
+#  Issue #12
 gap> gr := DigraphFromSparse6String(
 > ":]n?AL`CB_EDbFE`IGaGHdJIeKGcLK_@MhDCiFLaBJmHFmKJ");
 <digraph with 30 vertices, 90 edges>
@@ -1654,7 +1654,7 @@ gap> DigraphGroup(gr);
 gap> DigraphShortestDistance(gr, 1, 16);
 1
 
-#T# DigraphShortestDistance: two inputs
+#  DigraphShortestDistance: two inputs
 gap> gr := Digraph([[2], [3], [1, 4], [1, 3], [5]]);
 <digraph with 5 vertices, 7 edges>
 gap> DigraphShortestDistance(gr, 1, 3);
@@ -1667,7 +1667,7 @@ gap> DigraphShortestDistances(gr);;
 gap> DigraphShortestDistance(gr, [3, 4]);
 1
 
-#T# DigraphShortestDistance: bad input
+#  DigraphShortestDistance: bad input
 gap> DigraphShortestDistance(gr, 1, 74);
 Error, Digraphs: DigraphShortestDistance: usage,
 the second argument and third argument must be
@@ -1679,7 +1679,7 @@ gap> DigraphShortestDistance(gr, [1, 71, 3]);
 Error, Digraphs: DigraphShortestDistance: usage,
 the second argument must be of length 2,
 
-#T# DigraphDistancesSet
+#  DigraphDistancesSet
 gap> gr := ChainDigraph(10);
 <digraph with 10 vertices, 9 edges>
 gap> DigraphDistanceSet(gr, 5, 2);
@@ -1711,7 +1711,7 @@ gap> DigraphDistanceSet(gr, 2, -1);
 Error, Digraphs: DigraphDistanceSet: usage,
 the third argument must be a non-negative integer,
 
-#T# IsSubdigraph: Issue #46
+#  IsSubdigraph: Issue #46
 gap> gr1 := Digraph([[2], []]);;
 gap> gr2 := Digraph([[2, 2], []]);;
 gap> IsSubdigraph(gr1, gr2);
@@ -1721,7 +1721,7 @@ true
 gap> gr1 = gr2;
 false
 
-#T# IsSubdigraph: for two digraphs, 1
+#  IsSubdigraph: for two digraphs, 1
 gap> gr1 := CompleteDigraph(3);;
 gap> gr2 := CompleteDigraph(4);;
 gap> IsSubdigraph(gr1, gr2) or IsSubdigraph(gr1, gr2);
@@ -1755,7 +1755,7 @@ gap> gr2 := Digraph([[], [2, 2]]);
 gap> IsSubdigraph(gr1, gr2) or IsSubdigraph(gr2, gr1);
 false
 
-#T# IsUndirectedSpanningForest
+#  IsUndirectedSpanningForest
 gap> gr1 := CompleteDigraph(10);
 <digraph with 10 vertices, 90 edges>
 gap> gr2 := EmptyDigraph(9);
@@ -1777,7 +1777,7 @@ gap> gr := DigraphFromDigraph6String("+I?PIMAQc@A?W?ADPP?");
 gap> IsUndirectedSpanningForest(gr, DigraphByEdges([[2, 7], [7, 2]], 10));
 true
 
-#T# IsUndirectedSpanningTree
+#  IsUndirectedSpanningTree
 gap> IsUndirectedSpanningTree(EmptyDigraph(1), EmptyDigraph(1));
 true
 gap> IsUndirectedSpanningTree(EmptyDigraph(2), EmptyDigraph(2));
@@ -1799,7 +1799,7 @@ true
 gap> IsUndirectedSpanningTree(gr2, gr2);
 true
 
-#T# PartialOrderDigraphMeetOfVertices
+#  PartialOrderDigraphMeetOfVertices
 gap> gr := CycleDigraph(5);
 <digraph with 5 vertices, 5 edges>
 gap> PartialOrderDigraphJoinOfVertices(gr, 1, 4);
@@ -1852,7 +1852,7 @@ fail
 gap> PartialOrderDigraphJoinOfVertices(gr1, 3, 4);
 fail
 
-#T# DigraphClosure
+#  DigraphClosure
 gap> gr := Digraph([[4, 5, 6, 7, 9], [7, 3], [2, 6, 7, 9, 10],
 > [5, 6, 7, 1, 9], [1, 4, 6, 7], [7, 1, 3, 4, 5],
 > [1, 4, 9, 2, 3, 5, 6, 8], [7], [1, 4, 7, 3, 10], [9, 3]]);;
@@ -1873,7 +1873,7 @@ gap> DigraphClosure(gr, 2);
 Error, Digraphs: DigraphClosure: usage,
 the digraph must by symmetric, without loops, and no multiple edges,
 
-#T# IsMatching
+#  IsMatching
 gap>  gr := Digraph([[2], [3], [4], []]);;
 gap>  edges := [[1, 4], [2, 3]];;
 gap>  IsMatching(gr, edges);
@@ -1919,7 +1919,7 @@ gap> edges := [[1, 2], [3, 4], [4, 5], [6, 7]];;
 gap>  IsMatching(gr, edges);
 false
 
-#T# IsPerfectMatching
+#  IsPerfectMatching
 gap> gr := Digraph([[2], [3], [4], [5], [1]]);
 <digraph with 5 vertices, 5 edges>
 gap> IsPerfectMatching(gr, [[1, 3]]);
@@ -1951,7 +1951,7 @@ gap> edges := [[1, 2], [4, 5], [3, 3]];;
 gap> IsPerfectMatching(gr, edges);
 true
 
-#T# IsMaximalMatching
+#  IsMaximalMatching
 gap> gr := Digraph([[2], [3], [4], [5], [1]]);
 <digraph with 5 vertices, 5 edges>
 gap> edges := [[1, 2], [4, 3]];;
@@ -2046,7 +2046,7 @@ gap> S := AsMonoid(IsTransformation, di);;
 Error, Digraphs: AsMonoid usage,
 the first argument must be IsPartialPermMonoid or IsPartialPermSemigroup,
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(a);
 gap> Unbind(adj);
 gap> Unbind(b);

--- a/tst/standard/orbits.tst
+++ b/tst/standard/orbits.tst
@@ -13,14 +13,14 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# DigraphStabilizer, error
+#  DigraphStabilizer, error
 gap> gr := NullDigraph(0);
 <digraph with 0 vertices, 0 edges>
 gap> DigraphStabilizer(gr, 1);
 Error, Digraphs: DigraphStabilizer: usage,
 the second argument must not exceed 0,
 
-#T# DigraphStabilizer,
+#  DigraphStabilizer,
 gap> gr := CompleteDigraph(3);
 <digraph with 3 vertices, 6 edges>
 gap> DigraphStabilizer(gr, 1);
@@ -30,7 +30,7 @@ Group([ (1,3) ])
 gap> DigraphStabilizer(gr, 3);
 Group([ (1,2) ])
 
-#T# DigraphGroup
+#  DigraphGroup
 gap> gr := Digraph([[2, 2], [1]]);
 <multidigraph with 2 vertices, 3 edges>
 gap> DigraphGroup(gr);
@@ -44,13 +44,13 @@ gap> gr := Digraph([[3, 2], [1], [1]]);
 gap> DigraphGroup(gr);
 Group([ (2,3) ])
 
-#T# DigraphOrbits
+#  DigraphOrbits
 gap> gr := CycleDigraph(10);
 <digraph with 10 vertices, 10 edges>
 gap> DigraphOrbits(gr);
 [ [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ]
 
-#T# RepresentativeOutNeighbours
+#  RepresentativeOutNeighbours
 gap> gr := ChainDigraph(3);
 <digraph with 3 vertices, 2 edges>
 gap> RepresentativeOutNeighbours(gr);

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -14,7 +14,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# IsChainDigraph
+#  IsChainDigraph
 gap> IsChainDigraph(ChainDigraph(1));
 true
 gap> IsChainDigraph(ChainDigraph(7));
@@ -40,7 +40,7 @@ false
 gap> IsChainDigraph(Digraph([[2], [3], [4], []]));
 true
 
-#T# IsMultiDigraph
+#  IsMultiDigraph
 gap> gr1 := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsMultiDigraph(gr1);
@@ -64,7 +64,7 @@ gap> gr4 := Digraph(r);
 gap> IsMultiDigraph(gr4);
 true
 
-#T# IsAcyclicDigraph
+#  IsAcyclicDigraph
 gap> loop := Digraph([[1]]);
 <digraph with 1 vertex, 1 edge>
 gap> IsMultiDigraph(loop);
@@ -166,7 +166,7 @@ false
 gap> IsAcyclicDigraph(gr);
 false
 
-#T# IsFunctionalDigraph
+#  IsFunctionalDigraph
 gap> IsFunctionalDigraph(multiple);
 false
 gap> IsFunctionalDigraph(grid);
@@ -211,7 +211,7 @@ gap> g5 := Digraph(rec(vertices := [1 .. 3],
 gap> IsFunctionalDigraph(g5);
 false
 
-#T# IsSymmetricDigraph
+#  IsSymmetricDigraph
 gap> IsSymmetricDigraph(g1);
 false
 gap> IsSymmetricDigraph(g2);
@@ -235,7 +235,7 @@ gap> gr := Digraph(rec(nrvertices := 3, source := [1, 1, 2, 2, 2, 2, 3, 3],
 gap> IsSymmetricDigraph(gr);
 true
 
-#T# IsAntisymmetricDigraph
+#  IsAntisymmetricDigraph
 gap> gr := Digraph(rec(nrvertices := 10,
 > source := [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 6,
 >  6, 6, 6, 6, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 10],
@@ -269,7 +269,7 @@ gap> gr := Digraph([[1, 1, 1, 1, 2], [2, 2, 2, 1]]);
 gap> IsAntisymmetricDigraph(gr);
 false
 
-#T# IsEmptyDigraph
+#  IsEmptyDigraph
 gap> gr1 := Digraph(rec(nrvertices := 5, source := [], range := []));;
 gap> IsEmptyDigraph(gr1);
 true
@@ -292,7 +292,7 @@ gap> gr6 := DigraphByEdges([[3, 5], [1, 1], [2, 3], [5, 4]]);
 gap> IsEmptyDigraph(gr6);
 false
 
-#T# IsTournament
+#  IsTournament
 gap> gr := Digraph(rec(
 > nrvertices := 2, source := [1, 1], range := [2, 2]));
 <multidigraph with 2 vertices, 2 edges>
@@ -330,7 +330,7 @@ gap> gr := Digraph([[2], [1], [1]]);
 gap> IsTournament(gr);
 false
 
-#T# IsStronglyConnectedDigraph
+#  IsStronglyConnectedDigraph
 gap> gr := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsStronglyConnectedDigraph(gr);
@@ -387,7 +387,7 @@ false
 gap> IsStronglyConnectedDigraph(gr);
 false
 
-#T# IsReflexiveDigraph
+#  IsReflexiveDigraph
 gap> r := rec(vertices := [1 .. 5],
 > source := [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5],
 > range  := [1, 2, 3, 1, 2, 5, 1, 3, 5, 2, 3, 4, 1, 2, 2]);;
@@ -447,7 +447,7 @@ gap> gr := DigraphByAdjacencyMatrix(mat);
 gap> IsReflexiveDigraph(gr);
 true
 
-#T# IsCompleteDigraph
+#  IsCompleteDigraph
 gap> gr := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsCompleteDigraph(gr);
@@ -469,7 +469,7 @@ gap> gr := Digraph([[2], [1]]);
 gap> IsCompleteDigraph(gr);
 true
 
-#T# IsConnectedDigraph
+#  IsConnectedDigraph
 gap> gr := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsConnectedDigraph(gr);
@@ -507,7 +507,7 @@ gap> gr := Digraph([[2], [3], [], [3]]);
 gap> IsConnectedDigraph(gr);
 true
 
-#T# DigraphHasLoops
+#  DigraphHasLoops
 gap> gr := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> DigraphHasLoops(gr);
@@ -580,7 +580,7 @@ gap> AdjacencyMatrix(gr);;
 gap> DigraphHasLoops(gr);
 false
 
-#T# IsAperiodicDigraph
+#  IsAperiodicDigraph
 gap> gr := Digraph([[2], [3], [4], [5], [6], [1], [8], [7]]);
 <digraph with 8 vertices, 8 edges>
 gap> IsAperiodicDigraph(gr);
@@ -598,7 +598,7 @@ gap> gr := Digraph([[2, 2], [3, 3], [4], []]);
 gap> IsAperiodicDigraph(gr);
 false
 
-#T# IsTransitiveDigraph
+#  IsTransitiveDigraph
 gap> gr := Digraph([[2, 3, 4], [3, 4], [4], [4]]);
 <digraph with 4 vertices, 7 edges>
 gap> IsTransitiveDigraph(gr);
@@ -690,7 +690,7 @@ true
 gap> IS_TRANSITIVE_DIGRAPH(gr);
 true
 
-#T# IsBipartiteDigraph
+#  IsBipartiteDigraph
 gap> gr := Digraph([[2, 4], [], [1], [1], [4]]);
 <digraph with 5 vertices, 5 edges>
 gap> IsBipartiteDigraph(gr);
@@ -746,7 +746,7 @@ true
 gap> IsBipartiteDigraph(gr);
 false
 
-#T# IsIn/OutRegularDigraph
+#  IsIn/OutRegularDigraph
 gap> gr := Digraph([[1, 2, 3, 4], [], [], []]);;
 gap> IsInRegularDigraph(gr);
 true
@@ -761,7 +761,7 @@ gap> gr := CompleteDigraph(4);;
 gap> IsRegularDigraph(gr);
 true
 
-#T# IsDistanceRegularDigraph
+#  IsDistanceRegularDigraph
 gap> gr := DigraphSymmetricClosure(ChainDigraph(5));;
 gap> IsDistanceRegularDigraph(gr);
 false
@@ -796,7 +796,7 @@ gap> gr := Digraph([[], [3], [2]]);
 gap> IsDistanceRegularDigraph(gr);
 false
 
-#T# IsCompleteBipartiteDigraph
+#  IsCompleteBipartiteDigraph
 gap> gr := CompleteBipartiteDigraph(4, 5);
 <digraph with 9 vertices, 40 edges>
 gap> IsCompleteBipartiteDigraph(gr);
@@ -818,7 +818,7 @@ gap> gr := Digraph([[2], [1]]);
 gap> IsCompleteBipartiteDigraph(gr);
 true
 
-#T# IsDirectedTree
+#  IsDirectedTree
 gap> g := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsDirectedTree(g);
@@ -880,7 +880,7 @@ gap> g := Digraph([[2, 3, 4], [1, 3, 4], [1, 2, 4], [1, 2, 3]]);
 gap> IsDirectedTree(g);
 false
 
-#T# IsUndirectedTree
+#  IsUndirectedTree
 gap> g := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsUndirectedTree(g);
@@ -942,7 +942,7 @@ gap> g := Digraph([[1], [2]]);
 gap> IsConnectedDigraph(g);
 false
 
-#T# IsUndirectedForest
+#  IsUndirectedForest
 gap> gr := ChainDigraph(10);
 <digraph with 10 vertices, 9 edges>
 gap> IsUndirectedForest(gr);
@@ -984,7 +984,7 @@ gap> gr := DigraphDisjointUnion(CompleteDigraph(2), CycleDigraph(3));
 gap> IsUndirectedForest(gr);
 false
 
-#T# IsEulerianDigraph
+#  IsEulerianDigraph
 gap> g := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsEulerianDigraph(g);
@@ -1133,7 +1133,7 @@ false
 gap> IsLatticeDigraph(gr);
 false
 
-#T# IsCycleDigraph
+#  IsCycleDigraph
 gap> IsCycleDigraph(NullDigraph(10));
 false
 gap> IsCycleDigraph(CycleDigraph(10));
@@ -1145,7 +1145,7 @@ false
 gap> IsCycleDigraph(CycleDigraph(1));
 true
 
-#T# IsBiconnectedDigraph
+#  IsBiconnectedDigraph
 gap> gr := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsBiconnectedDigraph(gr);
@@ -1184,7 +1184,7 @@ gap> IsBiconnectedDigraph(Digraph([[2, 4, 5], [1, 4], [4, 7], [1, 2, 3, 5, 6,
 >                                   7], [1, 4], [4, 7], [3, 4, 6]]));
 false
 
-#T# IsHamiltonianDigraph
+#  IsHamiltonianDigraph
 gap> g := Digraph([]);
 <digraph with 0 vertices, 0 edges>
 gap> IsHamiltonianDigraph(g);
@@ -1342,7 +1342,7 @@ gap> gr := Digraph([[1], [1, 2], [2, 3]]);;
 gap> IsPreorderDigraph(gr) or IsQuasiorderDigraph(gr);
 false
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(circuit);
 gap> Unbind(complete100);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -13,7 +13,7 @@ gap> LoadPackage("digraphs", false);;
 #
 gap> DIGRAPHS_StartTest();
 
-#T# Conversion to and from GRAPE graphs
+#  Conversion to and from GRAPE graphs
 gap> gr := Digraph(
 > [[8], [4, 5, 6, 8, 9], [2, 4, 5, 7, 10], [9],
 > [1, 4, 6, 7, 9], [2, 3, 6, 7, 10], [3, 4, 5, 8, 9],
@@ -43,7 +43,7 @@ gap> not DIGRAPHS_IsGrapeLoaded or
 >  Digraph(Graph(Group(()), [1 .. 20], OnPoints, func, true)) = Digraph(adj));
 true
 
-#T# IsAcyclicDigraph
+#  IsAcyclicDigraph
 gap> gr := Digraph([
 >  [1, 2, 4, 10], [3, 15], [3, 15], [1, 3, 7, 8, 9, 11, 12, 13],
 >  [4, 8], [1, 2, 4, 5, 6, 7, 8, 10, 14, 15], [3, 4, 6, 11, 13, 15],
@@ -75,24 +75,24 @@ gap> gr := Digraph([[2, 3], [4, 5], [5, 6], [], [], [], [3]]);
 gap> IsDigraph(gr);
 true
 
-#T# OutNeighbours
+#  OutNeighbours
 # Check that it can handle non-plists in the source and range
 gap> gr := Digraph(rec(nrvertices := 1000,
 >                      source := [1 .. 1000],
 >                      range := Concatenation([2 .. 1000], [1])));;
 gap> OutNeighbours(gr);;
 
-#T# IsMultiDigraph: for an empty digraph
+#  IsMultiDigraph: for an empty digraph
 gap> d := Digraph(rec(vertices := [1 .. 5], range := [], source := []));
 <digraph with 5 vertices, 0 edges>
 gap> IsMultiDigraph(d);
 false
 
-#T# DigraphFromSparse6String
+#  DigraphFromSparse6String
 gap> DigraphFromSparse6String(":Fa@x^");
 <digraph with 7 vertices, 8 edges>
 
-#T# (In/Out)Neighbours and (In/Out)NeighboursOfVertex and (In/Out)DegreeOfVertex
+#  (In/Out)Neighbours and (In/Out)NeighboursOfVertex and (In/Out)DegreeOfVertex
 gap> gr := Digraph([[4], [2, 2], [2, 3, 1, 4], [1]]);
 <multidigraph with 4 vertices, 8 edges>
 gap> InDegreeOfVertex(gr, 2);
@@ -129,7 +129,7 @@ gap> DigraphOutEdges(gr, 2);
 gap> DigraphOutEdges(gr, 4);
 [ [ 4, 2 ], [ 4, 3 ], [ 4, 1 ] ]
 
-#T# DigraphPeriod and IsAperiodicDigraph
+#  DigraphPeriod and IsAperiodicDigraph
 gap> gr := Digraph([[2], [3], [4], [5], [1], [7], [6]]);
 <digraph with 7 vertices, 7 edges>
 gap> DigraphPeriod(gr);
@@ -143,7 +143,7 @@ gap> DigraphPeriod(gr);
 gap> IsAperiodicDigraph(gr);
 false
 
-#T# IsDigraphEdge
+#  IsDigraphEdge
 gap> gr := Digraph(rec(nrvertices := 5, source := [1, 2, 3, 4, 5],
 > range := [2, 3, 4, 5, 1]));
 <digraph with 5 vertices, 5 edges>
@@ -152,7 +152,7 @@ true
 gap> IsDigraphEdge(gr, [2, 2]);
 false
 
-#T# DigraphReverseEdge and DigraphEdges
+#  DigraphReverseEdge and DigraphEdges
 
 #
 gap> gr := Digraph([[2], [3, 5], [4], [5], [1, 2]]);
@@ -174,7 +174,7 @@ true
 gap> gr2 := DigraphReverseEdge(gr, 2);
 <digraph with 7 vertices, 12 edges>
 
-#T# DigraphTopologicalSort
+#  DigraphTopologicalSort
 gap> gr := Digraph([[2, 3], [3], [], [5, 6], [6], []]);
 <digraph with 6 vertices, 6 edges>
 gap> topo := DigraphTopologicalSort(gr);
@@ -194,7 +194,7 @@ gap> gr1 := OnDigraphs(gr, p ^ -1);;
 gap> DigraphTopologicalSort(gr1) = DigraphVertices(gr1);
 true
 
-#T# AutomorphismGroup: for a multidigraph
+#  AutomorphismGroup: for a multidigraph
 # CanonicalLabelling was being set incorrectly by AutomorphismGroup for
 # a multidigraph
 gap> gr := Digraph([
@@ -213,7 +213,7 @@ gap> BlissCanonicalLabelling(gr);
 gap> BlissCanonicalLabelling(gr) = BlissCanonicalLabelling(DigraphCopy(gr));
 true
 
-#T# DIGRAPH_IN_OUT_NBS: for a list containing ranges
+#  DIGRAPH_IN_OUT_NBS: for a list containing ranges
 # A segfault was caused by assuming that an element of OutNeighbours was a
 # PLIST. This is solved by using PLAIN_LIST on each entry of OutNeighbours.
 gap> gr := Digraph(List([1 .. 5], x -> [1 .. 5]));;
@@ -227,13 +227,13 @@ gap> out;
 gap> InNeighbours(gr) = out;
 true
 
-#T# Issue 13: DigraphAllSimpleCircuits, reported by JDM
+#  Issue 13: DigraphAllSimpleCircuits, reported by JDM
 gap> gr := Digraph([[3], [4], [5], [1, 5], [1, 2]]);
 <digraph with 5 vertices, 7 edges>
 gap> DigraphAllSimpleCircuits(gr);
 [ [ 1, 3, 5 ], [ 1, 3, 5, 2, 4 ], [ 5, 2, 4 ] ]
 
-#T# DigraphMaximalCliquesReps was returning too few results, since the choice
+#  DigraphMaximalCliquesReps was returning too few results, since the choice
 # of a pivot vertex was not necessarily valid when the stabilizer was
 # non-trivial
 gap> gr := DigraphFromGraph6String("L~~~ySrJ[N{NT^");
@@ -250,7 +250,7 @@ true
 gap> DigraphMaximalCliquesReps(gr);
 [ [ 1, 2, 3, 4, 5, 6 ], [ 1, 2, 5, 9 ], [ 1, 9, 10 ], [ 7, 8, 9, 10 ] ]
 
-#T# DigraphClosure
+#  DigraphClosure
 gap> gr := CompleteDigraph(7);;
 gap> gr2 := DigraphClosure(gr, 7);;
 gap> gr = gr2;
@@ -263,7 +263,7 @@ gap> gr2 := DigraphClosure(gr, 7);;
 gap> DigraphNrEdges(gr2);
 42
 
-#T# Fix seg fault cause by wrong handling of no edges in
+#  Fix seg fault cause by wrong handling of no edges in
 # FuncDIGRAPH_SOURCE_RANGE
 gap> gr := Digraph([[]]);
 <digraph with 1 vertex, 0 edges>
@@ -272,7 +272,7 @@ gap> DigraphSource(gr);
 gap> DigraphRange(gr);
 [  ]
 
-#T# Issue 17: Bug in OnDigraphs for a digraph and a transformation
+#  Issue 17: Bug in OnDigraphs for a digraph and a transformation
 gap> d := Digraph([[2], [3], [1, 1]]);
 <multidigraph with 3 vertices, 4 edges>
 gap> OutNeighbours(OnDigraphs(d, PermList([2, 3, 1])));
@@ -280,7 +280,7 @@ gap> OutNeighbours(OnDigraphs(d, PermList([2, 3, 1])));
 gap> OutNeighbours(OnDigraphs(d, Transformation([2, 3, 1])));
 [ [ 2, 2 ], [ 3 ], [ 1 ] ]
 
-#T# Issue 42: Bug in AsDigraph for a transformation and an integer
+#  Issue 42: Bug in AsDigraph for a transformation and an integer
 gap> f := Transformation([7, 10, 10, 1, 7, 9, 10, 4, 2, 3]);
 Transformation( [ 7, 10, 10, 1, 7, 9, 10, 4, 2, 3 ] )
 gap> AsDigraph(f);
@@ -293,13 +293,13 @@ gap> gr := Digraph([[1], [2], [1 .. 3]]);;
 gap> IsAntisymmetricDigraph(gr);
 true
 
-#T# Issue 55: Bug in FuncDIGRAPH_TOPO_SORT
+#  Issue 55: Bug in FuncDIGRAPH_TOPO_SORT
 gap> gr := Digraph([[1 .. 4], [2, 4], [3, 4], [4]]);
 <digraph with 4 vertices, 9 edges>
 gap> DigraphTopologicalSort(gr);
 [ 4, 2, 3, 1 ]
 
-#T# Issue 81: Bug in Digraph for a malformed list of out-neighbours
+#  Issue 81: Bug in Digraph for a malformed list of out-neighbours
 gap> gr := Digraph([[1],, [2]]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `Digraph' on 1 arguments
@@ -308,7 +308,7 @@ Error, Digraphs: Digraph: usage,
 the argument must be a list of lists of positive integers not exceeding the
 length of the argument,
 
-#T# Symmetric closure of a digraph with no vertices
+#  Symmetric closure of a digraph with no vertices
 gap> gr := EmptyDigraph(0);;
 gap> DigraphSymmetricClosure(gr);
 <digraph with 0 vertices, 0 edges>
@@ -327,7 +327,7 @@ gap> not DIGRAPHS_NautyAvailable or
 > NautyCanonicalLabelling(NullDigraph(0), []) = ();
 true
 
-#T# DIGRAPHS_UnbindVariables
+#  DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);
 gap> Unbind(G);


### PR DESCRIPTION
This PR removes some redundant comment lines, and comment tags from all files in `gap/` and `tst/`.