### PR TITLE
Use MakeString instead of C_NEW_STRING

### DIFF
--- a/src/homos.c
+++ b/src/homos.c
@@ -1926,8 +1926,7 @@ Obj FuncHomomorphismDigraphsFinder(Obj self, Obj args) {
     }
   }
 
-  Obj str;
-  C_NEW_STRING(str, 26, "HomomorphismDigraphsFinder");
+  Obj str = MakeString("HomomorphismDigraphsFinder");
   if (!IS_LIST(colors1_obj) && colors1_obj != Fail) {
     ErrorQuit("the 10th argument (colors1) must be a list or fail, not %s",
               (Int) TNAM_OBJ(colors1_obj),


### PR DESCRIPTION
The latter is kinda deprecated (I'll add a comment to the GAP header `stringobj.h` making that explicit.

This PR could also use `MakeImmString` instead of `MakeString`, to produce an immutable string; but I played it safe, and made sure to not change the semantics of the code.