### PR TITLE
Added DigraphNrStronglyConnectedComponents attribute

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -666,7 +666,7 @@ rec( comps := [ [ 3 ], [ 1, 2 ] ], id := [ 2, 2, 1 ] )
   <Description>
     This function returns the number of strongly connected components of
     <A>digraph</A>.  Note that this is no more efficient than calling <Ref
-    Attr="DigraphStronglyConnectedComponents"/>.
+    Attr="DigraphStronglyConnectedComponents"/>.<P/>
     
     For more information, see <Ref Attr="DigraphStronglyConnectedComponents"/>.
     <Example><![CDATA[

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -662,7 +662,7 @@ rec( comps := [ [ 3 ], [ 1, 2 ] ], id := [ 2, 2, 1 ] )
 <#GAPDoc Label="DigraphNrStronglyConnectedComponents">
 <ManSection>
   <Attr Name="DigraphNrStronglyConnectedComponents" Arg="digraph"/>
-  <Returns>A positive integer.</Returns>
+  <Returns>A non-negative integer.</Returns>
   <Description>
     This function returns the number of strongly connected components of
     <A>digraph</A>.  Note that this is no more efficient than calling <Ref

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -659,7 +659,26 @@ rec( comps := [ [ 3 ], [ 1, 2 ] ], id := [ 2, 2, 1 ] )
 </ManSection>
 <#/GAPDoc>
 
-#
+<#GAPDoc Label="DigraphNrStronglyConnectedComponents">
+<ManSection>
+  <Attr Name="DigraphNrStronglyConnectedComponents" Arg="digraph"/>
+  <Returns>A positive integer.</Returns>
+  <Description>
+    This function returns the number of strongly connected components of
+    <A>digraph</A>.  Note that this is no more efficient than calling <Ref
+    Attr="DigraphStronglyConnectedComponents"/>.
+    
+    For more information, see <Ref Attr="DigraphStronglyConnectedComponents"/>.
+    <Example><![CDATA[
+gap> D := DigraphDisjointUnion(CycleDigraph(4), CycleDigraph(5));
+<digraph with 9 vertices, 9 edges>
+gap> DigraphNrStronglyConnectedComponents(D);
+2
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 
 <#GAPDoc Label="DigraphConnectedComponents">
 <ManSection>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -46,6 +46,7 @@
     <#Include Label="DigraphConnectedComponents">
     <#Include Label="DigraphConnectedComponent">
     <#Include Label="DigraphStronglyConnectedComponents">
+    <#Include Label="DigraphNrStronglyConnectedComponents">
     <#Include Label="DigraphStronglyConnectedComponent">
     <#Include Label="DigraphBicomponents">
     <#Include Label="ArticulationPoints">

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -21,6 +21,7 @@ DeclareAttribute("DigraphTopologicalSort", IsDigraph);
 DeclareAttribute("DigraphDual", IsDigraph);
 DeclareAttribute("DigraphShortestDistances", IsDigraph);
 DeclareAttribute("DigraphStronglyConnectedComponents", IsDigraph);
+DeclareAttribute("DigraphNrStronglyConnectedComponents", IsDigraph);
 DeclareAttribute("DigraphConnectedComponents", IsDigraph);
 DeclareAttribute("DIGRAPHS_Bipartite", IsDigraph);
 DeclareAttribute("DigraphBicomponents", IsDigraph);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -478,9 +478,7 @@ end);
 
 InstallMethod(DigraphNrStronglyConnectedComponents, "for a digraph",
 [IsDigraph],
-function(digraph)
-  return Length(DigraphStronglyConnectedComponents(digraph).comps);
-end);
+digraph -> Length(DigraphStronglyConnectedComponents(digraph).comps));
 
 InstallMethod(DigraphConnectedComponents, "for a digraph",
 [IsDigraph],

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -476,6 +476,12 @@ function(digraph)
   return GABOW_SCC(OutNeighbours(digraph));
 end);
 
+InstallMethod(DigraphNrStronglyConnectedComponents, "for a digraph",
+[IsDigraph],
+function(digraph)
+  return Length(DigraphStronglyConnectedComponents(digraph).comps);
+end);
+
 InstallMethod(DigraphConnectedComponents, "for a digraph",
 [IsDigraph],
 DIGRAPH_CONNECTED_COMPONENTS);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -318,11 +318,11 @@ rec( comps := [ [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ],
 
 #  DigraphNrStronglyConnectedComponents
 gap> D := CycleDigraph(10);;
-gap> for i in [1 .. 1000] do
+gap> for i in [1 .. 50] do
 > D := DigraphDisjointUnion(D, CycleDigraph(10));
 > od;
 gap> DigraphNrStronglyConnectedComponents(D);
-1001
+51
 gap> D := CayleyDigraph(SymmetricGroup(6));;
 gap> DigraphNrStronglyConnectedComponents(D);
 1
@@ -332,6 +332,9 @@ gap> DigraphNrStronglyConnectedComponents(D);
 gap>  D := Digraph([[]]);;
 gap> DigraphNrStronglyConnectedComponents(D);
 1
+gap> D := EmptyDigraph(0);;
+gap> DigraphNrStronglyConnectedComponents(D);
+0
 
 #  DigraphConnectedComponents
 gap> gr := Digraph([[1, 2], [1], [2], [5], []]);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -316,6 +316,23 @@ gap> DigraphStronglyConnectedComponents(gr2);
 rec( comps := [ [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ], 
       [ 9 ], [ 10 ] ], id := [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] )
 
+#  DigraphNrStronglyConnectedComponents
+gap> D := CycleDigraph(10);;
+gap> for i in [1 .. 1000] do
+> D := DigraphDisjointUnion(D, CycleDigraph(10));
+> od;
+gap> DigraphNrStronglyConnectedComponents(D);
+1001
+gap> D := CayleyDigraph(SymmetricGroup(6));;
+gap> DigraphNrStronglyConnectedComponents(D);
+1
+gap> D := Digraph([[2, 3], [1, 4, 5], [3], [2, 5], [6], [3, 5]]);;
+gap> DigraphNrStronglyConnectedComponents(D);
+3
+gap>  D := Digraph([[]]);;
+gap> DigraphNrStronglyConnectedComponents(D);
+1
+
 #  DigraphConnectedComponents
 gap> gr := Digraph([[1, 2], [1], [2], [5], []]);
 <digraph with 5 vertices, 5 edges>


### PR DESCRIPTION
This pull requests adds an attribute DigraphNrStronglyConnectedComponents, which takes a digraph as its argument and returns the number of strongly connected components of the digraph.

The feature was suggested in [this issue](https://github.com/gap-packages/Digraphs/issues/176).