### PR TITLE
Add IsDigraphCore property

### DIFF
--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -954,3 +954,32 @@ true
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="IsDigraphCore">
+<ManSection>
+  <Prop Name="IsDigraphCore" Arg="digraph"/>
+  <Returns><K>true</K> or <K>false</K>.</Returns>
+  <Description>
+    This property returns <K>true</K> if <A>digraph</A> is a core,
+    and <K>false</K> if it is not.<P/>
+
+    A digraph <C>D</C> is a <E>core</E> if and only if it has no proper subdigraphs <C>A</C>
+    such that there exists a homomorphism from <C>D</C>  to <C>A</C>. In other words,
+    a digraph <C>D</C> is a core if and only if every endomorphism on <C>D</C> is an
+    automorphism on <C>D</C>.
+
+    <Example><![CDATA[
+gap> D := CompleteDigraph(6);
+<immutable digraph with 6 vertices, 30 edges>
+gap> IsDigraphCore(D);
+true
+gap> D := DigraphSymmetricClosure(CycleDigraph(6));
+<immutable digraph with 6 vertices, 12 edges>
+gap> DigraphHomomorphism(D, CompleteDigraph(2));
+Transformation( [ 1, 2, 1, 2, 1, 2 ] )
+gap> IsDigraphCore(D);
+false
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/z-chap5.xml
+++ b/doc/z-chap5.xml
@@ -43,5 +43,10 @@
     <#Include Label="IsPlanarDigraph">
     <#Include Label="IsOuterPlanarDigraph">
   </Section>
+
+  <Section><Heading>Homomorphisms and transformations</Heading>
+    <#Include Label="IsDigraphCore">
+  </Section>
+
   
 </Chapter>

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -42,6 +42,7 @@ DeclareProperty("IsHamiltonianDigraph", IsDigraph);
 DeclareProperty("IsMeetSemilatticeDigraph", IsDigraph);
 DeclareProperty("IsJoinSemilatticeDigraph", IsDigraph);
 DeclareProperty("IsCycleDigraph", IsDigraph);
+DeclareProperty("IsDigraphCore", IsDigraph);
 
 DeclareOperation("DIGRAPHS_IsMeetJoinSemilatticeDigraph",
                  [IsHomogeneousList]);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -596,15 +596,16 @@ function(D)
   local hook, proper_endo_found, N;
 
   N := DigraphNrVertices(D);
-  if DigraphHasLoops(D) and N > 1 then
+  if (DigraphHasLoops(D) or IsEmptyDigraph(D)) and N > 1 then
     return false;
   elif IsCompleteDigraph(D) then
     return true;
-  elif IsBipartiteDigraph(D) and N > 2 then
+  elif IsSymmetricDigraph(D) and IsBipartiteDigraph(D) and N > 2 then
     return false;
   fi;
-  # The core of a digraph with loops is a vertex with a loop, and the core of a
-  # bipartite digraph is the complete digraph on 2 vertices.
+  # The core of a digraph with loops is a vertex with a loop, of an empty
+  # digraph is a vertex, and of a non-empty, symmetric bipartite digraph is the
+  # complete digraph on 2 vertices.
 
   proper_endo_found := false;
   hook := function(unneded_argument, T)
@@ -628,9 +629,5 @@ function(D)
                              [],                        # partial_map
                              fail,                      # colors1
                              fail);                     # colors2
-  if not proper_endo_found then
-    return true;
-  else
-    return false;
-  fi;
+  return not proper_endo_found;
 end);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -589,3 +589,48 @@ end);
 
 InstallMethod(IsHamiltonianDigraph, "for a digraph with hamiltonian path",
 [IsDigraph and HasHamiltonianPath], x -> HamiltonianPath(x) <> fail);
