### PR TITLE
Add NrSpanningTrees attribute

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1381,7 +1381,7 @@ gap> OutNeighbours(sym);
     See <Ref Attr="OutDegrees"/> for more information.
     <Example><![CDATA[
 gap> gr := Digraph([[1, 2, 3], [4], [1, 3, 4], []]);
-<immutable digraph with 4 vertices, 6 edges>
+<immutable digraph with 4 vertices, 7 edges>
 gap> PrintArray(DegreeMatrix(gr));
 [ [  3,  0,  0,  0 ],
   [  0,  1,  0,  0 ],

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1367,6 +1367,91 @@ gap> OutNeighbours(sym);
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DegreeMatrix">
+<ManSection>
+  <Attr Name="DegreeMatrix" Arg="digraph"/>
+  <Returns>A square matrix of non-negative integers.</Returns>
+  <Description>
+    This function returns the outdegree matrix <C>mat</C> of the digraph
+    <A>digraph</A>. The value of the <C>i</C>th diagonal matrix entry is the
+    outdegree of the vertex <C>i</C> in <A>digraph</A>. All off-diagonal entries 
+    are <C>0</C>.
+    If <A>digraph</A> has no vertices, then the empty list is returned. <P/>
+
+    See <Ref Attr="OutDegrees"/> for more information.
+    <Example><![CDATA[
+gap> gr := Digraph([[1, 2, 3], [4], [1, 3, 4], []]);
+<immutable digraph with 4 vertices, 6 edges>
+gap> PrintArray(DegreeMatrix(gr));
+[ [  3,  0,  0,  0 ],
+  [  0,  1,  0,  0 ],
+  [  0,  0,  3,  0 ],
+  [  0,  0,  0,  0 ] ]
+gap> gr := CycleDigraph(5);;
+gap> PrintArray(DegreeMatrix(gr));
+[ [  1,  0,  0,  0,  0 ],
+  [  0,  1,  0,  0,  0 ],
+  [  0,  0,  1,  0,  0 ],
+  [  0,  0,  0,  1,  0 ],
+  [  0,  0,  0,  0,  1 ] ]
+gap> DegreeMatrix(EmptyDigraph(0));
+[  ]
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="LaplacianMatrix">
+<ManSection>
+  <Attr Name="LaplacianMatrix" Arg="digraph"/>
+  <Returns>A square matrix of integers.</Returns>
+  <Description>
+    This function returns the outdegree Laplacian matrix <C>mat</C> of the digraph
+    <A>digraph</A>. The outdegree Laplacian matrix is defined as <C>DegreeMatrix(digraph) - AdjacencyMatrix(digraph)</C>.
+    If <A>digraph</A> has no vertices, then the empty list is returned. <P/>
+
+    See <Ref Attr="DegreeMatrix"/> and <Ref Attr="AdjacencyMatrix"/> for more information.
+    <Example><![CDATA[
+gap> gr := Digraph([[1, 2, 3], [4], [1, 3, 4], []]);
+<immutable digraph with 4 vertices, 7 edges>
+gap> PrintArray(LaplacianMatrix(gr));
+[ [   2,  -1,  -1,   0 ],
+  [   0,   1,   0,  -1 ],
+  [  -1,   0,   2,  -1 ],
+  [   0,   0,   0,   0 ] ]
+gap> LaplacianMatrix(EmptyDigraph(0));
+[  ]
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="NrSpanningTrees">
+<ManSection>
+  <Attr Name="NrSpanningTrees" Arg="digraph"/>
+  <Returns>An integer.</Returns>
+  <Description>
+    Returns the number of spanning trees of the symmetric digraph <A>digraph</A>.
+    <C>NrSpanningTrees</C> will return an error if <A>digraph</A> is not a
+    symmetric digraph. <P/> 
+
+    See <Ref Prop="IsSymmetricDigraph"/> and <Ref Oper="IsUndirectedSpanningTree" /> 
+    for more information. 
+    <Example><![CDATA[
+gap> gr := CompleteDigraph(5);
+<immutable digraph with 5 vertices, 20 edges>
+gap> NrSpanningTrees(gr);
+125
+gap> gr := DigraphSymmetricClosure(CycleDigraph(24));;
+gap> NrSpanningTrees(gr);
+24
+gap> NrSpanningTrees(EmptyDigraph(0));
+0
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="UndirectedSpanningTree">
 <ManSection>
   <Attr Name="UndirectedSpanningTree" Arg="digraph"/>

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -33,6 +33,8 @@
     <#Include Label="InNeighboursOfVertex">
     <#Include Label="DigraphLoops">
     <#Include Label="PartialOrderDigraphMeetOfVertices">
+    <#Include Label="DegreeMatrix">
+    <#Include Label="LaplacianMatrix">
   </Section>
 
   <Section><Heading>Reachability and connectivity</Heading>
@@ -63,6 +65,7 @@
     <#Include Label="DigraphDegeneracy">
     <#Include Label="DigraphDegeneracyOrdering">
     <#Include Label="HamiltonianPath">
+    <#Include Label="NrSpanningTrees">
   </Section>
 
   <Section><Heading>Cayley graphs of groups</Heading>

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -81,6 +81,10 @@ DeclareOperation("MaximalSymmetricSubdigraphWithoutLoops", [IsDigraph]);
 DeclareAttribute("MaximalSymmetricSubdigraphWithoutLoopsAttr", IsDigraph);
 DeclareOperation("DIGRAPHS_MaximalSymmetricSubdigraph", [IsDigraph, IsBool]);
 
+DeclareAttribute("DegreeMatrix", IsDigraph);
+DeclareAttribute("LaplacianMatrix", IsDigraph);
+DeclareAttribute("NrSpanningTrees", IsDigraph);
+
 DeclareOperation("UndirectedSpanningTree", [IsDigraph]);
 DeclareAttribute("UndirectedSpanningTreeAttr", IsDigraph);
 DeclareOperation("UndirectedSpanningForest", [IsDigraph]);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1585,6 +1585,38 @@ end);
 InstallMethod(MaximalSymmetricSubdigraphAttr, "for an immutable digraph",
 [IsImmutableDigraph], MaximalSymmetricSubdigraph);
 
+InstallMethod(DegreeMatrix, "for a digraph", [IsDigraph],
+function(D)
+  if DigraphNrVertices(D) = 0 then
+    return [];
+  fi;
+  return DiagonalMat(OutDegrees(D));
+end);
+
+InstallMethod(LaplacianMatrix, "for a digraph", [IsDigraph],
+function(D)
+  return DegreeMatrix(D) - AdjacencyMatrix(D);
+end);
+
+InstallMethod(NrSpanningTrees, "for a digraph", [IsDigraph],
+function(D)
+  local mat, n;
+  if not IsSymmetricDigraph(D) then
+    ErrorNoReturn("the argument <D> must be a symmetric digraph,");
+  fi;
+
+  n := DigraphNrVertices(D);
+  if n = 0 then
+    return 0;
+  elif n = 1 then
+    return 1;
+  fi;
+
+  mat := LaplacianMatrix(D);
+  mat := mat{[1 .. n - 1]}{[1 .. n - 1]};
+  return Determinant(mat);
+end);
+
 InstallMethod(UndirectedSpanningForestAttr, [IsImmutableDigraph],
 UndirectedSpanningForest);
 

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1482,6 +1482,48 @@ gap> ChromaticNumber(a);
 gap> ChromaticNumber(b);
 49
 
+#  DegreeMatrix
+gap> gr := Digraph([[2, 3, 4], [2, 5], [1, 5, 4], [1], [1, 1, 2, 4]]);;
+gap> DegreeMatrix(gr);
+[ [ 3, 0, 0, 0, 0 ], [ 0, 2, 0, 0, 0 ], [ 0, 0, 3, 0, 0 ], [ 0, 0, 0, 1, 0 ], 
+  [ 0, 0, 0, 0, 4 ] ]
+gap> DegreeMatrix(Digraph([]));
+[  ]
+gap> DegreeMatrix(Digraph([[]]));
+[ [ 0 ] ]
+gap> DegreeMatrix(Digraph([[1]]));
+[ [ 1 ] ]
+
+#  LaplacianMatrix
+gap> gr := Digraph([[2, 3, 4], [2, 5], [1, 5, 4], [1], [1, 1, 2, 4]]);;
+gap> LaplacianMatrix(gr);
+[ [ 3, -1, -1, -1, 0 ], [ 0, 1, 0, 0, -1 ], [ -1, 0, 3, -1, -1 ], 
+  [ -1, 0, 0, 1, 0 ], [ -2, -1, 0, -1, 4 ] ]
+gap> LaplacianMatrix(Digraph([]));
+[  ]
+gap> LaplacianMatrix(Digraph([[1]]));
+[ [ 0 ] ]
+gap> LaplacianMatrix(CycleDigraph(5));
+[ [ 1, -1, 0, 0, 0 ], [ 0, 1, -1, 0, 0 ], [ 0, 0, 1, -1, 0 ], 
+  [ 0, 0, 0, 1, -1 ], [ -1, 0, 0, 0, 1 ] ]
+gap> LaplacianMatrix(CompleteDigraph(5));
+[ [ 4, -1, -1, -1, -1 ], [ -1, 4, -1, -1, -1 ], [ -1, -1, 4, -1, -1 ], 
+  [ -1, -1, -1, 4, -1 ], [ -1, -1, -1, -1, 4 ] ]
+
+#  NrSpanningTrees
+gap> NrSpanningTrees(CompleteDigraph(5));
+125
+gap> NrSpanningTrees(CycleDigraph(5));
+Error, the argument <D> must be a symmetric digraph,
+gap> NrSpanningTrees(DigraphSymmetricClosure(CycleDigraph(5)));
+5
+gap> NrSpanningTrees(Digraph([]));
+0
+gap> NrSpanningTrees(Digraph([[1]]));
+1
+gap> NrSpanningTrees(Digraph([[2, 3, 4], [1, 5], [1, 5], [1, 5], [2, 3, 4]]));
+12
+
 #  UndirectedSpanningTree and UndirectedSpanningForest
 gap> gr := EmptyDigraph(0);
 <immutable digraph with 0 vertices, 0 edges>


### PR DESCRIPTION
This PR adds the following attributes
- `DegreeMatrix` - for a digraph, returns the diagonal matrix whose `i`th diagonal entry is the outdegree of vertex `i`.
- `LaplacianMatrix` - for a digraph, returns the difference of the `DegreeMatrix` and `AdjacencyMatrix` of the digraph.
- `NrSpanningTrees` - for a symmetric digraph, returns the number of spanning trees of that digraph. Calculated by computing the determinant of `LaplacianMatrix` with a single row and column removed. Time complexity `O(n^3)`.

See Issue #197.