### PR TITLE
Add AsSemigroup method for strong semilattices of groups

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1566,3 +1566,45 @@ gap> Size(M);
     </Description>
   </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="AsCliffordSemigroup">
+  <ManSection>
+    <Oper Name="AsSemigroup" Arg="filt, Y, gps, homs"/>
+    <Returns> A Clifford semigroup of partial perms. </Returns>
+    <Description>
+      The operation <C>AsSemigroup</C> requires that <A>filt</A> be equal to
+      <Ref Filt="IsPartialPermSemigroup" BookName="ref"/>.
+      If <A>Y</A> is a <Ref Prop="IsJoinSemilatticeDigraph"/> or
+      <Ref Prop="IsMeetSemilatticeDigraph"/>,
+      <A>gps</A> is a list of groups corresponding to each vertex, and
+      <A>homs</A> is a list containing for each edge <C>(i, j)</C> in
+      the transitive reduction of <A>digraph</A> a triple <C>[i, j, hom]</C>
+      where <C>hom</C> is a group homomorphism from <C>gps[i]</C> to
+      <C>gps[j]</C>, and the diagram of homomorphisms commutes, then
+      <C>AsSemigroup</C> returns a semigroup of partial perms which is
+      isomorphic to the strong semilattice of groups <M>S[Y; gps; homs]</M>.
+      <Example><![CDATA[
+gap> G1 := AlternatingGroup(4);;
+gap> G2 := SymmetricGroup(2);;
+gap> G3 := SymmetricGroup(3);;
+gap> gr := Digraph([[1, 3], [2, 3], [3]]);;
+gap> sgn := function(x)
+> if SignPerm(x) = 1 then
+> return ();
+> fi;
+> return (1, 2);
+> end;;
+gap> hom13 := GroupHomomorphismByFunction(G1, G3, sgn);;
+gap> hom23 := GroupHomomorphismByFunction(G2, G3, sgn);;
+gap> T := AsSemigroup(IsPartialPermSemigroup,
+> gr,
+> [G1, G2, G3], [[1, 3, hom13], [2, 3, hom23]]);;
+gap> Size(T);
+20
+gap> D := GreensDClasses(T);;
+gap> List(D, x -> Size(x));
+[ 6, 12, 2 ]
+]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -71,6 +71,7 @@
 
   <Section><Heading>Associated semigroups</Heading>
     <#Include Label="AsSemigroup">
+    <#Include Label="AsCliffordSemigroup">
   </Section>
 
   <Section><Heading>Planarity</Heading>

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -121,3 +121,6 @@ DeclareOperation("PartialOrderDigraphJoinOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("PartialOrderDigraphMeetOfVertices",
                  [IsDigraph, IsPosInt, IsPosInt]);
+
+DeclareOperation("AsSemigroup",
+                 [IsFunction, IsDigraph, IsDenseList, IsDenseList]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1812,3 +1812,144 @@ function(D, i, j)
 
   return fail;
 end);
+
+InstallMethod(AsSemigroup,
+"for a function, a digraph, and a dense list",
+[IsFunction, IsDigraph, IsDenseList, IsDenseList],
+function(filt, digraph, gps, homs)
+  local red, n, hom_table, reps, rep, top, doms, starts, degs, max, gens, img,
+  start, deg, x, queue, j, k, g, y, hom, edge, i, gen;
+
+  if not filt = IsPartialPermSemigroup then
+    TryNextMethod();
+  elif not IsJoinSemilatticeDigraph(digraph) then
+    if IsMeetSemilatticeDigraph(digraph) then
+      return AsSemigroup(IsPartialPermSemigroup,
+                         DigraphReverse(digraph),
+                         gps,
+                         homs);
+    else
+      ErrorNoReturn("Digraphs: AsSemigroup usage,\n",
+                    "the second argument must be a join semilattice ",
+                    "digraph or a meet semilattice digraph,");
+    fi;
+  elif not ForAll(gps, x -> IsGroup(x)) then
+    ErrorNoReturn("Digraphs: AsSemigroup usage,\n",
+                  "the third argument must be a list of groups,");
+  elif not Length(gps) = DigraphNrVertices(digraph) then
+    ErrorNoReturn("Digraphs: AsSemigroup usage,\n",
+                  "the third argument must have length equal to the number ",
+                  "of vertices in the second argument,");
+  fi;
+
+  red := DigraphReflexiveTransitiveReduction(digraph);
+  if not Length(homs) = DigraphNrEdges(red) or
+       not ForAll(homs, x -> Length(x) = 3 and
+                             IsPosInt(x[1]) and
+                             IsPosInt(x[2]) and
+                             IsDigraphEdge(red, [x[1], x[2]]) and
+                             IsGroupHomomorphism(x[3]) and
+                             Source(x[3]) = gps[x[1]] and
+                             Range(x[3]) = gps[x[2]]) then
+    ErrorNoReturn("Digraphs: AsSemigroup usage,\n",
+                  "the third argument must be a list of triples [i, j, hom] ",
+                  "of length equal to the number of edges in the reflexive ",
+                  "transitive reduction of the second argument, where [i, j] ",
+                  "is an edge in the reflex transitive reduction and hom is ",
+                  "a group homomorphism from group i to group j,");
+  fi;
+
+  n := DigraphNrVertices(digraph);
+
+  hom_table := List([1 .. n], x -> []);
+  for hom in homs do
+    hom_table[hom[1]][hom[2]] := hom[3];
+  od;
+
+  for edge in DigraphEdges(red) do
+    if not IsBound(hom_table[edge[1]][edge[2]]) then
+      ErrorNoReturn("Digraphs: AsSemigroup usage,\n",
+                    "the fourth argument must contain a triple [i, j, hom] ",
+                    "for each edge [i, j] in the reflexive transitive ",
+                    "reduction of the second argument,");
+    fi;
+  od;
+
+  reps := [];
+  for i in [1 .. n] do
+    rep := IsomorphismPermGroup(gps[i]);
+    rep := rep * SmallerDegreePermutationRepresentation(Image(rep));
+    Add(reps, rep);
+  od;
+
+  top     := DigraphTopologicalSort(digraph);
+  doms    := [];
+  starts  := [];
+  degs    := List([1 .. n], i -> NrMovedPoints(Image(reps[i])));
+  for i in [1 .. n] do
+    if degs[i] = 0 then
+      degs[i] := 1;
+    fi;
+  od;
+  max             := degs[top[1]] + 1;
+  doms[top[1]]    := [1 .. max - 1];
+  starts[top[1]]  := 1;
+
+  for i in [2 .. n] do
+    doms[top[i]] := Union(List(OutNeighboursOfVertex(red, top[i]),
+                               j -> doms[j]));
+    Append(doms[top[i]], [max .. max + degs[top[i]] - 1]);
+    starts[top[i]] := max;
+    max := max + degs[top[i]];
+  od;
+
+  gens := [];
+  for i in [1 .. n] do
+    for gen in GeneratorsOfGroup(gps[top[i]]) do
+      img := [];
+      start := starts[top[i]];
+      deg := degs[top[i]];
+      x := ListPerm(gen ^ reps[top[i]]);
+
+      # make sure the partial permutation is defined on the whole domain
+      img{[start .. start + deg - 1]} := [1 .. deg] + start - 1;
+      # now the actual representation
+      img{[start .. start + Length(x) - 1]} := x + start - 1;
+
+      # travel up all the paths from top[i], applying the homomorphisms
+      # and storing the results as permutations on the appropriate set
+      # of points
+      queue := List(OutNeighboursOfVertex(red, top[i]), y -> [top[i], y, gen]);
+      while Length(queue) > 0 do
+        j     := queue[1][1];
+        k     := queue[1][2];
+        g     := queue[1][3];
+        start := starts[k];
+        deg   := degs[k];
+        Remove(queue, 1);
+        x := g ^ hom_table[j][k];
+        Append(queue, List(OutNeighboursOfVertex(red, k), y -> [k, y, x]));
+        x := x ^ reps[k];
+
+        # Check that compositions of homomorphisms commute.
+        # If img[start] is bound then we have already found some composition of
+        # homomorphisms which takes us into gps[k], so we must ensure that this
+        # agrees with the composition we are currently considering.
+        if IsBound(img[start]) then
+          y := PermList(img{[start .. start + deg - 1]} - start + 1);
+          if not x = y then
+            ErrorNoReturn("Digraphs: AsSemigroup usage,\n",
+                          "the homomorphisms given must form a commutative",
+                          " diagram,");
+          fi;
+        fi;
+        x := ListPerm(x);
+        img{[start .. start + deg - 1]} := [1 .. deg] + start - 1;
+        img{[start .. start + Length(x) - 1]} := x + start - 1;
+      od;
+      img := Compacted(img);
+      Add(gens, PartialPerm(doms[top[i]], img));
+    od;
+  od;
+  return Semigroup(gens);
+end);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1970,6 +1970,162 @@ Error, the 3rd argument <j> must be a vertex of the 1st argument <D>,
 gap> PartialOrderDigraphJoinOfVertices(D, 2, 1);
 Error, the 2nd argument <i> must be a vertex of the 1st argument <D>,
 
+# AsSemigroup (for IsPartialPermSemigroup, a digraph, a list of groups,
+# and homomorphisms)
+gap> G1 := SymmetricGroup(4);;
+gap> G2 := SymmetricGroup(2);;
+gap> G3 := SymmetricGroup(3);;
+gap> G4 := SymmetricGroup(4);;
+gap> gr := Digraph([[1, 3], [2, 3], [3]]);;
+gap> gr2 := Digraph([[1, 3], [2, 3], [3], [1, 2, 3, 4]]);;
+gap> sgn := function(x)
+> if SignPerm(x) = 1 then
+> return ();
+> fi;
+> return (1, 2);
+> end;;
+gap> hom13 := GroupHomomorphismByFunction(G1, G3, sgn);;
+gap> hom23 := GroupHomomorphismByFunction(G2, G3, sgn);;
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr, [G1, G2, G3], [[1, 3, hom13],
+> [2, 3, hom23]]);;
+gap> Size(T);
+32
+gap> D := GreensDClasses(T);;
+gap> List(D, x -> Size(x));
+[ 6, 24, 2 ]
+gap> for i in [1 .. 3] do
+> for j in [1 .. 3] do
+> for x in D[i] do
+> for y in D[j] do
+> if i = j and not x * y in D[i] then
+> Error(D[i], x, y);
+> elif i <> j and not x * y in D[1] then
+> Error(D[i], D[j], x, y, x * y);
+> fi;
+> od;
+> od;
+> od;
+> od;
+gap> Size(GroupHClassOfGreensDClass(D[1])) = Size(D[1]);
+true
+gap> Size(GroupHClassOfGreensDClass(D[2])) = Size(D[2]);
+true
+gap> Size(GroupHClassOfGreensDClass(D[3])) = Size(D[3]);
+true
+gap> hom41 := GroupHomomorphismByFunction(G4, G1, sgn);;
+gap> hom42 := GroupHomomorphismByFunction(G4, G2, sgn);;
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr2, [G1, G2, G3, G4],
+> [[1, 3, hom13], [2, 3, hom23], [4, 1, hom41], [4, 2, hom42]]);;
+gap> Size(T);
+56
+gap> List(GreensDClasses(T), x -> Size(x));
+[ 6, 24, 2, 24 ]
+gap> List(GreensDClasses(T), x -> Size(x) = Size(GroupHClassOfGreensDClass(x)));
+[ true, true, true, true ]
+gap> gr3 := Digraph([[1]]);;
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr3, [G1], []);;
+gap> Size(T);
+24
+gap> Size(GreensHClassOfElement(T, Representative(T)));
+24
+gap> gr4 := Digraph([[1], [1, 2], [1, 3], [1, 4], [1, 2, 3, 5]]);;
+gap> G5 := AlternatingGroup(4);;
+gap> G2 := SymmetricGroup(4);;
+gap> hom21 := GroupHomomorphismByFunction(G2, G1, sgn);;
+gap> hom31 := GroupHomomorphismByFunction(G3, G1, x -> x);;
+gap> hom41 := GroupHomomorphismByFunction(G4, G1, x -> One(G1));;
+gap> hom52 := GroupHomomorphismByFunction(G5, G2, x -> x);;
+gap> hom53 := GroupHomomorphismByFunction(G5, G3, sgn);;
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+gap> Size(T);
+90
+gap> List(GreensDClasses(T), x -> Size(x));
+[ 24, 24, 6, 24, 12 ]
+gap> U := AsSemigroup(IsPartialPermSemigroup,
+> DigraphReverse(gr4),
+> [G1, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+gap> U = T;
+true
+gap> gr5 := Digraph([[1], [1, 2], [1, 3], [1, 4], [2, 3, 5]]);;
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr5, [G1, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom52]]);;
+Error, Digraphs: AsSemigroup usage,
+the second argument must be a join semilattice digraph or a meet semilattice d\
+igraph,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom52]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must have length equal to the number of vertices in the sec\
+ond argument,
+gap> S := FullTransformationMonoid(4);;
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [S, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of groups,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 4, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[-2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, -1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, sgn], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 3, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, sgn], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [4, 1, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, sgn], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 2, hom53]]);;
+Error, Digraphs: AsSemigroup usage,
+the third argument must be a list of triples [i, j, hom] of length equal to th\
+e number of edges in the reflexive transitive reduction of the second argument\
+, where [i, j] is an edge in the reflex transitive reduction and hom is a grou\
+p homomorphism from group i to group j,
+gap> T := AsSemigroup(IsPartialPermSemigroup, gr4, [G1, G2, G3, G4, G5],
+> [[2, 1, hom21], [3, 1, hom31], [4, 1, hom41], [5, 2, hom52], [5, 2, hom52]]);;
+Error, Digraphs: AsSemigroup usage,
+the fourth argument must contain a triple [i, j, hom] for each edge [i, j] in \
+the reflexive transitive reduction of the second argument,
+
 # DIGRAPHS_UnbindVariables
 gap> Unbind(a);
 gap> Unbind(adj);
