### PR TITLE
Fix DIGRAPHS_Bipartite for digraphs with isolated vertices

### DIFF
--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -410,7 +410,7 @@ gap> DigraphColouring(ChainDigraph(10), 1);
 fail
 gap> D := ChainDigraph(10);;
 gap> t := DigraphColouring(D, 2);
-Transformation( [ 2, 1, 2, 1, 2, 1, 2, 1, 2, 1 ] )
+Transformation( [ 1, 2, 1, 2, 1, 2, 1, 2, 1, 2 ] )
 gap> IsDigraphColouring(D, t); 
 true
 gap> DigraphGreedyColouring(D);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1331,11 +1331,6 @@ function(D)
   return Concatenation(loops, out);
 end);
 
-# The following method 'DIGRAPHS_Bipartite' was originally written by Isabella
-# Scott and then modified by FLS.
-# It is the backend to IsBipartiteDigraph, Bicomponents, and DigraphColouring
-# for a 2-colouring
-
 InstallMethod(DigraphMycielskian, "for a mutable, symmetric digraph",
 [IsMutableDigraph],
 function(D)
@@ -1391,6 +1386,11 @@ end);
 InstallMethod(DigraphMycielskianAttr, "for an immutable, symmetric digraph",
 [IsImmutableDigraph], DigraphMycielskian);
 
+# The following method 'DIGRAPHS_Bipartite' was originally written by Isabella
+# Scott and then modified by FLS.
+# It is the backend to IsBipartiteDigraph, Bicomponents, and DigraphColouring
+# for a 2-colouring
+
 InstallMethod(DIGRAPHS_Bipartite, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local n, t, colours, in_nbrs, stack, pop, v, pos, nbrs, w, i;
@@ -1410,14 +1410,13 @@ function(D)
     if colours[v] <> 0 then
       continue;
     fi;
+    colours[v] := 1;
     stack := [[v, 1]];
     while Length(stack) > 0 do
-      pop := stack[Length(stack)];
-      Remove(stack, Length(stack));
+      pop := Remove(stack);
       v := pop[1];
       pos := pop[2];
-      nbrs := Concatenation(OutNeighboursOfVertex(D, v),
-                            in_nbrs[v]);
+      nbrs := Concatenation(OutNeighboursOfVertex(D, v), in_nbrs[v]);
       for i in [pos .. Length(nbrs)] do
         w := nbrs[i];
         if colours[w] <> 0 then

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -287,6 +287,12 @@ gap> DigraphColouring(gr, 4);
 Transformation( [ 1, 1, 1, 1, 1, 2, 2, 1, 2, 2, 2, 1, 1, 2, 1, 2, 1, 2, 2, 3,
   3, 2, 3, 3, 3, 2, 1, 4, 4, 2, 3, 3, 3, 3, 3, 1, 3, 4, 4, 3, 2, 1, 4, 3,
   1 ] )
+gap> D := Digraph([[4, 6, 8], [], [], [], [7], [2], [], [], [8], []]);
+<immutable digraph with 10 vertices, 6 edges>
+gap> DigraphColouring(D, 2);
+Transformation( [ 1, 1, 1, 2, 1, 2, 2, 2, 1, 1 ] )
+gap> DigraphColouring(Digraph([[1], []]), 2);
+fail
 
 #  DigraphGreedyColouring
 gap> DigraphGreedyColouring(EmptyDigraph(0));

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -745,6 +745,10 @@ gap> DigraphHasLoops(gr);
 true
 gap> IsBipartiteDigraph(gr);
 false
+gap> D := Digraph([[4, 6, 8], [], [], [], [7], [2], [], [], [8], []]);
+<immutable digraph with 10 vertices, 6 edges>
+gap> IsBipartiteDigraph(D);
+true
 
 #  IsIn/OutRegularDigraph
 gap> gr := Digraph([[1, 2, 3, 4], [], [], []]);;


### PR DESCRIPTION
This code was recently refactored; the problem is that the assignment of colours to vertices didn't give a colour to isolated vertices. This bug was only ever present in `master`, it wasn't released.

Resolves #199.