### PR TITLE
Add DigraphCore method

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1467,12 +1467,12 @@ gap> HamiltonianPath(g);
     <Returns>A list of positive integers.</Returns>
     <Description>
       If <A>D</A> is a digraph, then <C>DigraphCore</C> returns a list of vertices
-      corresponding to the <C>core</C> of <A>D</A>. In particular, the subdigraph of <A>D</A>
-      induced by this list is isomorphic to the core of <A>D</A>.<P/>
+      corresponding to the <C>core</C> of <A>D</A>. In particular, the subdigraph
+      of <A>D</A> induced by this list is isomorphic to the core of <A>D</A>.<P/>
 
-    The <E>core</E> of a digraph <C>D</C> is the minimal subdigraph <E>C</E> of <C>D</C> which
-    is a homomorphic image of <C>D</C>. The core of a digraph <C>D</C> is unique up to
-    isomorphism.
+    The <E>core</E> of a digraph <C>D</C> is the minimal subdigraph <A>C</A> of
+    <C>D</C> which is a homomorphic image of <C>D</C>. The core of a digraph 
+    is unique up to isomorphism.
       <Example><![CDATA[
 gap> D := DigraphSymmetricClosure(CycleDigraph(8));
 <immutable digraph with 8 vertices, 16 edges>

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1461,6 +1461,35 @@ gap> HamiltonianPath(g);
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphCore">
+  <ManSection>
+    <Oper Name = "DigraphCore" Arg = "D"/>
+    <Returns>A list of positive integers.</Returns>
+    <Description>
+      If <A>D</A> is a digraph, then <C>DigraphCore</C> returns a list of vertices
+      corresponding to the <C>core</C> of <A>D</A>. In particular, the subdigraph of <A>D</A>
+      induced by this list is isomorphic to the core of <A>D</A>.<P/>
+
+    The <E>core</E> of a digraph <C>D</C> is the minimal subdigraph <E>C</E> of <C>D</C> which
+    is a homomorphic image of <C>D</C>. The core of a digraph <C>D</C> is unique up to
+    isomorphism.
+      <Example><![CDATA[
+gap> D := DigraphSymmetricClosure(CycleDigraph(8));
+<immutable digraph with 8 vertices, 16 edges>
+gap> DigraphCore(D);
+[ 1, 2 ]
+gap> D := PetersenGraph();
+<immutable digraph with 10 vertices, 30 edges>
+gap> DigraphCore(D);
+[ 1 .. 10 ]
+gap> D := Digraph([[3], [3], [4], [5], [2]]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> DigraphCore(D);
+[ 2, 3, 4, 5 ]]]></Example>
+    </Description>
+  </ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="MaximalAntiSymmetricSubdigraph">
 <ManSection>
   <Attr Name="MaximalAntiSymmetricSubdigraph" Arg="digraph"/>

--- a/doc/z-chap6.xml
+++ b/doc/z-chap6.xml
@@ -66,6 +66,7 @@ from} $E_a$ \emph{to} $E_b$. In this case we say that $E_a$ and $E_b$ are
     <#Include Label="DigraphGreedyColouring">
     <#Include Label="DigraphWelshPowellOrder">
     <#Include Label="ChromaticNumber">
+    <#Include Label="DigraphCore">
   </Section>
 
 </Chapter>

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -69,6 +69,8 @@ DeclareAttribute("CharacteristicPolynomial", IsDigraph);
 
 DeclareAttribute("DigraphAdjacencyFunction", IsDigraph);
 
+DeclareAttribute("DigraphCore", IsDigraph);
+
 DeclareAttribute("AdjacencyMatrix", IsDigraph);
 DeclareAttribute("BooleanAdjacencyMatrix", IsDigraph);
 DeclareOperation("ReducedDigraph", [IsDigraph]);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1706,8 +1706,9 @@ function(digraph)
   digraph := ReducedDigraph(digraph);  # isolated verts are not in core
   N       := DigraphNrVertices(digraph);
   if DigraphHasLoops(digraph) then
-    i := First(DigraphVertices(digraph), i -> i in OutNeighbours(digraph)[i]);
-    return [DigraphVertexLabels(digraph)[i]];
+    i := First(DigraphVertices(digraph),
+         i -> i in OutNeighboursOfVertex(digraph, i));
+    return [DigraphVertexLabel(digraph, i)];
   elif IsCompleteDigraph(digraph) then
     return DigraphVertexLabels(digraph);
   elif IsSymmetricDigraph(digraph) and IsBipartiteDigraph(digraph) then

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1719,13 +1719,12 @@ function(digraph)
     cores  := [];
     for comp in comps do
       D := InducedSubdigraph(digraph, comp);
-      N := DigraphNrVertices(D);
       D := InducedSubdigraph(D, DigraphCore(D));
       Add(cores, D);
     od;
-    L := Length(cores);
-    in_core := List([1 .. L], x -> true);
-    n := 1;
+    L       := Length(cores);
+    in_core := ListWithIdenticalEntries(L, true);
+    n       := 1;
     while n <= L do
       if n <> L then
         m := n + 1;
@@ -1746,9 +1745,7 @@ function(digraph)
     od;
     cores := ListBlist(cores, in_core);
     return Union(List(cores, DigraphVertexLabels));
-  fi;
-
-  if IsDigraphCore(digraph) then
+  elif IsDigraphCore(digraph) then
     return DigraphVertexLabels(digraph);
   fi;
 
@@ -1762,9 +1759,9 @@ function(digraph)
   end;
 
   hom      := [];
-  lo_var := lo(digraph);
+  lo_var   := lo(digraph);
   bottomup := lo_var;
-  N := DigraphNrVertices(digraph);
+  N        := DigraphNrVertices(digraph);
   topdown  := N;
 
   while topdown >= bottomup do
@@ -1781,8 +1778,7 @@ function(digraph)
                                fail);                     # colors2
 
     if Length(hom) = 1 then
-      image    := ImageSetOfTransformation(hom[1], N);
-      return DigraphVertexLabels(digraph){image};
+      return DigraphVertexLabels(digraph){ImageSetOfTransformation(hom[1], N)};
     fi;
 
     HomomorphismDigraphsFinder(digraph,                   # domain copy
@@ -1796,24 +1792,18 @@ function(digraph)
                                [],                        # partial_map
                                fail,                      # colors1
                                fail);                     # colors2
+
     if Length(hom) = 1 then
       image    := ImageSetOfTransformation(hom[1], N);
       digraph  := InducedSubdigraph(digraph, image);
       N        := DigraphNrVertices(digraph);
+      lo_var   := lo(digraph);
       Unbind(hom[1]);
-      lo_var := lo(digraph);
     fi;
 
-    if topdown - 1 < N then
-      topdown := topdown - 1;
-    else
-      topdown := N;
-    fi;
-    if bottomup + 1 > lo_var then
-      bottomup := bottomup + 1;
-    else
-      bottomup := lo_var;
-    fi;
+    topdown  := Minimum(topdown - 1, N);
+    bottomup := Maximum(bottomup + 1, lo_var);
+
   od;
   return DigraphVertexLabels(digraph);
 end);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1691,10 +1691,9 @@ InstallMethod(DigraphCore, "for a digraph",
 [IsDigraph],
 function(digraph)
   local N, lo, topdown, bottomup, hom, lo_var, image,
-  comps, comp, cores, G, vert_labels, D, in_core, n, m, L;
-  if not IsImmutableDigraph(digraph) then
-    digraph := DigraphImmutableCopy(digraph);
-  fi;
+  comps, comp, cores, D, in_core, n, m, L;
+  digraph := DigraphImmutableCopy(digraph);
+  # copy is necessary so can change vertex labels in function
   N := DigraphNrVertices(digraph);
   if IsEmptyDigraph(digraph) then
     if N >= 1 then
@@ -1703,17 +1702,18 @@ function(digraph)
       return [];
     fi;
   fi;
+  SetDigraphVertexLabels(digraph, [1 .. N]);
   digraph := ReducedDigraph(digraph);  # isolated verts are not in core
+  N       := DigraphNrVertices(digraph);
   if DigraphHasLoops(digraph) then
-    return DigraphLoops(digraph){[1]};
+    return [DigraphVertexLabels(digraph)[DigraphLoops(digraph)[1]]];
   elif not IsConnectedDigraph(digraph) then
-    comps := DigraphConnectedComponents(digraph).comps;
-    DigraphVertexLabels(digraph);
-    cores := [];
+    comps  := DigraphConnectedComponents(digraph).comps;
+    cores  := [];
     for comp in comps do
       D := InducedSubdigraph(digraph, comp);
-      D := InducedSubdigraph(D,
-           Positions(BlistList(DigraphVertexLabels(D), DigraphCore(D)), true));
+      N := DigraphNrVertices(D);
+      D := InducedSubdigraph(D, DigraphCore(D));
       Add(cores, D);
     od;
     L := Length(cores);
@@ -1738,15 +1738,11 @@ function(digraph)
       n := n + 1;
     od;
     cores := ListBlist(cores, in_core);
-    vert_labels := [];
-    for G in cores do
-      vert_labels := Concatenation(vert_labels, DigraphVertexLabels(G));
-    od;
-    return vert_labels;
+    return Union(List(cores, DigraphVertexLabels));
   elif IsCompleteDigraph(digraph) then
-    return [1 .. N];
+    return DigraphVertexLabels(digraph);
   elif IsSymmetricDigraph(digraph) and IsBipartiteDigraph(digraph) then
-    return DigraphEdges(digraph)[1];
+    return DigraphVertexLabels(digraph){DigraphEdges(digraph)[1]};
   fi;
 
   if IsDigraphCore(digraph) then

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1691,7 +1691,7 @@ InstallMethod(DigraphCore, "for a digraph",
 [IsDigraph],
 function(digraph)
   local N, lo, topdown, bottomup, hom, lo_var, image,
-  comps, comp, cores, D, in_core, n, m, L;
+  comps, comp, cores, D, in_core, n, m, L, i;
   digraph := DigraphImmutableCopy(digraph);
   # copy is necessary so can change vertex labels in function
   N := DigraphNrVertices(digraph);
@@ -1706,7 +1706,14 @@ function(digraph)
   digraph := ReducedDigraph(digraph);  # isolated verts are not in core
   N       := DigraphNrVertices(digraph);
   if DigraphHasLoops(digraph) then
-    return [DigraphVertexLabels(digraph)[DigraphLoops(digraph)[1]]];
+    i := First(DigraphVertices(digraph), i -> i in OutNeighbours(digraph)[i]);
+    return [DigraphVertexLabels(digraph)[i]];
+  elif IsCompleteDigraph(digraph) then
+    return DigraphVertexLabels(digraph);
+  elif IsSymmetricDigraph(digraph) and IsBipartiteDigraph(digraph) then
+    i := First(DigraphVertices(digraph), i -> OutDegreeOfVertex(digraph, i) > 0);
+    return DigraphVertexLabels(digraph){
+    [i, OutNeighboursOfVertex(digraph, i)[1]]};
   elif not IsConnectedDigraph(digraph) then
     comps  := DigraphConnectedComponents(digraph).comps;
     cores  := [];
@@ -1739,10 +1746,6 @@ function(digraph)
     od;
     cores := ListBlist(cores, in_core);
     return Union(List(cores, DigraphVertexLabels));
-  elif IsCompleteDigraph(digraph) then
-    return DigraphVertexLabels(digraph);
-  elif IsSymmetricDigraph(digraph) and IsBipartiteDigraph(digraph) then
-    return DigraphVertexLabels(digraph){DigraphEdges(digraph)[1]};
   fi;
 
   if IsDigraphCore(digraph) then

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1796,7 +1796,7 @@ gap> DigraphCore(D);
 gap> D := Digraph([[2], [1], [4, 5], [5], [4]]);
 <immutable digraph with 5 vertices, 6 edges>
 gap> DigraphCore(D);
-[ 3, 4, 5 ]
+[ 3 .. 5 ]
 gap> D := EmptyDigraph(0);
 <immutable digraph with 0 vertices, 0 edges>
 gap> DigraphCore(D);
@@ -1829,8 +1829,7 @@ true
 gap> D := DigraphDisjointUnion(D1, D2, M1);
 <immutable digraph with 29 vertices, 134 edges>
 gap> DigraphCore(D);
-[ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 
-  27, 28, 29 ]
+[ 8 .. 29 ]
 gap> IsDigraphCore(InducedSubdigraph(D, DigraphCore(D)));
 true
 gap> str := ".qb`hOAW@fAiG]g??aGD[TXAbjgWl^?fkG{~cA@p`e~EIRlHSxBFHx\\RJ@ERCYhVSoIDvIE?c?x_\
@@ -1843,7 +1842,19 @@ gap> DigraphCore(D);
 gap> D := Digraph([[2, 8], [3], [1], [5], [6], [7], [4], []]);
 <immutable digraph with 8 vertices, 8 edges>
 gap> DigraphCore(D);
-[ 1, 2, 3, 4, 5, 6, 7 ]
+[ 1 .. 7 ]
+gap> D := Digraph([[], [2]]);
+<immutable digraph with 2 vertices, 1 edge>
+gap> DigraphCore(D);
+[ 2 ]
+gap> D := DigraphDisjointUnion(EmptyDigraph(1), CompleteBipartiteDigraph(3, 3));
+<immutable digraph with 7 vertices, 18 edges>
+gap> DigraphCore(D);
+[ 2, 5 ]
+gap> D := DigraphFromDigraph6String("&IO?_@?A?CG??O?_G??");
+<immutable digraph with 10 vertices, 9 edges>
+gap> DigraphCore(D);
+[ 7 .. 9 ]
 
 # MaximalAntiSymmetricSubdigraph
 gap> MaximalAntiSymmetricSubdigraph(NullDigraph(0));

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1774,6 +1774,77 @@ gap> gr := DigraphAddEdges(DigraphAddVertex(CycleDigraph(600)),
 gap> HamiltonianPath(gr);
 fail
 
+# DigraphCore
+gap> D := Digraph([[3, 6], [1], [4], [5, 7], [1], [2, 7], [4, 1]]);
+<immutable digraph with 7 vertices, 11 edges>
+gap> DigraphCore(D);
+[ 1, 3, 4, 6, 7 ]
+gap> D := Digraph([[2, 3], [1, 3], [1, 2, 4], [1]]);
+<immutable digraph with 4 vertices, 8 edges>
+gap> DigraphCore(D);
+[ 1, 2, 3 ]
+gap> DigraphHomomorphism(D, InducedSubdigraph(D, DigraphCore(D)));
+Transformation( [ 1, 3, 2, 3 ] )
+gap> D := CompleteDigraph(10);
+<immutable digraph with 10 vertices, 90 edges>
+gap> DigraphCore(D);
+[ 1 .. 10 ]
+gap> D := Digraph([[2], [3], [4], [5], [6], [2]]);
+<immutable digraph with 6 vertices, 6 edges>
+gap> DigraphCore(D);
+[ 2, 3, 4, 5, 6 ]
+gap> D := Digraph([[2], [1], [4, 5], [5], [4]]);
+<immutable digraph with 5 vertices, 6 edges>
+gap> DigraphCore(D);
+[ 3, 4, 5 ]
+gap> D := EmptyDigraph(0);
+<immutable digraph with 0 vertices, 0 edges>
+gap> DigraphCore(D);
+[  ]
+gap> D := EmptyDigraph(1000);
+<immutable digraph with 1000 vertices, 0 edges>
+gap> DigraphCore(D);
+[ 1 ]
+gap> D := EmptyDigraph(IsMutableDigraph, 0);
+<mutable digraph with 0 vertices, 0 edges>
+gap> for i in [2 .. 15] do
+> DigraphDisjointUnion(D, CycleDigraph(i));
+> od;
+gap> DigraphCore(D);
+[ 1, 2, 3, 4, 5, 10, 11, 12, 13, 14, 21, 22, 23, 24, 25, 26, 27, 55, 56, 57, 
+  58, 59, 60, 61, 62, 63, 64, 65, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 
+  89, 90 ]
+gap> D1 := DigraphFromDigraph6String("&FJBWqNbXV?");
+<immutable digraph with 7 vertices, 24 edges>
+gap> IsDigraphCore(D1);
+true
+gap> D2 := DigraphFromDigraph6String("&FJbWqNbWu?");
+<immutable digraph with 7 vertices, 24 edges>
+gap> IsDigraphCore(D2);
+true
+gap> M1 := DigraphMycielskian(D1);
+<immutable digraph with 15 vertices, 86 edges>
+gap> IsDigraphCore(M1);
+true
+gap> D := DigraphDisjointUnion(D1, D2, M1);
+<immutable digraph with 29 vertices, 134 edges>
+gap> DigraphCore(D);
+[ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 
+  27, 28, 29 ]
+gap> IsDigraphCore(InducedSubdigraph(D, DigraphCore(D)));
+true
+gap> str := ".qb`hOAW@fAiG]g??aGD[TXAbjgWl^?fkG{~cA@p`e~EIRlHSxBFHx\\RJ@ERCYhVSoIDvIE?c?x_\
+> YBJg?IWmoN_djWMyKnckGkdMqBsQMBWsBaK?\\BBFWOvY[vcHp]N";;
+gap> D := DigraphFromDiSparse6String(str);
+<immutable digraph with 50 vertices, 79 edges>
+gap> DigraphCore(D);
+[ 1, 2, 4, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 25, 26, 
+  29, 30, 32, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 46, 47, 48, 49, 50 ]
+gap> D := Digraph([[2, 8], [3], [1], [5], [6], [7], [4], []]);
+<immutable digraph with 8 vertices, 8 edges>
+gap> DigraphCore(D);
+[ 1, 2, 3, 4, 5, 6, 7 ]
+
 # MaximalAntiSymmetricSubdigraph
 gap> MaximalAntiSymmetricSubdigraph(NullDigraph(0));
 <immutable digraph with 0 vertices, 0 edges>

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1855,6 +1855,13 @@ gap> D := DigraphFromDigraph6String("&IO?_@?A?CG??O?_G??");
 <immutable digraph with 10 vertices, 9 edges>
 gap> DigraphCore(D);
 [ 7 .. 9 ]
+gap> D := CycleDigraph(IsMutableDigraph, 2);
+<mutable digraph with 2 vertices, 2 edges>
+gap> for i in [1 .. 9] do
+>      DigraphDisjointUnion(D, D);
+>    od;
+gap> DigraphCore(D);
+[ 1, 2 ]
 
 # MaximalAntiSymmetricSubdigraph
 gap> MaximalAntiSymmetricSubdigraph(NullDigraph(0));


### PR DESCRIPTION
This pull request adds a method `DigraphCore`, which takes a digraph and returns its core.

The core of a digraph _D_ is the (unique up to isomorphism) minimal subdigraph which is a homomorphic image of _D_.

The method works by searching for endomorphisms of the argument digraph, alternating between looking for ones of the smallest and largest possible rank. If one of the smallest possible rank is found, then the procedure stops. If one of the largest possible rank is found, then unnecessary parts of the digraph are removed from consideration.

In the case where the digraph is non-connected, the method computes the core of each connected component and then combines them in the minimal possible way, rather than searching for the core of the digraph as a whole. This works significantly faster on the disjoint union of cycle digraphs in the tests.