@@ -1979,12 +2135,18 @@ gap> Unbind(edges);
 gap> Unbind(edges2);
 gap> Unbind(erev);
 gap> Unbind(func);
+gap> Unbind(G1);
+gap> Unbind(G2);
+gap> Unbind(G3);
+gap> Unbind(G4);
+gap> Unbind(G5);
 gap> Unbind(g);
 gap> Unbind(gr);
 gap> Unbind(gr1);
 gap> Unbind(gr2);
 gap> Unbind(gr3);
 gap> Unbind(gr4);
+gap> Unbind(gr5);
 gap> Unbind(gri);
 gap> Unbind(grrt);
 gap> Unbind(grt);
@@ -2017,9 +2179,11 @@ gap> Unbind(rev);
 gap> Unbind(rgr);
 gap> Unbind(rtclosure);
 gap> Unbind(source);
+gap> Unbind(T);
 gap> Unbind(t);
 gap> Unbind(tclosure);
 gap> Unbind(temp);
+gap> Unbind(U);
 gap> Unbind(u1);
 gap> Unbind(u2);
 


### PR DESCRIPTION
This PR adds a method for constructing Clifford semigroups as partial permutation semigroups, given a semilattice, groups, and homomorphisms.

You can choose between an easily-computed representation (the default) and a more difficult but possibly smaller degree representation. The smaller degree representation is based on 

"The minimal faithful degree of a semilattice of groups"
David Easdown
J. Austral. Math. Soc. (Series A) 45 (1988), 341-350