### PR TITLE
Allow rational numbers as the second argument of RandomDigraph

### DIFF
--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -69,6 +69,7 @@ DeclareOperation("AsDigraph", [IsTransformation, IsInt]);
 DeclareOperation("DigraphCopy", [IsDigraph]);
 
 DeclareOperation("RandomDigraph", [IsPosInt]);
+DeclareOperation("RandomDigraph", [IsPosInt, IsRat]);
 DeclareOperation("RandomDigraph", [IsPosInt, IsFloat]);
 DeclareOperation("RandomMultiDigraph", [IsPosInt]);
 DeclareOperation("RandomMultiDigraph", [IsPosInt, IsPosInt]);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -601,6 +601,12 @@ function(n)
   return RandomDigraph(n, Float(Random([0 .. 10000])) / 10000);
 end);
 
+InstallMethod(RandomDigraph, "for a pos int and a rational",
+[IsPosInt, IsRat],
+function(n, p)
+  return RandomDigraph(n, Float(p));
+end);
+
 InstallMethod(RandomDigraph, "for a pos int and a float",
 [IsPosInt, IsFloat],
 function(n, p)
@@ -608,7 +614,7 @@ function(n, p)
 
   if p < 0.0 or 1.0 < p then
     ErrorNoReturn("Digraphs: RandomDigraph: usage,\n",
-                  "the second argument <p> must be a float between 0 and 1,");
+                  "the second argument <p> must be between 0 and 1,");
   fi;
   out := DigraphNC(RANDOM_DIGRAPH(n, Int(p * 10000)));
   SetIsMultiDigraph(out, false);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -611,14 +611,14 @@ gap> RandomDigraph("a");
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RandomDigraph' on 1 arguments
 gap> RandomDigraph(4, 0);
-Error, no method found! For debugging hints type ?Recovery from NoMethodFound
-Error, no 1st choice method found for `RandomDigraph' on 2 arguments
+<digraph with 4 vertices, 0 edges>
 gap> RandomDigraph(10, 1.01);
 Error, Digraphs: RandomDigraph: usage,
-the second argument <p> must be a float between 0 and 1,
+the second argument <p> must be between 0 and 1,
 gap> RandomDigraph(10, -0.01);
 Error, Digraphs: RandomDigraph: usage,
-the second argument <p> must be a float between 0 and 1,
+the second argument <p> must be between 0 and 1,
+gap> RandomDigraph(10, 1 / 10);;
 
 #  RandomMultiDigraph
 gap> DigraphNrVertices(RandomMultiDigraph(100));


### PR DESCRIPTION
This small PR allows the use of rationals in addition to floats for the second argument of `RandomDigraph`.