### PR TITLE
Improve DigraphVertexLabels and DigraphRemoveVertex for mutable digraphs

### DIFF
--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -382,6 +382,12 @@ gap> new := DigraphRemoveVertex(gr, 2);
 <immutable digraph with 2 vertices, 3 edges>
 gap> DigraphVertexLabels(new);
 [ "a", "c" ]
+gap> D := CycleDigraph(IsMutableDigraph, 5);
+<mutable digraph with 5 vertices, 5 edges>
+gap> DigraphRemoveVertex(D, 1);
+<mutable digraph with 4 vertices, 3 edges>
+gap> DigraphVertexLabels(D);
+[ 2, 3, 4, 5 ]
 ]]></Example>
   </Description>
 </ManSection>

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -50,7 +50,7 @@ InstallMethod(RemoveDigraphVertexLabel, "for a digraph and positive integer",
 function(D, v)
   IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then
-    return;
+    D!.vertexlabels := [1 .. DigraphNrVertices(D)];
   fi;
   Remove(D!.vertexlabels, v);
 end);
@@ -67,7 +67,7 @@ function(D, names)
   D!.vertexlabels := names;
 end);
 
-InstallMethod(DigraphVertexLabels, "for a digraph and pos int", [IsDigraph],
+InstallMethod(DigraphVertexLabels, "for a digraph", [IsDigraph],
 function(D)
   IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -50,7 +50,7 @@ InstallMethod(RemoveDigraphVertexLabel, "for a digraph and positive integer",
 function(D, v)
   IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then
-    D!.vertexlabels := [1 .. DigraphNrVertices(D)];
+    DigraphVertexLabels(D);
   fi;
   Remove(D!.vertexlabels, v);
 end);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -96,8 +96,8 @@ function(D, u)
   if u > DigraphNrVertices(D) then
     return D;
   fi;
-  Remove(D!.OutNeighbours, u);
   RemoveDigraphVertexLabel(D, u);
+  Remove(D!.OutNeighbours, u);
   for v in DigraphVertices(D) do
     pos := 1;
     while pos <= Length(D!.OutNeighbours[v]) do

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -715,6 +715,12 @@ gap> DigraphNrVertices(gr2);
 gap> DigraphNrEdges(gr2) =
 > DigraphNrEdges(gr) - OutDegreeOfVertex(gr, 10) - InDegreeOfVertex(gr, 10);
 true
+gap> D := CycleDigraph(IsMutableDigraph, 5);
+<mutable digraph with 5 vertices, 5 edges>
+gap> DigraphRemoveVertex(D, 1);
+<mutable digraph with 4 vertices, 3 edges>
+gap> DigraphVertexLabels(D);
+[ 2, 3, 4, 5 ]
 
 #  DigraphRemoveVertices
 gap> gr := CompleteDigraph(4);


### PR DESCRIPTION
This pull request improves the way `DigraphVertexLabels` behaves with `DigraphRemoveVertex`, for mutable digraphs.

**Previously**
~~~
gap> D := CycleDigraph(IsMutableDigraph, 5);
<mutable digraph with 5 vertices, 5 edges>
gap> DigraphRemoveVertex(D, 1);
<mutable digraph with 4 vertices, 3 edges>
gap> DigraphVertexLabels(D);
[ 1 .. 4 ]
~~~

**With these commits**
~~~
gap> D := CycleDigraph(IsMutableDigraph, 5);
<mutable digraph with 5 vertices, 5 edges>
gap> DigraphRemoveVertex(D, 1);
<mutable digraph with 4 vertices, 3 edges>
gap> DigraphVertexLabels(D);
[ 2, 3, 4, 5 ]
~~~