### PR TITLE
Add DigraphCartesianProduct and DigraphDirectProduct methods

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1785,15 +1785,18 @@ gap> ChromaticNumber(D);
     <C>DigraphCartesianProductProjections</C> returns a list <C>proj</C>
     such that <C>proj[i]</C> is the projection onto the <C>i</C>-th
     coordinate of the product.
+    <P/>
 
     A projection is an idempotent endomorphism of <A>digraph</A>. If
     <C>gr1, gr2, ...</C> are all loopless digraphs, then the restriction
     of <A>digraph</A> onto the image of <C>proj[i]</C> is isomorphic to
     <C>gr_i</C>.
+    <P/>
 
-    Currently this attribute is only set upon creating a graph via
+    Currently this attribute is only set upon creating a digraph via
     <C>DigraphCartesianProduct</C> and there is no way of calculating
-    it for general graphs.
+    it for other digraphs.
+    <P/>
 
     For more information see <Ref Oper="DigraphCartesianProduct"/> 
 
@@ -1826,14 +1829,17 @@ true
     <C>DigraphDirectProductProjections</C> returns a list <C>proj</C>
     such that <C>proj[i]</C> is the projection onto the <C>i</C>-th
     coordinate of the product.
+    <P/>
 
     A projection is an idempotent endomorphism of <A>digraph</A>. If
     <C>gr1, gr2, ...</C> are all loopless digraphs, then the projection 
     of <A>digraph</A> via <C>proj[i]</C> is isomorphic to <C>gr_i</C>.
+    <P/>
 
-    Currently this attribute is only set upon creating a graph via
+    Currently this attribute is only set upon creating a digraph via
     <C>DigraphDirectProduct</C> and there is no way of calculating
