### PR TITLE
Display

### DIFF
--- a/gap/display.gi
+++ b/gap/display.gi
@@ -97,13 +97,8 @@ end);
 # AN's code
 
 if not IsBound(Splash) then  # This function is written by A. Egri-Nagy
-  if ARCH_IS_MAC_OS_X() then
-    BindGlobal("VizViewers", ["xpdf", "open", "evince", "okular", "gv"]);
-  elif ARCH_IS_UNIX() then
-    BindGlobal("VizViewers", ["xpdf", "xdg-open", "evince", "okular", "gv"]);
-  elif ARCH_IS_WINDOWS() then
-    BindGlobal("VizViewers", ["xpdf", "evince", "okular", "gv"]);
-  fi;
+  BindGlobal("VizViewers",
+             ["xpdf", "xdg-open", "open", "evince", "okular", "gv"]);
 
   BindGlobal("Splash",
   function(arg)

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -153,9 +153,21 @@ if not IsBound(Splash) then  # This function is written by A. Egri-Nagy
     # viewer
     if IsBound(opt.viewer) then
       viewer := opt.viewer;
+      if not IsString(viewer) then
+        ErrorNoReturn("the option `viewer` must be a string, not an ",
+                      TNAM_OBJ(viewer), ",");
+      elif Filename(DirectoriesSystemPrograms(), viewer) = fail then
+        ErrorNoReturn("the viewer \"", viewer, "\" specified in the option ",
+                      "`viewer` is not available,");
+      fi;
     else
       viewer := First(VizViewers, x ->
                       Filename(DirectoriesSystemPrograms(), x) <> fail);
+      if viewer = fail then
+        ErrorNoReturn("none of the default viewers ", VizViewers,
+                      " is available, please specify an available viewer",
+                      " in the options record component `viewer`,");
+      fi;
     fi;
 
     # type

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -205,7 +205,8 @@ node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
 gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := 1));
 Error, the option `viewer` must be a string, not an integer,
 gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := "asdfasfa"));
-Error, the viewer "asdfasfa" specified in the option `viewer` is not available,
+Error, the viewer "asdfasfa" specified in the option `viewer` is not available\
+,
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -204,8 +204,8 @@ node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
 # Splash
 gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := 1));
 Error, the option `viewer` must be a string, not an integer,
-gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := "shit"));
-Error, the viewer "shit" specified in the option `viewer` is not available,
+gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := "asdfasfa"));
+Error, the viewer "asdfasfa" specified in the option `viewer` is not available,
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -201,6 +201,12 @@ node [shape=Mrecord, height=0.5, fixedsize=true]ranksep=1;
 2 -> 1
 }
 
+# Splash
+gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := 1));
+Error, the option `viewer` must be a string, not an integer,
+gap> Splash(DotDigraph(RandomDigraph(10)), rec(viewer := "shit"));
+Error, the viewer "shit" specified in the option `viewer` is not available,
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(dot);


### PR DESCRIPTION
This PR improves the error messages in `Splash` if the specified, or none of the default, viewers is available. It also stops using the architecture to decide about the list of `VizViewers`.