+
+InstallMethod(IsDigraphCore, "for a digraph",
+[IsDigraph],
+function(D)
+  local hook, proper_endo_found, N;
+
+  N := DigraphNrVertices(D);
+  if DigraphHasLoops(D) and N > 1 then
+    return false;
+  elif IsCompleteDigraph(D) then
+    return true;
+  elif IsBipartiteDigraph(D) and N > 2 then
+    return false;
+  fi;
+  # The core of a digraph with loops is a vertex with a loop, and the core of a
+  # bipartite digraph is the complete digraph on 2 vertices.
+
+  proper_endo_found := false;
+  hook := function(unneded_argument, T)
+    # the hook is required by HomomorphismDigraphsFinder to have two arguments,
+    # the 1st of which is user_param, which this method doesn't need.
+    if RankOfTransformation(T, [1 .. N]) < N then
+      proper_endo_found := true;
+      return true;
+    fi;
+    return false;
+  end;
+
+  HomomorphismDigraphsFinder(D,                         # D1
+                             D,                         # D2
+                             hook,                      # hook
+                             fail,                      # user_param
+                             infinity,                  # max results
+                             fail,                      # hint
+                             false,                     # injective
+                             DigraphVertices(D),        # image
+                             [],                        # partial_map
+                             fail,                      # colors1
+                             fail);                     # colors2
+  if not proper_endo_found then
+    return true;
+  else
+    return false;
+  fi;
+end);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -600,7 +600,7 @@ function(D)
     return false;
   elif IsCompleteDigraph(D) then
     return true;
-  elif IsSymmetricDigraph(D) and IsBipartiteDigraph(D) and N > 2 then
+  elif IsBipartiteDigraph(D) and IsSymmetricDigraph(D) and N > 2 then
     return false;
   fi;
   # The core of a digraph with loops is a vertex with a loop, of an empty

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1346,6 +1346,14 @@ gap> IsDigraphCore(D);
 false
 gap> D;
 <mutable digraph with 40 vertices, 80 edges>
+gap> D := EmptyDigraph(100000);
+<immutable digraph with 100000 vertices, 0 edges>
+gap> IsDigraphCore(D);
+false
+gap> D := EmptyDigraph(0);
+<immutable digraph with 0 vertices, 0 edges>
+gap> IsDigraphCore(D);
+true
 
 # IsPreorderDigraph and IsQuasiorderDigraph
 gap> gr := Digraph([[1], [1, 2], [1, 3], [1, 4], [1 .. 5], [1 .. 6],

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -1323,6 +1323,30 @@ gap> gr := Digraph([[2, 2], [1, 1]]);;
 gap> IsMultiDigraph(gr) and IsHamiltonianDigraph(gr);
 true
 
+# IsDigraphCore
+gap> D := CompleteDigraph(10);
+<immutable digraph with 10 vertices, 90 edges>
+gap> IsDigraphCore(D);
+true
+gap> D := JohnsonDigraph(8, 3);
+<immutable digraph with 56 vertices, 840 edges>
+gap> IsDigraphCore(D);
+true
+gap> D := CompleteBipartiteDigraph(500, 500);
+<immutable digraph with 1000 vertices, 500000 edges>
+gap> IsDigraphCore(D);
+false
+gap> D := PetersenGraph();
+<immutable digraph with 10 vertices, 30 edges>
+gap> IsDigraphCore(D);
+true
+gap> D := DigraphSymmetricClosure(CycleDigraph(IsMutableDigraph, 40));
+<mutable digraph with 40 vertices, 80 edges>
+gap> IsDigraphCore(D);
+false
+gap> D;
+<mutable digraph with 40 vertices, 80 edges>
+
 # IsPreorderDigraph and IsQuasiorderDigraph
 gap> gr := Digraph([[1], [1, 2], [1, 3], [1, 4], [1 .. 5], [1 .. 6],
 > [1, 2, 3, 4, 5, 7], [1, 8]]);;


### PR DESCRIPTION
This pull request adds a method for determining whether or not a digraph is a core. A digraph _D_ is a core if and only if every endomorphism on _D_ is an automorphism on _D_.