-    it for general graphs.
+    it for other digraphs.
+    <P/>
 
     For more information see <Ref Oper="DigraphDirectProduct"/> 
 

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1774,3 +1774,83 @@ gap> ChromaticNumber(D);
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="DigraphCartesianProductProjections">
+<ManSection>
+  <Attr Name="DigraphCartesianProductProjections" Arg="digraph"/>
+  <Returns>A list of transformations.</Returns>
+  <Description>
+    If <A>digraph</A> is a Cartesian product digraph, 
+    <C>digraph = DigraphCartesianProduct(gr_1, gr_2, ... )</C>, then
+    <C>DigraphCartesianProductProjections</C> returns a list <C>proj</C>
+    such that <C>proj[i]</C> is the projection onto the <C>i</C>-th
+    coordinate of the product.
+
+    A projection is an idempotent endomorphism of <A>digraph</A>. If
+    <C>gr1, gr2, ...</C> are all loopless digraphs, then the restriction
+    of <A>digraph</A> onto the image of <C>proj[i]</C> is isomorphic to
+    <C>gr_i</C>.
+
+    Currently this attribute is only set upon creating a graph via
+    <C>DigraphCartesianProduct</C> and there is no way of calculating
+    it for general graphs.
+
+    For more information see <Ref Oper="DigraphCartesianProduct"/> 
+
+    <Example><![CDATA[
+gap> D := DigraphCartesianProduct(ChainDigraph(3), CycleDigraph(4),
+> Digraph([[2], [2]]));;
+gap> HasDigraphCartesianProductProjections(D);
+true
+gap> proj := DigraphCartesianProductProjections(D);; Length(proj);
+3
+gap> IsIdempotent(proj[2]);
+true
+gap> RankOfTransformation(proj[3]);
+2
+gap> S := ImageSetOfTransformation(proj[2]);;
+gap> IsIsomorphicDigraph(CycleDigraph(4), InducedSubdigraph(D, S));
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphDirectProductProjections">
+<ManSection>
+  <Attr Name="DigraphDirectProductProjections" Arg="digraph"/>
+  <Returns>A list of transformations.</Returns>
+  <Description>
+    If <A>digraph</A> is a direct product digraph, 
+    <C>digraph = DigraphDirectProduct(gr_1, gr_2, ... )</C>, then
+    <C>DigraphDirectProductProjections</C> returns a list <C>proj</C>
+    such that <C>proj[i]</C> is the projection onto the <C>i</C>-th
+    coordinate of the product.
+
+    A projection is an idempotent endomorphism of <A>digraph</A>. If
+    <C>gr1, gr2, ...</C> are all loopless digraphs, then the projection 
+    of <A>digraph</A> via <C>proj[i]</C> is isomorphic to <C>gr_i</C>.
+
+    Currently this attribute is only set upon creating a graph via
+    <C>DigraphDirectProduct</C> and there is no way of calculating
+    it for general graphs.
+
+    For more information see <Ref Oper="DigraphDirectProduct"/> 
+
+    <Example><![CDATA[
+gap> D := DigraphDirectProduct(ChainDigraph(3), CycleDigraph(4),
+> Digraph([[2], [2]]));;
+gap> HasDigraphDirectProductProjections(D);
+true
+gap> proj := DigraphDirectProductProjections(D);; Length(proj);
+3
+gap> IsIdempotent(proj[2]);
+true
+gap> RankOfTransformation(proj[3]);
+2
+gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));; gap> IsIsomorphicDigraph(CycleDigraph(4), P);
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1788,14 +1788,14 @@ gap> ChromaticNumber(D);
     <P/>
 
     A projection is an idempotent endomorphism of <A>digraph</A>. If
-    <C>gr1, gr2, ...</C> are all loopless digraphs, then the restriction
-    of <A>digraph</A> onto the image of <C>proj[i]</C> is isomorphic to
-    <C>gr_i</C>.
+    <C>gr1, gr2, ...</C> are all loopless digraphs, then the induced 
+    subdigraph of <A>digraph</A> on the image of <C>proj[i]</C> is 
+    isomorphic to <C>gr_i</C>.
     <P/>
 
-    Currently this attribute is only set upon creating a digraph via
-    <C>DigraphCartesianProduct</C> and there is no way of calculating
-    it for other digraphs.
+    Currently this attribute is only set upon creating an immutable 
+    digraph via <C>DigraphCartesianProduct</C> and there is no way 
+    of calculating it for other digraphs.
     <P/>
 
     For more information see <Ref Oper="DigraphCartesianProduct"/> 
@@ -1832,13 +1832,13 @@ true
     <P/>
 
     A projection is an idempotent endomorphism of <A>digraph</A>. If
-    <C>gr1, gr2, ...</C> are all loopless digraphs, then the projection 
-    of <A>digraph</A> via <C>proj[i]</C> is isomorphic to <C>gr_i</C>.
+    <C>gr1, gr2, ...</C> are all loopless digraphs, then the image 
+    of <A>digraph</A> under <C>proj[i]</C> is isomorphic to <C>gr_i</C>.
     <P/>
 
-    Currently this attribute is only set upon creating a digraph via
-    <C>DigraphDirectProduct</C> and there is no way of calculating
-    it for other digraphs.
+    Currently this attribute is only set upon creating an immutable
+    digraph via <C>DigraphDirectProduct</C> and there is no way of 
+    calculating it for other digraphs.
     <P/>
 
     For more information see <Ref Oper="DigraphDirectProduct"/> 

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -1848,7 +1848,9 @@ gap> IsIdempotent(proj[2]);
 true
 gap> RankOfTransformation(proj[3]);
 2
-gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));; gap> IsIsomorphicDigraph(CycleDigraph(4), P);
+gap> P := DigraphRemoveAllMultipleEdges(
+> ReducedDigraph(OnDigraphs(D, proj[2])));; 
+gap> IsIsomorphicDigraph(CycleDigraph(4), P);
 true
 ]]></Example>
   </Description>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -962,6 +962,96 @@ gap> DigraphJoin(gr, gr2);
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="DigraphCartesianProduct">
+<ManSection>
+  <Func Name="DigraphCartesianProduct" Arg="gr1, gr2, ..." Label="for an arbitrary 
+   number of digraphs"/>
+  <Func Name="DigraphCartesianProduct" Arg="list" Label="for a list of digraphs"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    In the first form, if <A>gr1</A>, <A>gr2</A>, etc. are digraphs, then
+    <C>DigraphCartesianProduct</C> returns their Cartesian product.
+
+    In the second form, if <A>list</A> is a non-empty list of digraphs,
+    then <C>DigraphCartesianProduct</C> returns the Cartesian product of 
+    the digraphs contained in the list. <P/>
+
+    The Cartesian product of two digraphs <C>G</C>, <C>H</C> is a digraph with 
+    vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> and there
+    is an edge connecting <C>[u, u']</C> with <C>[v, v']</C> iff <C> u = v </C> 
+    and <C>u'</C> is connected to <C>v'</C> in <C>H</C> or <C> u' = v'</C> and 
+    <C>u</C> is connected to <C>v</C> in <C>G</C>.
+ 
+    As the Cartesian product is associative, the Cartesian product of a collection 
+    of digraphs <A>gr1</A>, <A>gr2</A>, <C>...</C> is computed in the obvious 
+    fashion. 
+
+    <P/>
+
+    Note that previously set <Ref Oper="DigraphVertexLabels"/> will be lost.
+
+<Example><![CDATA[
+gap> gr := ChainDigraph(4);
+<immutable digraph with 4 vertices, 3 edges>
+gap> gr2 := CycleDigraph(3);
+<immutable digraph with 3 vertices, 3 edges>
+gap> gr3 := DigraphCartesianProduct(gr, gr2);
+<immutable digraph with 12 vertices, 21 edges>
+gap> IsIsomorphicDigraph(gr3, 
+> Digraph([[2, 5], [3, 6], [4, 7], [8], 
+>          [6, 9], [7, 10], [8, 11], [12],
+>          [10, 1], [11, 2], [12, 3], [4]]));
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphDirectProduct">
+<ManSection>
+  <Func Name="DigraphDirectProduct" Arg="gr1, gr2, ..." Label="for an arbitrary 
+   number of digraphs"/>
+  <Func Name="DigraphDirectProduct" Arg="list" Label="for a list of digraphs"/>
+  <Returns>A digraph.</Returns>
+  <Description>
+    In the first form, if <A>gr1</A>, <A>gr2</A>, etc. are digraphs, then
+    <C>DigraphDirectProduct</C> returns their direct product.
+
+    In the second form, if <A>list</A> is a non-empty list of digraphs,
+    then <C>DigraphDirectProduct</C> returns the direct product of 
+    the digraphs contained in the list. <P/>
+
+    The direct product of two digraphs <C>G</C>, <C>H</C> is a digraph with 
+    vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> and there
+    is an edge connecting <C>[u, u']</C> with <C>[v, v']</C> iff <C>u</C> is
+    connected to <C>v</C> in <C>G</C> and <C>u'</C> is connected to <C>v'</C> 
+    in <C>H</C>.
+ 
+    As the direct product is associative, the direct product of a collection 
+    of digraphs <A>gr1</A>, <A>gr2</A>, <C>...</C> is computed in the obvious 
+    fashion. 
+
+    <P/>
+
+    Note that previously set <Ref Oper="DigraphVertexLabels"/> will be lost.
+
+<Example><![CDATA[
+gap> gr := ChainDigraph(4);
+<immutable digraph with 4 vertices, 3 edges>
+gap> gr2 := CycleDigraph(3);
+<immutable digraph with 3 vertices, 3 edges>
+gap> gr3 := DigraphDirectProduct(gr, gr2);
+<immutable digraph with 12 vertices, 9 edges>
+gap> IsIsomorphicDigraph(gr3, 
+> Digraph([[6], [7], [8], [], 
+>          [10], [11], [12], [],
+>          [2], [3], [4], []]));
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="IsReachable">
 <ManSection>
   <Oper Name="IsReachable" Arg="digraph, u, v"/>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -965,27 +965,32 @@ gap> DigraphJoin(gr, gr2);
 <#GAPDoc Label="DigraphCartesianProduct">
 <ManSection>
   <Func Name="DigraphCartesianProduct" Arg="gr1, gr2, ..." Label="for an arbitrary 
-   number of digraphs"/>
+   non-zero number of digraphs"/>
   <Func Name="DigraphCartesianProduct" Arg="list" Label="for a list of digraphs"/>
   <Returns>A digraph.</Returns>
   <Description>
     In the first form, if <A>gr1</A>, <A>gr2</A>, etc. are digraphs, then
     <C>DigraphCartesianProduct</C> returns their Cartesian product.
+    <P/>
 
     In the second form, if <A>list</A> is a non-empty list of digraphs,
     then <C>DigraphCartesianProduct</C> returns the Cartesian product of 
-    the digraphs contained in the list. <P/>
-
-    The Cartesian product of two digraphs <C>G</C>, <C>H</C> is a digraph with 
-    vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> and there
-    is an edge connecting <C>[u, u']</C> with <C>[v, v']</C> iff <C> u = v </C> 
-    and <C>u'</C> is connected to <C>v'</C> in <C>H</C> or <C> u' = v'</C> and 
-    <C>u</C> is connected to <C>v</C> in <C>G</C>.
+    the digraphs contained in the list.
+    <P/>
  
+    Mathematically, the Cartesian product of two digraphs <C>G</C>, <C>H</C> is a 
+    digraph with vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> 
+    such that there is an edge from <C>[u, u']</C> to <C>[v, v']</C> iff <C> u = v </C> 
+    and there is an edge from <C>u'</C> to <C>v'</C> in <C>H</C> or 
+    <C> u' = v'</C> and there is an edge from <C>u</C> to <C>v</C> in <C>G</C>.
+    Due to technical reasons, the digraph returned by <C>DigraphCartesianProduct</C> has 
+    vertex set <C>[1 .. DigraphNrVertices(G)*DigraphNrVertices(H)]</C> instead. The vertex
+    pair can be somewhat regained by using <Ref Attr="DigraphCartesianProductProjections"/>.
+    <P/>
+
     As the Cartesian product is associative, the Cartesian product of a collection 
     of digraphs <A>gr1</A>, <A>gr2</A>, <C>...</C> is computed in the obvious 
     fashion. 
-
     <P/>
 
     Note that previously set <Ref Oper="DigraphVertexLabels"/> will be lost.
@@ -1010,27 +1015,31 @@ true
 <#GAPDoc Label="DigraphDirectProduct">
 <ManSection>
   <Func Name="DigraphDirectProduct" Arg="gr1, gr2, ..." Label="for an arbitrary 
-   number of digraphs"/>
+   non-zero number of digraphs"/>
   <Func Name="DigraphDirectProduct" Arg="list" Label="for a list of digraphs"/>
   <Returns>A digraph.</Returns>
   <Description>
     In the first form, if <A>gr1</A>, <A>gr2</A>, etc. are digraphs, then
     <C>DigraphDirectProduct</C> returns their direct product.
+    <P/>
 
     In the second form, if <A>list</A> is a non-empty list of digraphs,
     then <C>DigraphDirectProduct</C> returns the direct product of 
-    the digraphs contained in the list. <P/>
+    the digraphs contained in the list.
+    <P/>
 
-    The direct product of two digraphs <C>G</C>, <C>H</C> is a digraph with 
-    vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> and there
-    is an edge connecting <C>[u, u']</C> with <C>[v, v']</C> iff <C>u</C> is
-    connected to <C>v</C> in <C>G</C> and <C>u'</C> is connected to <C>v'</C> 
-    in <C>H</C>.
+    Mathematically, the direct product of two digraphs <C>G</C>, <C>H</C> is a 
+    digraph with vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> 
+    such that there is an edge from <C>[u, u']</C> to <C>[v, v']</C> iff there is an edge from
+    <C>u</C> to <C>v</C> in <C>G</C> and an edge from <C>u'</C> to <C>v'</C> in <C>H</C>. 
+    Due to technical reasons, the digraph returned by <C>DigraphDirectProduct</C> has 
+    vertex set <C>[1 .. DigraphNrVertices(G)*DigraphNrVertices(H)]</C> instead. The vertex
+    pair can be somewhat regained by using <Ref Attr="DigraphDirectProductProjections"/>.
+    <P/>
  
     As the direct product is associative, the direct product of a collection 
     of digraphs <A>gr1</A>, <A>gr2</A>, <C>...</C> is computed in the obvious 
     fashion. 
-
     <P/>
 
     Note that previously set <Ref Oper="DigraphVertexLabels"/> will be lost.

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -992,9 +992,9 @@ gap> DigraphJoin(gr, gr2);
 
 <Example><![CDATA[
 gap> gr := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> gr2 := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> gr3 := DigraphCartesianProduct(gr, gr2);
 <immutable digraph with 12 vertices, 21 edges>
 gap> IsIsomorphicDigraph(gr3, 
@@ -1037,9 +1037,9 @@ true
 
 <Example><![CDATA[
 gap> gr := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> gr2 := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> gr3 := DigraphDirectProduct(gr, gr2);
 <immutable digraph with 12 vertices, 9 edges>
 gap> IsIsomorphicDigraph(gr3, 

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -970,12 +970,12 @@ gap> DigraphJoin(gr, gr2);
   <Returns>A digraph.</Returns>
   <Description>
     In the first form, if <A>gr1</A>, <A>gr2</A>, etc. are digraphs, then
-    <C>DigraphCartesianProduct</C> returns their Cartesian product.
+    <C>DigraphCartesianProduct</C> returns a digraph isomorphic to their Cartesian product.
     <P/>
 
     In the second form, if <A>list</A> is a non-empty list of digraphs,
-    then <C>DigraphCartesianProduct</C> returns the Cartesian product of 
-    the digraphs contained in the list.
+    then <C>DigraphCartesianProduct</C> returns a digraph isomorphic to the 
+    Cartesian product of the digraphs contained in the list.
     <P/>
  
     Mathematically, the Cartesian product of two digraphs <C>G</C>, <C>H</C> is a 
@@ -983,17 +983,22 @@ gap> DigraphJoin(gr, gr2);
     such that there is an edge from <C>[u, u']</C> to <C>[v, v']</C> iff <C> u = v </C> 
     and there is an edge from <C>u'</C> to <C>v'</C> in <C>H</C> or 
     <C> u' = v'</C> and there is an edge from <C>u</C> to <C>v</C> in <C>G</C>.
-    Due to technical reasons, the digraph returned by <C>DigraphCartesianProduct</C> has 
-    vertex set <C>[1 .. DigraphNrVertices(G)*DigraphNrVertices(H)]</C> instead. The vertex
-    pair can be somewhat regained by using <Ref Attr="DigraphCartesianProductProjections"/>.
+    <P/>
+
+    Due to technical reasons, the digraph <C>D</C> returned by <C>DigraphCartesianProduct</C> has 
+    vertex set <C>[1 .. DigraphNrVertices(G)*DigraphNrVertices(H)]</C> instead, and the 
+    exact method of encoding pairs of vertices into integers is implementation specific.
+    The original vertex pair can be somewhat regained by using 
+    <Ref Attr="DigraphCartesianProductProjections"/>. In addition <Ref Oper="DigraphVertexLabels"/>
+    are preserved - if vertex pair <C>[u,u']</C> was encoded as <C>i</C> then the vertex label of 
+    <C>i</C> will be the pair of vertex labels of <C>u</C> and <C>u'</C> i.e. 
+    <C>DigraphVertexLabel(D,i) = [DigraphVertexLabel(G,u), DigraphVertexLabel(H,u')]</C>.
     <P/>
 
     As the Cartesian product is associative, the Cartesian product of a collection 
     of digraphs <A>gr1</A>, <A>gr2</A>, <C>...</C> is computed in the obvious 
     fashion. 
     <P/>
-
-    Note that previously set <Ref Oper="DigraphVertexLabels"/> will be lost.
 
 <Example><![CDATA[
 gap> gr := ChainDigraph(4);
@@ -1020,11 +1025,11 @@ true
   <Returns>A digraph.</Returns>
   <Description>
     In the first form, if <A>gr1</A>, <A>gr2</A>, etc. are digraphs, then
-    <C>DigraphDirectProduct</C> returns their direct product.
+    <C>DigraphDirectProduct</C> returns a digraph isomorphic to their direct product.
     <P/>
 
     In the second form, if <A>list</A> is a non-empty list of digraphs,
-    then <C>DigraphDirectProduct</C> returns the direct product of 
+    then <C>DigraphDirectProduct</C> returns a digraph isomorphic to the direct product of 
     the digraphs contained in the list.
     <P/>
 
@@ -1032,17 +1037,22 @@ true
     digraph with vertex set <C>Cartesian(DigraphVertices(G), DigraphVertices(H))</C> 
     such that there is an edge from <C>[u, u']</C> to <C>[v, v']</C> iff there is an edge from
     <C>u</C> to <C>v</C> in <C>G</C> and an edge from <C>u'</C> to <C>v'</C> in <C>H</C>. 
-    Due to technical reasons, the digraph returned by <C>DigraphDirectProduct</C> has 
-    vertex set <C>[1 .. DigraphNrVertices(G)*DigraphNrVertices(H)]</C> instead. The vertex
-    pair can be somewhat regained by using <Ref Attr="DigraphDirectProductProjections"/>.
+    <P/> 
+
+    Due to technical reasons, the digraph <C>D</C> returned by <C>DigraphCartesianProduct</C> has 
+    vertex set <C>[1 .. DigraphNrVertices(G)*DigraphNrVertices(H)]</C> instead, and the 
+    exact method of encoding pairs of vertices into integers is implementation specific.
+    The original vertex pair can be somewhat regained by using 
+    <Ref Attr="DigraphDirectProductProjections"/>. In addition <Ref Oper="DigraphVertexLabels"/>
+    are preserved - if vertex pair <C>[u,u']</C> was encoded as <C>i</C> then the vertex label of 
+    <C>i</C> will be the pair of vertex labels of <C>u</C> and <C>u'</C> i.e. 
+    <C>DigraphVertexLabel(D,i) = [DigraphVertexLabel(G,u), DigraphVertexLabel(H,u')]</C>.
     <P/>
- 
+
     As the direct product is associative, the direct product of a collection 
     of digraphs <A>gr1</A>, <A>gr2</A>, <C>...</C> is computed in the obvious 
     fashion. 
     <P/>
-
-    Note that previously set <Ref Oper="DigraphVertexLabels"/> will be lost.
 
 <Example><![CDATA[
 gap> gr := ChainDigraph(4);

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -57,6 +57,8 @@
     <#Include Label="DigraphJoin">
     <#Include Label="DigraphCartesianProduct">
     <#Include Label="DigraphDirectProduct">
+    <#Include Label="DigraphCartesianProductProjections">
+    <#Include Label="DigraphDirectProductProjections">
     <#Include Label="LineDigraph">
     <#Include Label="LineUndirectedDigraph">
     <#Include Label="DoubleDigraph">

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -55,6 +55,8 @@
     <#Include Label="DigraphDisjointUnion">
     <#Include Label="DigraphEdgeUnion">
     <#Include Label="DigraphJoin">
+    <#Include Label="DigraphCartesianProduct">
+    <#Include Label="DigraphDirectProduct">
     <#Include Label="LineDigraph">
     <#Include Label="LineUndirectedDigraph">
     <#Include Label="DoubleDigraph">

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -112,3 +112,6 @@ DeclareAttribute("UndirectedSpanningTreeAttr", IsDigraph);
 
 DeclareOperation("DigraphMycielskian", [IsDigraph]);
 DeclareAttribute("DigraphMycielskianAttr", IsDigraph);
+
+DeclareAttribute("DigraphCartesianProductProjections", IsDigraph);
+DeclareAttribute("DigraphDirectProductProjections", IsDigraph);

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -37,6 +37,8 @@ DeclareOperation("DigraphClosure", [IsDigraph, IsPosInt]);
 DeclareGlobalFunction("DigraphDisjointUnion");
 DeclareGlobalFunction("DigraphJoin");
 DeclareGlobalFunction("DigraphEdgeUnion");
+DeclareGlobalFunction("DigraphCartesianProduct");
+DeclareGlobalFunction("DigraphDirectProduct");
 DeclareGlobalFunction("DIGRAPHS_CombinationOperProcessArgs");
 
 # 4. Actions . . .

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -587,10 +587,10 @@ function(arg)
     n := Length(arg[1]);
     for j in [2 .. Length(arg[i])] do
       arg[1]{[1 + n * (j - 1) .. n * j]} := List([1 .. n],
-        x -> arg[1][x] + n * (arg[i][j] - 1));
+        x -> List(Cartesian(arg[1][x], n * (arg[i][j] - 1)), Sum));
     od;
     for j in [1 .. n] do
-      Append(arg[1][j], j + n * (arg[i][1] - 1));
+      arg[1][j] := List(Cartesian(arg[1][j], n * (arg[i][1] - 1)), Sum);
     od;
   od;
 

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -497,7 +497,7 @@ end);
 
 InstallGlobalFunction(DigraphCartesianProduct,
 function(arg)
-  local D, copy, n, i, j;
+  local D, copy, n, i, j, proj, m;
 
   # Allow the possibility of supplying arguments in a list.
   if Length(arg) = 1 and IsList(arg[1]) then
@@ -529,8 +529,12 @@ function(arg)
     od;
   fi;
 
+  m := Product(List(arg, Length));
+  proj := [Transformation([1 .. m], x -> RemInt(x - 1, Length(arg[1])) + 1)];
   for i in [2 .. Length(arg)] do
     n := Length(arg[1]);
+    Add(proj, Transformation([1 .. m],
+              x -> RemInt(QuoInt(x - 1, n), Length(arg[i])) * n + 1));
     for j in [2 .. Length(arg[i])] do
       arg[1]{[1 + n * (j - 1) .. n * j]} := List([1 .. n],
         x -> Concatenation(arg[1][x] + n * (j - 1),
@@ -543,15 +547,16 @@ function(arg)
 
   if IsMutableDigraph(D) then
     ClearDigraphEdgeLabels(D);
-    return D;
   else
-    return DigraphNC(arg[1]);
+    D := DigraphNC(arg[1]);
   fi;
+  SetDigraphCartesianProductProjections(D, proj);
+  return D;
 end);
 
 InstallGlobalFunction(DigraphDirectProduct,
 function(arg)
-  local D, copy, n, i, j;
+  local D, copy, n, i, j, proj, m;
 
   # Allow the possibility of supplying arguments in a list.
   if Length(arg) = 1 and IsList(arg[1]) then
@@ -583,8 +588,12 @@ function(arg)
     od;
   fi;
 
+  m := Product(List(arg, Length));
+  proj := [Transformation([1 .. m], x -> RemInt(x - 1, Length(arg[1])) + 1)];
   for i in [2 .. Length(arg)] do
     n := Length(arg[1]);
+    Add(proj, Transformation([1 .. m],
+              x -> RemInt(QuoInt(x - 1, n), Length(arg[i])) * n + 1));
     for j in [2 .. Length(arg[i])] do
       arg[1]{[1 + n * (j - 1) .. n * j]} := List([1 .. n],
         x -> List(Cartesian(arg[1][x], n * (arg[i][j] - 1)), Sum));
@@ -596,10 +605,11 @@ function(arg)
 
   if IsMutableDigraph(D) then
     ClearDigraphEdgeLabels(D);
-    return D;
   else
-    return DigraphNC(arg[1]);
+    D := DigraphNC(arg[1]);
   fi;
+  SetDigraphDirectProductProjections(D, proj);
+  return D;
 end);
 
 ###############################################################################

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -504,9 +504,10 @@ function(arg)
     arg := arg[1];
   fi;
 
-  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
-    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
-                  "list of dense digraphs,");
+  if not IsList(arg) or IsEmpty(arg)
+      or not ForAll(arg, IsDigraphByOutNeighboursRep) then
+    ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
+                  "single list of digraphs by out-neighbours,");
   fi;
 
   D := arg[1];
@@ -546,9 +547,10 @@ function(arg)
     arg := arg[1];
   fi;
 
-  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
-    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
-                  "list of dense digraphs,");
+  if not IsList(arg) or IsEmpty(arg)
+      or not ForAll(arg, IsDigraphByOutNeighboursRep) then
+    ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
+                  "single list of digraphs by out-neighbours,");
   fi;
 
   D := arg[1];

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -495,6 +495,113 @@ function(arg)
   return ConvertToImmutableDigraphNC(arg[1]);
 end);
 
+InstallGlobalFunction(DigraphCartesianProduct,
+function(arg)
+  local D, copy, n, i, j;
+
+  # Allow the possibility of supplying arguments in a list.
+  if Length(arg) = 1 and IsList(arg[1]) then
+    arg := arg[1];
+  fi;
+
+  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
+    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
+                  "list of dense digraphs,");
+  fi;
+
+  D := arg[1];
+  if IsMutableDigraph(arg[1]) then
+    for i in [2 .. Length(arg)] do
+      if IsIdenticalObj(arg[1], arg[i]) then
+        if not IsBound(copy) then
+          copy := OutNeighboursMutableCopy(arg[1]);
+        fi;
+        arg[i] := copy;
+      else
+        arg[i] := OutNeighbours(arg[i]);
+      fi;
+    od;
+    arg[1] := arg[1]!.OutNeighbours;
+  else
+    arg[1] := OutNeighboursMutableCopy(arg[1]);
+    for i in [2 .. Length(arg)] do
+      arg[i] := OutNeighbours(arg[i]);
+    od;
+  fi;
+
+  for i in [2 .. Length(arg)] do
+    n := Length(arg[1]);
+    for j in [2 .. Length(arg[i])] do
+      arg[1]{[1 + n * (j - 1) .. n * j]} := List([1 .. n],
+        x -> Concatenation(arg[1][x] + n * (j - 1),
+                            x + n * (arg[i][j] - 1)));
+    od;
+    for j in [1 .. n] do
+      Append(arg[1][j], j + n * (arg[i][1] - 1));
+    od;
+  od;
+
+  if IsMutableDigraph(D) then
+    ClearDigraphEdgeLabels(D);
+    return D;
+  else
+    return DigraphNC(arg[1]);
+  fi;
+end);
+
+InstallGlobalFunction(DigraphDirectProduct,
+function(arg)
+  local D, copy, n, i, j;
+
+  # Allow the possibility of supplying arguments in a list.
+  if Length(arg) = 1 and IsList(arg[1]) then
+    arg := arg[1];
+  fi;
+
+  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
+    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
+                  "list of dense digraphs,");
+  fi;
+
+  D := arg[1];
+  if IsMutableDigraph(arg[1]) then
+    for i in [2 .. Length(arg)] do
+      if IsIdenticalObj(arg[1], arg[i]) then
+        if not IsBound(copy) then
+          copy := OutNeighboursMutableCopy(arg[1]);
+        fi;
+        arg[i] := copy;
+      else
+        arg[i] := OutNeighbours(arg[i]);
+      fi;
+    od;
+    arg[1] := arg[1]!.OutNeighbours;
+  else
+    arg[1] := OutNeighboursMutableCopy(arg[1]);
+    for i in [2 .. Length(arg)] do
+      arg[i] := OutNeighbours(arg[i]);
+    od;
+  fi;
+
+  for i in [2 .. Length(arg)] do
+    n := Length(arg[1]);
+    for j in [2 .. Length(arg[i])] do
+      arg[1]{[1 + n * (j - 1) .. n * j]} := List([1 .. n],
+        x -> arg[1][x] + n * (arg[i][j] - 1));
+    od;
+    for j in [1 .. n] do
+      Append(arg[1][j], j + n * (arg[i][1] - 1));
+    od;
+  od;
+
+  if IsMutableDigraph(D) then
+    ClearDigraphEdgeLabels(D);
+    return D;
+  else
+    return DigraphNC(arg[1]);
+  fi;
+end);
+
 ###############################################################################
 # 4. Actions
 ###############################################################################

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -497,7 +497,7 @@ end);
 
 InstallGlobalFunction(DigraphCartesianProduct,
 function(arg)
-  local D, copy, n, i, j, proj, m;
+  local D, n, i, j, proj, m;
 
   # Allow the possibility of supplying arguments in a list.
   if Length(arg) = 1 and IsList(arg[1]) then
@@ -510,24 +510,7 @@ function(arg)
   fi;
 
   D := arg[1];
-  if IsMutableDigraph(arg[1]) then
-    for i in [2 .. Length(arg)] do
-      if IsIdenticalObj(arg[1], arg[i]) then
-        if not IsBound(copy) then
-          copy := OutNeighboursMutableCopy(arg[1]);
-        fi;
-        arg[i] := copy;
-      else
-        arg[i] := OutNeighbours(arg[i]);
-      fi;
-    od;
-    arg[1] := arg[1]!.OutNeighbours;
-  else
-    arg[1] := OutNeighboursMutableCopy(arg[1]);
-    for i in [2 .. Length(arg)] do
-      arg[i] := OutNeighbours(arg[i]);
-    od;
-  fi;
+  DIGRAPHS_CombinationOperProcessArgs(arg);
 
   m := Product(List(arg, Length));
   proj := [Transformation([1 .. m], x -> RemInt(x - 1, Length(arg[1])) + 1)];
@@ -556,7 +539,7 @@ end);
 
 InstallGlobalFunction(DigraphDirectProduct,
 function(arg)
-  local D, copy, n, i, j, proj, m;
+  local D, n, i, j, proj, m;
 
   # Allow the possibility of supplying arguments in a list.
   if Length(arg) = 1 and IsList(arg[1]) then
@@ -569,24 +552,7 @@ function(arg)
   fi;
 
   D := arg[1];
-  if IsMutableDigraph(arg[1]) then
-    for i in [2 .. Length(arg)] do
-      if IsIdenticalObj(arg[1], arg[i]) then
-        if not IsBound(copy) then
-          copy := OutNeighboursMutableCopy(arg[1]);
-        fi;
-        arg[i] := copy;
-      else
-        arg[i] := OutNeighbours(arg[i]);
-      fi;
-    od;
-    arg[1] := arg[1]!.OutNeighbours;
-  else
-    arg[1] := OutNeighboursMutableCopy(arg[1]);
-    for i in [2 .. Length(arg)] do
-      arg[i] := OutNeighbours(arg[i]);
-    od;
-  fi;
+  DIGRAPHS_CombinationOperProcessArgs(arg);
 
   m := Product(List(arg, Length));
   proj := [Transformation([1 .. m], x -> RemInt(x - 1, Length(arg[1])) + 1)];

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -497,7 +497,7 @@ end);
 
 InstallGlobalFunction(DigraphCartesianProduct,
 function(arg)
-  local D, n, i, j, proj, m;
+  local D, n, i, j, proj, m, labs;
 
   # Allow the possibility of supplying arguments in a list.
   if Length(arg) = 1 and IsList(arg[1]) then
@@ -509,6 +509,8 @@ function(arg)
     ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
                   "single list of digraphs by out-neighbours,");
   fi;
+
+  labs := List(Cartesian(Reversed(List(arg, DigraphVertexLabels))), Reversed);
 
   D := arg[1];
   DIGRAPHS_CombinationOperProcessArgs(arg);
@@ -535,12 +537,13 @@ function(arg)
     D := DigraphNC(arg[1]);
   fi;
   SetDigraphCartesianProductProjections(D, proj);
+  SetDigraphVertexLabels(D, labs);
   return D;
 end);
 
 InstallGlobalFunction(DigraphDirectProduct,
 function(arg)
-  local D, n, i, j, proj, m;
+  local D, n, i, j, proj, m, labs;
 
   # Allow the possibility of supplying arguments in a list.
   if Length(arg) = 1 and IsList(arg[1]) then
@@ -552,6 +555,8 @@ function(arg)
     ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
                   "single list of digraphs by out-neighbours,");
   fi;
+
+  labs := List(Cartesian(Reversed(List(arg, DigraphVertexLabels))), Reversed);
 
   D := arg[1];
   DIGRAPHS_CombinationOperProcessArgs(arg);
@@ -577,6 +582,7 @@ function(arg)
     D := DigraphNC(arg[1]);
   fi;
   SetDigraphDirectProductProjections(D, proj);
+  SetDigraphVertexLabels(D, labs);
   return D;
 end);
 

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2149,6 +2149,58 @@ true
 gap> DigraphReverse(Digraph(IsMutableDigraph, [[2], [1]])) = CompleteDigraph(2);
 true
 
+# DigraphCartesianProductProjections
+gap> D := DigraphCartesianProduct(ChainDigraph(3), CycleDigraph(4),
+> Digraph([[2], [2]]));;
+gap> HasDigraphCartesianProductProjections(D);
+true
+gap> proj := DigraphCartesianProductProjections(D);; Length(proj);
+3
+gap> IsIdempotent(proj[2]);
+true
+gap> RankOfTransformation(proj[3]);
+2
+gap> S := ImageSetOfTransformation(proj[2]);;
+gap> IsIsomorphicDigraph(CycleDigraph(4), InducedSubdigraph(D, S));
+true
+gap> G := DigraphRemoveLoops(RandomDigraph(12));; 
+gap> H := DigraphRemoveLoops(RandomDigraph(50));;
+gap> D := DigraphCartesianProduct(G, H);;
+gap> proj := DigraphCartesianProductProjections(D);;
+gap> IsIdempotent(proj[1]);
+true
+gap> RankOfTransformation(proj[2]);
+50
+gap> S := ImageSetOfTransformation(proj[2]);;
+gap> IsIsomorphicDigraph(H, InducedSubdigraph(D, S));
+true
+
+# DigraphDirectProductProjections
+gap> D := DigraphDirectProduct(ChainDigraph(3), CycleDigraph(4),
+> Digraph([[2], [2]]));;
+gap> HasDigraphDirectProductProjections(D);
+true
+gap> proj := DigraphDirectProductProjections(D);; Length(proj);
+3
+gap> IsIdempotent(proj[2]);
+true
+gap> RankOfTransformation(proj[3]);
+2
+gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));;
+gap> IsIsomorphicDigraph(CycleDigraph(4), P);
+true
+gap> G := RandomDigraph(12);; 
+gap> H := RandomDigraph(50);;
+gap> D := DigraphDirectProduct(G, H);;
+gap> proj := DigraphDirectProductProjections(D);;
+gap> IsIdempotent(proj[1]);
+true
+gap> RankOfTransformation(proj[2]);
+50
+gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));;
+gap> IsIsomorphicDigraph(H, P);
+true
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1923,6 +1923,31 @@ true
 gap> DigraphCartesianProduct(Digraph([[1]]), Digraph([[1]]));
 <immutable multidigraph with 1 vertex, 2 edges>
 
+# DigraphDirectProduct
+gap> D := DigraphMutableCopy(CycleDigraph(3));
+<mutable digraph with 3 vertices, 3 edges>
+gap> DigraphDirectProduct(D, D, D);
+<mutable digraph with 27 vertices, 27 edges>
+gap> D := DigraphMutableCopy(CycleDigraph(3));
+<mutable digraph with 3 vertices, 3 edges>
+gap> DigraphDirectProduct(D, CycleDigraph(3), CycleDigraph(3), CycleDigraph(3));
+<mutable digraph with 81 vertices, 81 edges>
+gap> D := DigraphDirectProduct(ChainDigraph(3), CycleDigraph(3));
+<immutable digraph with 9 vertices, 6 edges>
+gap> IsIsomorphicDigraph(D,
+> Digraph([[5], [6], [], [8], [9], [], [2], [3], []]));
+true
+gap> D := DigraphDirectProduct(ChainDigraph(3), CycleDigraph(3),
+> Digraph([[2], [2]]));
+<immutable digraph with 18 vertices, 12 edges>
+gap> G := DigraphFromDigraph6String(
+> "&Q??O??G?????A??@????A??@??????O??G?????A??@????A??@????");;
+gap> IsIsomorphicDigraph(D, G);
+true
+gap> D := RandomDigraph(100);; IsIsomorphicDigraph(D,
+> DigraphDirectProduct(D, Digraph([[1]])));
+true
+
 # Issue 213
 gap> D := Digraph(IsMutableDigraph, [[3, 4, 6, 8], [1, 3, 4, 6, 7, 8, 10], 
 > [1, 2, 6, 7, 8, 9], [3, 5, 7], [1, 2, 3, 6, 8, 9], [2, 6, 8, 10], 

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1913,6 +1913,10 @@ true
 gap> D := DigraphCartesianProduct(ChainDigraph(3), CycleDigraph(3),
 > Digraph([[2], [2]]));
 <immutable digraph with 18 vertices, 48 edges>
+gap> HasDigraphCartesianProductProjections(D);
+true
+gap> Length(DigraphCartesianProductProjections(D));
+3
 gap> G := DigraphFromDigraph6String(
 > "&QSC?IA?@@?A__@OO?GG_OCOGAG?@?E_?BO?@G??s??Y??H?CE?AB?@@");;
 gap> IsIsomorphicDigraph(D, G);
@@ -1940,6 +1944,10 @@ true
 gap> D := DigraphDirectProduct(ChainDigraph(3), CycleDigraph(3),
 > Digraph([[2], [2]]));
 <immutable digraph with 18 vertices, 12 edges>
+gap> HasDigraphDirectProductProjections(D);
+true
+gap> Length(DigraphDirectProductProjections(D));
+3
 gap> G := DigraphFromDigraph6String(
 > "&Q??O??G?????A??@????A??@??????O??G?????A??@????A??@????");;
 gap> IsIsomorphicDigraph(D, G);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1896,6 +1896,33 @@ Error, the 3rd argument <j> must be a vertex of the 1st argument <D>,
 gap> PartialOrderDigraphJoinOfVertices(D, 2, 1);
 Error, the 2nd argument <i> must be a vertex of the 1st argument <D>,
 
+# DigraphCartesianProduct
+gap> D := DigraphMutableCopy(CycleDigraph(3));
+<mutable digraph with 3 vertices, 3 edges>
+gap> DigraphCartesianProduct(D, D, D);
+<mutable digraph with 27 vertices, 81 edges>
+gap> D := DigraphMutableCopy(CycleDigraph(3));
+<mutable digraph with 3 vertices, 3 edges>
+gap> DigraphCartesianProduct(D, CycleDigraph(3), CycleDigraph(3), CycleDigraph(3));
+<mutable digraph with 81 vertices, 324 edges>
+gap> D := DigraphCartesianProduct(ChainDigraph(3), CycleDigraph(3));
+<immutable digraph with 9 vertices, 15 edges>
+gap> IsIsomorphicDigraph(D,
+> Digraph([[2, 4], [3, 5], [6], [5, 7], [6, 8], [9], [8, 1], [9, 2], [3]]));
+true
+gap> D := DigraphCartesianProduct(ChainDigraph(3), CycleDigraph(3),
+> Digraph([[2], [2]]));
+<immutable digraph with 18 vertices, 48 edges>
+gap> G := DigraphFromDigraph6String(
+> "&QSC?IA?@@?A__@OO?GG_OCOGAG?@?E_?BO?@G??s??Y??H?CE?AB?@@");;
+gap> IsIsomorphicDigraph(D, G);
+true
+gap> D := RandomDigraph(100);; IsIsomorphicDigraph(D, 
+> DigraphCartesianProduct(D, Digraph([[]])));
+true
+gap> DigraphCartesianProduct(Digraph([[1]]), Digraph([[1]]));
+<immutable multidigraph with 1 vertex, 2 edges>
+
 # Issue 213
 gap> D := Digraph(IsMutableDigraph, [[3, 4, 6, 8], [1, 3, 4, 6, 7, 8, 10], 
 > [1, 2, 6, 7, 8, 9], [3, 5, 7], [1, 2, 3, 6, 8, 9], [2, 6, 8, 10], 


### PR DESCRIPTION
This PR implements two types of digraph product as discussed in #226 for a collection of digraphs. `DigraphCartesianProduct` computes the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product_of_graphs) of a collection of digraphs and `DigraphDirectProduct` computes the [direct product](https://en.wikipedia.org/wiki/Tensor_product_of_graphs) of a collection of digraphs. It also includes two new attributes `DigraphCartesianProductProjections` and `DigraphDirectProductProjections` for storing projections onto the coordinates of vertices.

Since the vertex set of `DigraphCartesianProduct(G, H)` is the Cartesian product of the vertex sets of `G` and `H`, but the `Digraphs` package does not permit a vertex set to contain pairs of integers, only integers themselves, then we encode a pair `(i, j)` as `i + n * (j-1)` where `n = DigraphNrVertices(G)`.

If `D = DigraphCartesianProduct(gr_1, gr_2, ...)` then `DigraphCartesianProductProjections(D)` returns a list of transformations, where the `i`-th transformation corresponds to a projection onto a copy of `gr_i` contained within `D`. The projections are useful as they allow for us to reconstruct (under some circumstances) the graphs used for creating the product, and also provide for a way of regaining the information of the coordinates of each vertex (which were lost when we decided to encode `(i, j)` as `i + n * (j-1)`). 

To make sure my code works with mutable as well as immutable digraphs, I used DigraphJoin as a basis, changing only the moving parts responsible for creating the digraph and leaving the more technical bits untouched. It seems like this has worked, but I would appreciate if someone told me whether everything is sound with regards to mutability.

Not exactly sure about the time complexity. For two graphs I think it should be `O(E_1 + E_2)` for Cartesian product and `O(E_1 * E_2)` for Direct product, where `E_1, E_2` is the number of edges of each digraph.