### PR TITLE
Make digraphs immutable via MakeImmutable

### DIFF
--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -9,14 +9,10 @@
 ##
 
 InstallMethod(DigraphNrVertices, "for a dense digraph", [IsDenseDigraphRep],
-function(D)
-  return DIGRAPH_NR_VERTICES(D);
-end);
+D -> DIGRAPH_NR_VERTICES(D));
 
 InstallMethod(OutNeighbours, "for a dense digraph", [IsDenseDigraphRep],
-function(D)
-  return DIGRAPH_OUT_NEIGHBOURS(D);
-end);
+D -> DIGRAPH_OUT_NEIGHBOURS(D));
 
 # The next method is (yet another) DFS as described in
 # http://www.eecs.wsu.edu/~holder/courses/CptS223/spr08/slides/graphapps.pdf
@@ -250,9 +246,7 @@ end);
 # end);
 
 InstallMethod(DigraphAdjacencyFunction, "for a dense digraph", [IsDigraph],
-function(D)
-  return {u, v} -> IsDigraphEdge(D, u, v);
-end);
+D -> {u, v} -> IsDigraphEdge(D, u, v));
 
 InstallMethod(AsTransformation, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
@@ -334,9 +328,7 @@ InstallMethod(DigraphDualAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphDual);
 
 InstallMethod(DigraphNrEdges, "for a digraph", [IsDenseDigraphRep],
-function(D)
-  return DIGRAPH_NREDGES(D);
-end);
+DIGRAPH_NREDGES);
 
 InstallMethod(DigraphEdges, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
@@ -357,14 +349,10 @@ end);
 # attributes for digraphs . . .
 
 InstallMethod(AsGraph, "for a digraph", [IsDigraph],
-function(D)
-  return Graph(D);
-end);
+D -> Graph(D));
 
 InstallMethod(DigraphVertices, "for a digraph", [IsDigraph],
-function(D)
-  return [1 .. DigraphNrVertices(D)];
-end);
+D -> [1 .. DigraphNrVertices(D)]);
 
 InstallMethod(DigraphRange, "for a dense digraph attribute storing digraph",
 [IsDenseDigraphRep and IsAttributeStoringRep],
@@ -378,9 +366,7 @@ end);
 
 InstallMethod(DigraphRange, "for a dense digraph attribute storing digraph",
 [IsDenseDigraphRep and IsMutableDigraph],
-function(D)
-  return DIGRAPH_SOURCE_RANGE(D).DigraphRange;
-end);
+D -> DIGRAPH_SOURCE_RANGE(D).DigraphRange);
 
 InstallMethod(DigraphSource, "for a dense digraph attribute storing digraph",
 [IsDenseDigraphRep and IsAttributeStoringRep],
@@ -394,19 +380,13 @@ end);
 
 InstallMethod(DigraphSource, "for a dense digraph attribute storing digraph",
 [IsDenseDigraphRep and IsMutableDigraph],
-function(D)
-  return DIGRAPH_SOURCE_RANGE(D).DigraphSource;
-end);
+D -> DIGRAPH_SOURCE_RANGE(D).DigraphSource);
 
 InstallMethod(InNeighbours, "for a digraph", [IsDenseDigraphRep],
-function(D)
-  return DIGRAPH_IN_OUT_NBS(OutNeighbours(D));
-end);
+D -> DIGRAPH_IN_OUT_NBS(OutNeighbours(D)));
 
 InstallMethod(AdjacencyMatrix, "for a digraph", [IsDenseDigraphRep],
-function(D)
-  return ADJACENCY_MATRIX(D);
-end);
+D -> ADJACENCY_MATRIX(D));
 
 InstallMethod(BooleanAdjacencyMatrix, "for a dense digraph",
 [IsDenseDigraphRep],
@@ -458,9 +438,7 @@ end);
 
 InstallMethod(DigraphTopologicalSort, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return DIGRAPH_TOPO_SORT(OutNeighbours(D));
-end);
+D -> DIGRAPH_TOPO_SORT(OutNeighbours(D)));
 
 InstallMethod(DigraphStronglyConnectedComponents, "for a dense digraph",
 [IsDenseDigraphRep],
@@ -482,15 +460,11 @@ end);
 
 InstallMethod(DigraphNrStronglyConnectedComponents, "for a digraph",
 [IsDigraph],
-function(D)
-  return Length(DigraphStronglyConnectedComponents(D).comps);
-end);
+D -> Length(DigraphStronglyConnectedComponents(D).comps));
 
 InstallMethod(DigraphConnectedComponents, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return DIGRAPH_CONNECTED_COMPONENTS(D);
-end);
+D -> DIGRAPH_CONNECTED_COMPONENTS(D));
 
 InstallMethod(OutDegrees, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
@@ -553,9 +527,7 @@ function(D)
 end);
 
 InstallMethod(OutDegreeSet, "for a digraph", [IsDigraph],
-function(D)
-  return Set(ShallowCopy(OutDegrees(D)));
-end);
+D -> Set(ShallowCopy(OutDegrees(D))));
 
 InstallMethod(InDegreeSequence, "for a digraph", [IsDigraph],
 function(D)
@@ -581,9 +553,7 @@ function(D)
 end);
 
 InstallMethod(InDegreeSet, "for a digraph", [IsDigraph],
-function(D)
-  return Set(ShallowCopy(InDegrees(D)));
-end);
+D -> Set(ShallowCopy(InDegrees(D))));
 
 InstallMethod(DigraphSources, "for a digraph with in-degrees",
 [IsDigraph and HasInDegrees], 3,
@@ -703,9 +673,7 @@ function(D)
 end);
 
 InstallMethod(DIGRAPHS_ConnectivityData, "for a digraph", [IsDigraph],
-function(D)
-  return [];
-end);
+D -> EmptyPlist(0));
 
 BindGlobal("DIGRAPH_ConnectivityDataForVertex",
 function(D, v)
@@ -1482,9 +1450,7 @@ end);
 
 InstallMethod(MaximalSymmetricSubdigraphWithoutLoops, "for a mutable digraph",
 [IsMutableDigraph],
-function(D)
-  return DigraphRemoveLoops(MaximalSymmetricSubdigraph(D));
-end);
+D -> DigraphRemoveLoops(MaximalSymmetricSubdigraph(D)));
 
 InstallMethod(MaximalSymmetricSubdigraphWithoutLoops,
 "for an immutable digraph",
@@ -1548,9 +1514,7 @@ function(D)
 end);
 
 InstallMethod(LaplacianMatrix, "for a digraph", [IsDigraph],
-function(D)
-  return DegreeMatrix(D) - AdjacencyMatrix(D);
-end);
+D -> DegreeMatrix(D) - AdjacencyMatrix(D));
 
 InstallMethod(NrSpanningTrees, "for a digraph", [IsDigraph],
 function(D)
@@ -1857,14 +1821,10 @@ function(D)
 end);
 
 InstallMethod(CharacteristicPolynomial, "for a digraph", [IsDigraph],
-function(D)
-  return CharacteristicPolynomial(AdjacencyMatrix(D));
-end);
+D -> CharacteristicPolynomial(AdjacencyMatrix(D)));
 
 InstallMethod(IsVertexTransitive, "for a digraph", [IsDigraph],
-function(D)
-  return IsTransitive(AutomorphismGroup(D), DigraphVertices(D));
-end);
+D -> IsTransitive(AutomorphismGroup(D), DigraphVertices(D)));
 
 InstallMethod(IsEdgeTransitive, "for a digraph", [IsDigraph],
 function(D)

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -296,7 +296,7 @@ function(D)
     return D;
   fi;
   D := ReducedDigraph(DigraphMutableCopy(D));
-  return MakeImmutableDigraph(D);
+  return MakeImmutable(D);
 end);
 
 InstallMethod(ReducedDigraphAttr, "for an immutable digraph",
@@ -328,7 +328,7 @@ function(D)
     return DigraphDualAttr(D);
   fi;
   C := DigraphMutableCopy(D);
-  C := MakeImmutableDigraph(DigraphDual(C));
+  C := MakeImmutable(DigraphDual(C));
   if HasDigraphGroup(D) then
     SetDigraphGroup(C, DigraphGroup(D));
   fi;
@@ -1121,7 +1121,7 @@ function(D)
   fi;
 
   C := DigraphMutableCopy(D);
-  C := MakeImmutableDigraph(DigraphSymmetricClosure(C));
+  C := MakeImmutable(DigraphSymmetricClosure(C));
   SetIsSymmetricDigraph(C, true);
   SetDigraphSymmetricClosureAttr(D, C);
   return C;
@@ -1194,7 +1194,7 @@ function(D)
                   "edges,");
   fi;
   C := DigraphTransitiveClosure(DigraphMutableCopy(D));
-  C := MakeImmutableDigraph(C);
+  C := MakeImmutable(C);
   SetIsTransitiveDigraph(C, true);
   SetDigraphVertexLabels(C, DigraphVertexLabels(D));
   SetDigraphTransitiveClosureAttr(D, C);
@@ -1213,7 +1213,7 @@ function(D)
                   "edges,");
   fi;
   C := DigraphReflexiveTransitiveClosure(DigraphMutableCopy(D));
-  C := MakeImmutableDigraph(C);
+  C := MakeImmutable(C);
   SetIsTransitiveDigraph(C, true);
   SetIsReflexiveDigraph(C, true);
   SetDigraphVertexLabels(C, DigraphVertexLabels(D));
@@ -1384,7 +1384,7 @@ function(D)
   fi;
 
   C := DigraphMutableCopy(D);
-  C := MakeImmutableDigraph(DigraphMycielskian(C));
+  C := MakeImmutable(DigraphMycielskian(C));
   SetDigraphMycielskianAttr(D, C);
   return C;
 end);
@@ -1541,7 +1541,7 @@ function(D)
     return MaximalSymmetricSubdigraphWithoutLoopsAttr(D);
   fi;
   C := DigraphMutableCopy(D);
-  C := MakeImmutableDigraph(MaximalSymmetricSubdigraphWithoutLoops(C));
+  C := MakeImmutable(MaximalSymmetricSubdigraphWithoutLoops(C));
   SetMaximalSymmetricSubdigraphWithoutLoopsAttr(D, C);
   return C;
 end);
@@ -1576,7 +1576,7 @@ function(D)
     return MaximalSymmetricSubdigraphAttr(D);
   fi;
   C := DigraphMutableCopy(D);
-  C := MakeImmutableDigraph(MaximalSymmetricSubdigraph(C));
+  C := MakeImmutable(MaximalSymmetricSubdigraph(C));
   SetDigraphVertexLabels(C, DigraphVertexLabels(D));
   SetMaximalSymmetricSubdigraphAttr(D, C);
   return C;
@@ -1644,7 +1644,7 @@ function(D)
     return fail;
   fi;
   C := UndirectedSpanningForest(DigraphMutableCopy(D));
-  C := MakeImmutableDigraph(C);
+  C := MakeImmutable(C);
   SetIsUndirectedForest(C, true);
   SetIsMultiDigraph(C, false);
   SetDigraphHasLoops(C, false);
@@ -1682,7 +1682,7 @@ function(D)
     return C;
   fi;
   SetIsUndirectedTree(C, true);
-  return MakeImmutableDigraph(C);
+  return MakeImmutable(C);
 end);
 
 InstallMethod(HamiltonianPath, "for a digraph", [IsDigraph],
@@ -1852,7 +1852,7 @@ function(D)
     return MaximalAntiSymmetricSubdigraphAttr(D);
   fi;
   C := DigraphMutableCopy(D);
-  C := MakeImmutableDigraph(MaximalAntiSymmetricSubdigraph(C));
+  C := MakeImmutable(MaximalAntiSymmetricSubdigraph(C));
   SetIsAntisymmetricDigraph(C, true);
   SetMaximalAntiSymmetricSubdigraphAttr(D, C);
   return C;

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -10,13 +10,11 @@
 
 InstallMethod(DigraphNrVertices, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return DIGRAPH_NR_VERTICES(D);
 end);
 
 InstallMethod(OutNeighbours, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return DIGRAPH_OUT_NEIGHBOURS(D);
 end);
 
@@ -27,7 +25,6 @@ InstallMethod(ArticulationPoints, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local copy, nbs, counter, visited, num, low, parent, points, points_seen,
         stack, depth, v, w, i;
-  IsValidDigraph(D);
   if (HasIsConnectedDigraph(D) and not IsConnectedDigraph(D))
       or DigraphNrVertices(D) <= 1 then
     return [];
@@ -108,7 +105,6 @@ InstallMethod(ChromaticNumber, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local nr, comps, upper, chrom, tmp_comps, tmp_upper, n, comp, bound, clique,
   c, i;
-  IsValidDigraph(D);
   nr := DigraphNrVertices(D);
 
   if DigraphHasLoops(D) then
@@ -255,13 +251,11 @@ end);
 
 InstallMethod(DigraphAdjacencyFunction, "for a dense digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return {u, v} -> IsDigraphEdge(D, u, v);
 end);
 
 InstallMethod(AsTransformation, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   if not IsFunctionalDigraph(D) then
     return fail;
   fi;
@@ -341,14 +335,12 @@ InstallMethod(DigraphDualAttr, "for an immutable digraph",
 
 InstallMethod(DigraphNrEdges, "for a digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return DIGRAPH_NREDGES(D);
 end);
 
 InstallMethod(DigraphEdges, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local out, adj, nr, i, j;
-  IsValidDigraph(D);
   out := EmptyPlist(DigraphNrEdges(D));
   adj := OutNeighbours(D);
   nr := 0;
@@ -366,20 +358,17 @@ end);
 
 InstallMethod(AsGraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Graph(D);
 end);
 
 InstallMethod(DigraphVertices, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return [1 .. DigraphNrVertices(D)];
 end);
 
 InstallMethod(DigraphRange, "for a dense digraph attribute storing digraph",
 [IsDenseDigraphRep and IsAttributeStoringRep],
 function(D)
-  IsValidDigraph(D);
   if not IsBound(D!.DigraphRange) then
     DIGRAPH_SOURCE_RANGE(D);
     SetDigraphSource(D, D!.DigraphSource);
@@ -396,7 +385,6 @@ end);
 InstallMethod(DigraphSource, "for a dense digraph attribute storing digraph",
 [IsDenseDigraphRep and IsAttributeStoringRep],
 function(D)
-  IsValidDigraph(D);
   if not IsBound(D!.DigraphSource) then
     DIGRAPH_SOURCE_RANGE(D);
     SetDigraphRange(D, D!.DigraphRange);
@@ -412,13 +400,11 @@ end);
 
 InstallMethod(InNeighbours, "for a digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return DIGRAPH_IN_OUT_NBS(OutNeighbours(D));
 end);
 
 InstallMethod(AdjacencyMatrix, "for a digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return ADJACENCY_MATRIX(D);
 end);
 
@@ -426,7 +412,6 @@ InstallMethod(BooleanAdjacencyMatrix, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local n, nbs, mat, i, j;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   nbs := OutNeighbours(D);
   mat := List(DigraphVertices(D), x -> BlistList([1 .. n], []));
@@ -442,7 +427,6 @@ InstallMethod(DigraphShortestDistances, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local vertices, data, sum, distances, v, u;
-  IsValidDigraph(D);
   if HasDIGRAPHS_ConnectivityData(D) then
     vertices := DigraphVertices(D);
     data := DIGRAPHS_ConnectivityData(D);
@@ -475,7 +459,6 @@ end);
 InstallMethod(DigraphTopologicalSort, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return DIGRAPH_TOPO_SORT(OutNeighbours(D));
 end);
 
@@ -483,7 +466,6 @@ InstallMethod(DigraphStronglyConnectedComponents, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local verts;
-  IsValidDigraph(D);
 
   if HasIsAcyclicDigraph(D) and IsAcyclicDigraph(D) then
     verts := DigraphVertices(D);
@@ -501,21 +483,18 @@ end);
 InstallMethod(DigraphNrStronglyConnectedComponents, "for a digraph",
 [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Length(DigraphStronglyConnectedComponents(D).comps);
 end);
 
 InstallMethod(DigraphConnectedComponents, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return DIGRAPH_CONNECTED_COMPONENTS(D);
 end);
 
 InstallMethod(OutDegrees, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local adj, degs, i;
-  IsValidDigraph(D);
   adj := OutNeighbours(D);
   degs := EmptyPlist(DigraphNrVertices(D));
   for i in DigraphVertices(D) do
@@ -529,7 +508,6 @@ InstallMethod(InDegrees, "for a digraph with in neighbours",
 2,  # to beat the method for IsDenseDigraphRep
 function(D)
   local inn, degs, i;
-  IsValidDigraph(D);
   inn := InNeighbours(D);
   degs := EmptyPlist(DigraphNrVertices(D));
   for i in DigraphVertices(D) do
@@ -541,7 +519,6 @@ end);
 InstallMethod(InDegrees, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local adj, degs, x, i;
-  IsValidDigraph(D);
   adj := OutNeighbours(D);
   degs := [1 .. DigraphNrVertices(D)] * 0;
   for x in adj do
@@ -554,7 +531,6 @@ end);
 
 InstallMethod(OutDegreeSequence, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   D := ShallowCopy(OutDegrees(D));
   Sort(D, {a, b} -> b < a);
   return D;
@@ -566,7 +542,6 @@ InstallMethod(OutDegreeSequence,
 [IsDenseDigraphRep and HasDigraphGroup],
 function(D)
   local out, adj, orbs, orb;
-  IsValidDigraph(D);
   out := [];
   adj := OutNeighbours(D);
   orbs := DigraphOrbits(D);
@@ -579,13 +554,11 @@ end);
 
 InstallMethod(OutDegreeSet, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Set(ShallowCopy(OutDegrees(D)));
 end);
 
 InstallMethod(InDegreeSequence, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   D := ShallowCopy(InDegrees(D));
   Sort(D, {a, b} -> b < a);
   return D;
@@ -597,7 +570,6 @@ InstallMethod(InDegreeSequence,
 [IsDigraph and HasDigraphGroup and HasInNeighbours],
 function(D)
   local out, adj, orbs, orb;
-  IsValidDigraph(D);
   out := [];
   adj := InNeighbours(D);
   orbs := DigraphOrbits(D);
@@ -610,7 +582,6 @@ end);
 
 InstallMethod(InDegreeSet, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Set(ShallowCopy(InDegrees(D)));
 end);
 
@@ -618,7 +589,6 @@ InstallMethod(DigraphSources, "for a digraph with in-degrees",
 [IsDigraph and HasInDegrees], 3,
 function(D)
   local degs;
-  IsValidDigraph(D);
   degs := InDegrees(D);
   return Filtered(DigraphVertices(D), x -> degs[x] = 0);
 end);
@@ -628,7 +598,6 @@ InstallMethod(DigraphSources, "for a digraph with in-neighbours",
 2,  # to beat the method for IsDenseDigraphRep
 function(D)
   local inn, sources, count, i;
-  IsValidDigraph(D);
 
   inn := InNeighbours(D);
   sources := EmptyPlist(DigraphNrVertices(D));
@@ -646,7 +615,6 @@ end);
 InstallMethod(DigraphSources, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local out, seen, tmp, next, v;
-  IsValidDigraph(D);
   out  := OutNeighbours(D);
   seen := BlistList(DigraphVertices(D), []);
   for next in out do
@@ -665,7 +633,6 @@ InstallMethod(DigraphSinks, "for a digraph with out-degrees",
 2,  # to beat the method for IsDenseDigraphRep
 function(D)
   local degs;
-  IsValidDigraph(D);
   degs := OutDegrees(D);
   return Filtered(DigraphVertices(D), x -> degs[x] = 0);
 end);
@@ -673,7 +640,6 @@ end);
 InstallMethod(DigraphSinks, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local out, sinks, count, i;
-  IsValidDigraph(D);
 
   out   := OutNeighbours(D);
   sinks := [];
@@ -692,7 +658,6 @@ function(D)
   local comps, out, deg, nrvisited, period, stack, len, depth, current,
         olddepth, i;
 
-  IsValidDigraph(D);
   if HasIsAcyclicDigraph(D) and IsAcyclicDigraph(D) then
     return 0;
   fi;
@@ -739,7 +704,6 @@ end);
 
 InstallMethod(DIGRAPHS_ConnectivityData, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return [];
 end);
 
@@ -909,7 +873,6 @@ end);
 
 InstallMethod(DigraphDiameter, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if not IsStronglyConnectedDigraph(D) then
     # Diameter undefined
     return fail;
@@ -923,7 +886,6 @@ end);
 
 InstallMethod(DigraphUndirectedGirth, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   # This is only defined on undirected graphs (i.e. symmetric digraphs)
   if not IsSymmetricDigraph(D) then
     ErrorNoReturn("the argument <D> must be a symmetric digraph,");
@@ -942,7 +904,6 @@ end);
 InstallMethod(DigraphGirth, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local verts, girth, out, dist, i, j;
-  IsValidDigraph(D);
   if DigraphHasLoops(D) then
     return 1;
   fi;
@@ -1023,7 +984,6 @@ InstallMethod(DigraphLongestSimpleCircuit, "for a digraph",
 [IsDigraph],
 function(D)
   local circs, lens, max;
-  IsValidDigraph(D);
   if IsAcyclicDigraph(D) then
     return fail;
   fi;
@@ -1233,7 +1193,6 @@ InstallMethod(DigraphAllSimpleCircuits, "for a dense digraph",
 function(D)
   local UNBLOCK, CIRCUIT, out, stack, endofstack, C, scc, n, blocked, B,
   c_comp, comp, s, loops, i;
-  IsValidDigraph(D);
 
   if DigraphNrVertices(D) = 0 or DigraphNrEdges(D) = 0 then
     return [];
@@ -1400,7 +1359,6 @@ InstallMethod(DigraphMycielskianAttr, "for an immutable, symmetric digraph",
 InstallMethod(DIGRAPHS_Bipartite, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local n, t, colours, in_nbrs, stack, pop, v, pos, nbrs, w, i;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   if n < 2 then
     return [false, fail];
@@ -1443,7 +1401,6 @@ end);
 InstallMethod(DigraphBicomponents, "for a digraph", [IsDigraph],
 function(D)
   local b;
-  IsValidDigraph(D);
 
   # Attribute only applies to bipartite digraphs
   if not IsBipartiteDigraph(D) then
@@ -1456,7 +1413,6 @@ end);
 
 InstallMethod(DigraphLoops, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   if HasDigraphHasLoops(D) and not DigraphHasLoops(D) then
     return [];
   fi;
@@ -1465,7 +1421,6 @@ end);
 
 InstallMethod(DigraphDegeneracy, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if not IsSymmetricDigraph(D) or IsMultiDigraph(D) then
     ErrorNoReturn("the argument <D> must be a symmetric digraph ",
                   "with no multiple edges,");
@@ -1475,7 +1430,6 @@ end);
 
 InstallMethod(DigraphDegeneracyOrdering, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if not IsSymmetricDigraph(D) or IsMultiDigraph(D) then
     ErrorNoReturn("the argument <D> must be a symmetric digraph ",
                   "with no multiple edges,");
@@ -1688,7 +1642,6 @@ end);
 InstallMethod(HamiltonianPath, "for a digraph", [IsDigraph],
 function(D)
   local path, iter, n;
-  IsValidDigraph(D);
 
   if DigraphNrVertices(D) <= 1 and IsEmptyDigraph(D) then
     if DigraphNrVertices(D) = 0 then
@@ -1905,19 +1858,16 @@ end);
 
 InstallMethod(CharacteristicPolynomial, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return CharacteristicPolynomial(AdjacencyMatrix(D));
 end);
 
 InstallMethod(IsVertexTransitive, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return IsTransitive(AutomorphismGroup(D), DigraphVertices(D));
 end);
 
 InstallMethod(IsEdgeTransitive, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     ErrorNoReturn("the argument <D> must be a digraph with no multiple",
                   " edges,");

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -12,7 +12,6 @@
 
 InstallMethod(CliqueNumber, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Maximum(List(DigraphMaximalCliquesReps(D), Length));
 end);
 
@@ -20,7 +19,6 @@ InstallMethod(IsIndependentSet, "for a dense digraph and a homogeneous list",
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, list)
   local x;
-  IsValidDigraph(D);
   if not IsDuplicateFreeList(list)
       or not ForAll(list, x -> x in DigraphVertices(D)) then
     ErrorNoReturn("the 2nd argument <list> must be a duplicate-free list of ",
@@ -39,7 +37,6 @@ InstallMethod(IsMaximalIndependentSet,
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, set)
   local nbs, vtx, try, i;
-  IsValidDigraph(D);
 
   if not IsIndependentSet(D, set) then
     return false;
@@ -65,7 +62,6 @@ InstallMethod(IsClique, "for a dense digraph and a homogeneous list",
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, clique)
   local nbs, v;
-  IsValidDigraph(D);
   if not IsDuplicateFreeList(clique)
       or not ForAll(clique, x -> x in DigraphVertices(D)) then
     ErrorNoReturn("the 2nd argument <clique> must be a duplicate-free list ",
@@ -84,7 +80,6 @@ InstallMethod(IsMaximalClique, "for a dense digraph and a homogeneous list",
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, clique)
   local nbs, try, n, i;
-  IsValidDigraph(D);
 
   if not IsClique(D, clique) then
     return false;
@@ -149,7 +144,6 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  IsValidDigraph(arg[1]);
   arg[1] := DigraphCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DigraphCliquesReps, arg);
@@ -164,7 +158,6 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  IsValidDigraph(arg[1]);
   arg[1] := DigraphCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DigraphCliques, arg);
@@ -183,7 +176,6 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  IsValidDigraph(arg[1]);
   if not IsBound(arg[2])
       and HasDigraphMaximalIndependentSetsRepsAttr(arg[1]) then
     return DigraphMaximalIndependentSetsRepsAttr(arg[1]);
@@ -212,7 +204,6 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  IsValidDigraph(arg[1]);
   if not IsBound(arg[2])
       and HasDigraphMaximalIndependentSetsAttr(arg[1]) then
     return DigraphMaximalIndependentSetsAttr(arg[1]);
@@ -258,7 +249,6 @@ function(arg)
   if not IsDenseDigraphRep(D) then
     ErrorNoReturn("the 1st argument <D> must be a dense digraph,");
   fi;
-  IsValidDigraph(D);
 
   # Validate arg[3]
   if IsBound(arg[3]) then
@@ -353,7 +343,6 @@ function(arg)
   if IsEmpty(arg) then
     ErrorNoReturn("there must be at least 1 argument,");
   fi;
-  IsValidDigraph(arg[1]);
 
   D := arg[1];
 
@@ -394,7 +383,6 @@ function(arg)
   if IsEmpty(arg) then
     ErrorNoReturn("there must be at least 1 argument,");
   fi;
-  IsValidDigraph(arg[1]);
 
   D := arg[1];
 
@@ -438,7 +426,6 @@ function(arg)
   if IsEmpty(arg) then
     ErrorNoReturn("there must be at least 1 argument,");
   fi;
-  IsValidDigraph(arg[1]);
 
   D := arg[1];
 
@@ -494,7 +481,6 @@ function(arg)
   if IsEmpty(arg) then
     ErrorNoReturn("there must be at least 1 argument,");
   fi;
-  IsValidDigraph(arg[1]);
 
   D := arg[1];
 
@@ -562,7 +548,6 @@ function(digraph, hook, user_param, limit, include, exclude, max, size, reps)
   if not IsDigraph(digraph) then
     ErrorNoReturn("the 1st argument <digraph> must be a digraph,");
   fi;
-  IsValidDigraph(digraph);
 
   if hook <> fail then
     if not (IsFunction(hook) and NumberArgumentsFunction(hook) = 2) then

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -11,9 +11,7 @@
 ##
 
 InstallMethod(CliqueNumber, "for a digraph", [IsDigraph],
-function(D)
-  return Maximum(List(DigraphMaximalCliquesReps(D), Length));
-end);
+D -> Maximum(List(DigraphMaximalCliquesReps(D), Length)));
 
 InstallMethod(IsIndependentSet, "for a dense digraph and a homogeneous list",
 [IsDenseDigraphRep, IsHomogeneousList],

--- a/gap/cnstr.gi
+++ b/gap/cnstr.gi
@@ -122,7 +122,6 @@ end);
 InstallMethod(DistanceDigraph, "for a digraph and an integer",
 [IsDigraph, IsInt],
 function(D, distance)
-  IsValidDigraph(D);
   if distance < 0 then
     ErrorNoReturn("the 2nd argument <distance> must be a non-negative ",
                   "integer,");
@@ -138,7 +137,6 @@ end);
 InstallMethod(LineDigraph, "for a digraph", [IsDigraph],
 function(D)
   local G;
-  IsValidDigraph(D);
   if HasDigraphGroup(D) then
     G := DigraphGroup(D);
   else
@@ -153,7 +151,6 @@ end);
 InstallMethod(LineUndirectedDigraph, "for a digraph", [IsDigraph],
 function(D)
   local G;
-  IsValidDigraph(D);
   if not IsSymmetricDigraph(D) then
     ErrorNoReturn("the argument <D> must be a symmetric digraph,");
   fi;

--- a/gap/cnstr.gi
+++ b/gap/cnstr.gi
@@ -31,7 +31,7 @@ InstallMethod(BipartiteDoubleDigraph, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   local C, X, N, p;
-  C := MakeImmutableDigraph(BipartiteDoubleDigraph(DigraphMutableCopy(D)));
+  C := MakeImmutable(BipartiteDoubleDigraph(DigraphMutableCopy(D)));
   if HasDigraphGroup(D) then
     X := GeneratorsOfGroup(DigraphGroup(D));
     N := DigraphNrVertices(D);
@@ -63,7 +63,7 @@ InstallMethod(DoubleDigraph, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   local C, X, N, p;
-  C := MakeImmutableDigraph(DoubleDigraph(DigraphMutableCopy(D)));
+  C := MakeImmutable(DoubleDigraph(DigraphMutableCopy(D)));
   if HasDigraphGroup(D) then
     X := GeneratorsOfGroup(DigraphGroup(D));
     N := DigraphNrVertices(D);
@@ -113,8 +113,7 @@ function(D, distances)
     od;
     C := DigraphNC(list);
   else
-    C := MakeImmutableDigraph(DistanceDigraph(DigraphMutableCopy(D),
-                                              distances));
+    C := MakeImmutable(DistanceDigraph(DigraphMutableCopy(D), distances));
   fi;
   SetDigraphGroup(C, DigraphGroup(D));
   return C;

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -48,9 +48,6 @@ DeclareSynonym("DigraphImmutableCopy", DigraphCopy);
 DeclareOperation("DigraphCopyIfMutable", [IsDigraph]);
 DeclareOperation("DigraphCopyIfImmutable", [IsDigraph]);
 
-# Converter
-DeclareOperation("MakeImmutableDigraph", [IsDigraph]);
-
 # Constructors
 DeclareConstructor("DigraphCons", [IsDigraph, IsRecord]);
 DeclareConstructor("DigraphCons", [IsDigraph, IsDenseList]);

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -15,8 +15,6 @@ DeclareCategory("IsDigraphWithAdjacencyFunction", IsDigraph);
 DeclareSynonym("IsMutableDigraph", IsDigraph and IsMutable);
 DeclareCategory("IsImmutableDigraph", IsDigraph);
 
-DeclareGlobalFunction("IsValidDigraph");
-
 # Family
 BindGlobal("DigraphFamily", NewFamily("DigraphFamily", IsDigraph));
 

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -55,16 +55,12 @@ function(list)
 end);
 
 InstallMethod(ConvertToImmutableDigraphNC, "for a record", [IsRecord],
-function(record)
-  return MakeImmutable(ConvertToMutableDigraphNC(record));
-end);
+record -> MakeImmutable(ConvertToMutableDigraphNC(record)));
 
 InstallMethod(ConvertToImmutableDigraphNC,
 "for a dense list of out-neighbours",
 [IsDenseList],
-function(list)
-  return MakeImmutable(ConvertToMutableDigraphNC(list));
-end);
+list -> MakeImmutable(ConvertToMutableDigraphNC(list)));
 
 InstallMethod(DigraphConsNC, "for IsMutableDigraph and a record",
 [IsMutableDigraph, IsRecord],
@@ -90,9 +86,7 @@ end);
 InstallMethod(DigraphConsNC,
 "for IsMutableDigraph and a dense mutable list of out-neighbours",
 [IsMutableDigraph, IsDenseList and IsMutable],
-function(filt, list)
-  return ConvertToMutableDigraphNC(StructuralCopy(list));
-end);
+{filt, list} -> ConvertToMutableDigraphNC(StructuralCopy(list)));
 
 InstallMethod(DigraphConsNC, "for IsImmutableDigraph and a record",
 [IsImmutableDigraph, IsRecord],
@@ -115,31 +109,21 @@ end);
 InstallMethod(DigraphConsNC,
 "for IsImmutableDigraph and a dense list of adjacencies",
 [IsImmutableDigraph, IsDenseList],
-function(filt, list)
-  return MakeImmutable(DigraphConsNC(IsMutableDigraph, list));
-end);
+{filt, list} -> MakeImmutable(DigraphConsNC(IsMutableDigraph, list)));
 
 InstallMethod(DigraphNC, "for a function and a dense list",
 [IsFunction, IsDenseList],
-function(func, list)
-  return DigraphConsNC(func, list);
-end);
+{func, list} -> DigraphConsNC(func, list));
 
 InstallMethod(DigraphNC, "for a dense list", [IsDenseList],
-function(list)
-  return DigraphConsNC(IsImmutableDigraph, list);
-end);
+list -> DigraphConsNC(IsImmutableDigraph, list));
 
 InstallMethod(DigraphNC, "for a function and a record",
 [IsFunction, IsRecord],
-function(func, record)
-  return DigraphConsNC(func, record);
-end);
+{func, record} -> DigraphConsNC(func, record));
 
 InstallMethod(DigraphNC, "for a record", [IsRecord],
-function(record)
-  return DigraphConsNC(IsImmutableDigraph, record);
-end);
+record -> DigraphConsNC(IsImmutableDigraph, record));
 
 ########################################################################
 # 3. Digraph copies
@@ -358,9 +342,7 @@ end);
 InstallMethod(DigraphCons,
 "for IsImmutableDigraph and a dense list of out-neighbours",
 [IsImmutableDigraph, IsDenseList],
-function(filt, list)
-  return MakeImmutable(DigraphCons(IsMutableDigraph, list));
-end);
+{filt, list} -> MakeImmutable(DigraphCons(IsMutableDigraph, list)));
 
 InstallMethod(DigraphCons, "for IsImmutableDigraph, a list, and function",
 [IsImmutableDigraph, IsList, IsFunction],
@@ -388,58 +370,38 @@ function(filt, domain, src, ran)
 end);
 
 InstallMethod(Digraph, "for a filter and a record", [IsFunction, IsRecord],
-function(filt, record)
-  return DigraphCons(filt, record);
-end);
+{filt, record} -> DigraphCons(filt, record));
 
 InstallMethod(Digraph, "for a record", [IsRecord],
-function(record)
-  return DigraphCons(IsImmutableDigraph, record);
-end);
+record -> DigraphCons(IsImmutableDigraph, record));
 
 InstallMethod(Digraph, "for a filter and a list", [IsFunction, IsList],
-function(func, list)
-  return DigraphCons(func, list);
-end);
+{func, list} -> DigraphCons(func, list));
 
 InstallMethod(Digraph, "for a list", [IsList],
-function(list)
-  return DigraphCons(IsImmutableDigraph, list);
-end);
+list -> DigraphCons(IsImmutableDigraph, list));
 
 InstallMethod(Digraph, "for a filter, a list, and a function",
 [IsFunction, IsList, IsFunction],
-function(filt, list, func)
-  return DigraphCons(filt, list, func);
-end);
+{filt, list, func} -> DigraphCons(filt, list, func));
 
 InstallMethod(Digraph, "for a list and a function", [IsList, IsFunction],
-function(list, func)
-  return DigraphCons(IsImmutableDigraph, list, func);
-end);
+{list, func} -> DigraphCons(IsImmutableDigraph, list, func));
 
 InstallMethod(Digraph, "for a filter, integer, list, and list",
 [IsFunction, IsInt, IsList, IsList],
-function(filt, n, src, ran)
-  return DigraphCons(filt, n, src, ran);
-end);
+{filt, n, src, ran} -> DigraphCons(filt, n, src, ran));
 
 InstallMethod(Digraph, "for an integer, list, and list",
 [IsInt, IsList, IsList],
-function(n, src, ran)
-  return DigraphCons(IsImmutableDigraph, n, src, ran);
-end);
+{n, src, ran} -> DigraphCons(IsImmutableDigraph, n, src, ran));
 
 InstallMethod(Digraph, "for a filter, list, list, and list",
 [IsFunction, IsList, IsList, IsList],
-function(filt, dom, src, ran)
-  return DigraphCons(filt, dom, src, ran);
-end);
+{filt, dom, src, ran} -> DigraphCons(filt, dom, src, ran));
 
 InstallMethod(Digraph, "for a list, list, and list", [IsList, IsList, IsList],
-function(dom, src, ran)
-  return DigraphCons(IsImmutableDigraph, dom, src, ran);
-end);
+{dom, src, ran} -> DigraphCons(IsImmutableDigraph, dom, src, ran));
 
 ########################################################################
 # 6. Printing, viewing, strings
@@ -515,14 +477,10 @@ end);
 ########################################################################
 
 InstallMethod(\=, "for two digraphs", [IsDigraph, IsDigraph],
-function(C, D)
-  return DIGRAPH_EQUALS(C, D);
-end);
+{C, D} -> DIGRAPH_EQUALS(C, D));
 
 InstallMethod(\<, "for two digraphs", [IsDigraph, IsDigraph],
-function(C, D)
-  return DIGRAPH_LT(C, D);
-end);
+{C, D} -> DIGRAPH_LT(C, D));
 
 ########################################################################
 # 8. Digraph by-something constructors
@@ -588,9 +546,7 @@ InstallMethod(DigraphByAdjacencyMatrixCons,
 InstallMethod(DigraphByAdjacencyMatrixConsNC,
 "for IsMutableDigraph and an empty list",
 [IsMutableDigraph, IsList and IsEmpty],
-function(filt, dummy)
-  return EmptyDigraph(IsMutableDigraph, 0);
-end);
+{filt, dummy} -> EmptyDigraph(IsMutableDigraph, 0));
 
 InstallMethod(DigraphByAdjacencyMatrixCons,
 "for IsImmutableDigraph and a homogeneous list",
@@ -610,15 +566,11 @@ end);
 InstallMethod(DigraphByAdjacencyMatrix,
 "for a function and a homogeneous list",
 [IsFunction, IsHomogeneousList],
-function(func, mat)
-  return DigraphByAdjacencyMatrixCons(func, mat);
-end);
+{func, mat} -> DigraphByAdjacencyMatrixCons(func, mat));
 
 InstallMethod(DigraphByAdjacencyMatrix, "for a homogeneous list",
 [IsHomogeneousList],
-function(mat)
-  return DigraphByAdjacencyMatrixCons(IsImmutableDigraph, mat);
-end);
+mat -> DigraphByAdjacencyMatrixCons(IsImmutableDigraph, mat));
 
 InstallMethod(DigraphByEdgesCons,
 "for IsMutableDigraph, a list, and an integer",
@@ -678,26 +630,18 @@ end);
 
 InstallMethod(DigraphByEdges, "for a list and an integer",
 [IsList, IsInt],
-function(edges, n)
-  return DigraphByEdgesCons(IsImmutableDigraph, edges, n);
-end);
+{edges, n} -> DigraphByEdgesCons(IsImmutableDigraph, edges, n));
 
 InstallMethod(DigraphByEdges, "for a list", [IsList],
-function(edges)
-  return DigraphByEdgesCons(IsImmutableDigraph, edges);
-end);
+edges -> DigraphByEdgesCons(IsImmutableDigraph, edges));
 
 InstallMethod(DigraphByEdges, "for a function, a list, and an integer",
 [IsFunction, IsList, IsInt],
-function(func, edges, n)
-  return DigraphByEdgesCons(func, edges, n);
-end);
+{func, edges, n} -> DigraphByEdgesCons(func, edges, n));
 
 InstallMethod(DigraphByEdges, "for a function and a list",
 [IsFunction, IsList],
-function(func, edges)
-  return DigraphByEdgesCons(func, edges);
-end);
+{func, edges} -> DigraphByEdgesCons(func, edges));
 
 InstallMethod(DigraphByInNeighboursCons, "for IsMutableDigraph, and a list",
 [IsMutableDigraph, IsList],
@@ -724,9 +668,7 @@ end);
 
 InstallMethod(DigraphByInNeighboursConsNC, "for IsMutableDigraph and a list",
 [IsMutableDigraph, IsList],
-function(filt, list)
-  return DigraphNC(IsMutableDigraph, DIGRAPH_IN_OUT_NBS(list));
-end);
+{filt, list} -> DigraphNC(IsMutableDigraph, DIGRAPH_IN_OUT_NBS(list)));
 
 InstallMethod(DigraphByInNeighboursConsNC, "for IsImmutableDigraph and a list",
 [IsImmutableDigraph, IsList],
@@ -738,15 +680,11 @@ function(filt, list)
 end);
 
 InstallMethod(DigraphByInNeighbours, "for a list", [IsList],
-function(list)
-  return DigraphByInNeighboursCons(IsImmutableDigraph, list);
-end);
+list -> DigraphByInNeighboursCons(IsImmutableDigraph, list));
 
 InstallMethod(DigraphByInNeighbours, "for a function and a list",
 [IsFunction, IsList],
-function(func, list)
-  return DigraphByInNeighboursCons(func, list);
-end);
+{func, list} -> DigraphByInNeighboursCons(func, list));
 
 ########################################################################
 # 9. Converters to/from other types -> digraph . . .
@@ -790,15 +728,11 @@ function(filt, rel)
 end);
 
 InstallMethod(AsDigraph, "for a binary relation", [IsBinaryRelation],
-function(rel)
-  return AsDigraphCons(IsImmutableDigraph, rel);
-end);
+rel -> AsDigraphCons(IsImmutableDigraph, rel));
 
 InstallMethod(AsDigraph, "for a function and a binary relation",
 [IsFunction, IsBinaryRelation],
-function(func, rel)
-  return AsDigraphCons(func, rel);
-end);
+{func, rel} -> AsDigraphCons(func, rel));
 
 InstallMethod(AsDigraphCons,
 "for IsMutableDigraph, a transformation, and an integer",
@@ -838,26 +772,18 @@ end);
 InstallMethod(AsDigraph,
 "for a function, a transformation, and an integer",
 [IsFunction, IsTransformation, IsInt],
-function(func, t, n)
-  return AsDigraphCons(func, t, n);
-end);
+{func, t, n} -> AsDigraphCons(func, t, n));
 
 InstallMethod(AsDigraph, "for a transformation and an integer",
 [IsTransformation, IsInt],
-function(t, n)
-  return AsDigraphCons(IsImmutableDigraph, t, n);
-end);
+{t, n} -> AsDigraphCons(IsImmutableDigraph, t, n));
 
 InstallMethod(AsDigraph, "for a function and a transformation",
 [IsFunction, IsTransformation],
-function(func, t)
-  return AsDigraphCons(func, t, DegreeOfTransformation(t));
-end);
+{func, t} -> AsDigraphCons(func, t, DegreeOfTransformation(t)));
 
 InstallMethod(AsDigraph, "for a transformation", [IsTransformation],
-function(t)
-  return AsDigraphCons(IsImmutableDigraph, t, DegreeOfTransformation(t));
-end);
+t -> AsDigraphCons(IsImmutableDigraph, t, DegreeOfTransformation(t)));
 
 InstallMethod(AsBinaryRelation, "for a digraph", [IsDenseDigraphRep],
 function(D)
@@ -959,16 +885,12 @@ end);
 InstallMethod(RandomDigraphCons,
 "for IsMutableDigraph, an integer, and a rational",
 [IsMutableDigraph, IsInt, IsRat],
-function(filt, n, p)
-  return RandomDigraphCons(IsMutableDigraph, n, Float(p));
-end);
+{filt, n, p} -> RandomDigraphCons(IsMutableDigraph, n, Float(p)));
 
 InstallMethod(RandomDigraphCons,
 "for IsImmutableDigraph, an integer, and a rational",
 [IsImmutableDigraph, IsInt, IsRat],
-function(filt, n, p)
-  return RandomDigraphCons(IsImmutableDigraph, n, Float(p));
-end);
+{filt, n, p} -> RandomDigraphCons(IsImmutableDigraph, n, Float(p)));
 
 InstallMethod(RandomDigraphCons,
 "for IsMutableDigraph, a positive integer, and a float",
@@ -991,50 +913,34 @@ function(filt, n, p)
 end);
 
 InstallMethod(RandomDigraph, "for a pos int", [IsPosInt],
-function(n)
-  return RandomDigraphCons(IsImmutableDigraph, n);
-end);
+n -> RandomDigraphCons(IsImmutableDigraph, n));
 
 InstallMethod(RandomDigraph, "for a pos int and a rational",
 [IsPosInt, IsRat],
-function(n, p)
-  return RandomDigraphCons(IsImmutableDigraph, n, p);
-end);
+{n, p} -> RandomDigraphCons(IsImmutableDigraph, n, p));
 
 InstallMethod(RandomDigraph, "for a pos int and a float",
 [IsPosInt, IsFloat],
-function(n, p)
-  return RandomDigraphCons(IsImmutableDigraph, n, p);
-end);
+{n, p} -> RandomDigraphCons(IsImmutableDigraph, n, p));
 
 InstallMethod(RandomDigraph, "for a func and a pos int", [IsFunction, IsPosInt],
-function(func, n)
-  return RandomDigraphCons(func, n);
-end);
+{func, n} -> RandomDigraphCons(func, n));
 
 InstallMethod(RandomDigraph, "for a func, a pos int, and a rational",
 [IsFunction, IsPosInt, IsRat],
-function(func, n, p)
-  return RandomDigraphCons(func, n, p);
-end);
+{func, n, p} -> RandomDigraphCons(func, n, p));
 
 InstallMethod(RandomDigraph, "for a func, a pos int, and a float",
 [IsFunction, IsPosInt, IsFloat],
-function(func, n, p)
-  return RandomDigraphCons(func, n, p);
-end);
+{func, n, p} -> RandomDigraphCons(func, n, p));
 
 InstallMethod(RandomMultiDigraph, "for a pos int",
 [IsPosInt],
-function(n)
-  return RandomMultiDigraph(n, Random([1 .. (n * (n - 1)) / 2]));
-end);
+n -> RandomMultiDigraph(n, Random([1 .. (n * (n - 1)) / 2])));
 
 InstallMethod(RandomMultiDigraph, "for two pos ints",
 [IsPosInt, IsPosInt],
-function(n, m)
-  return DigraphNC(RANDOM_MULTI_DIGRAPH(n, m));
-end);
+{n, m} -> DigraphNC(RANDOM_MULTI_DIGRAPH(n, m)));
 
 InstallMethod(RandomTournamentCons, "for IsMutableDigraph and an integer",
 [IsMutableDigraph, IsInt],
@@ -1062,20 +968,14 @@ end);
 
 InstallMethod(RandomTournamentCons, "for IsImmutableDigraph and an integer",
 [IsImmutableDigraph, IsInt],
-function(filt, n)
-  return MakeImmutable(RandomTournamentCons(IsMutableDigraph, n));
-end);
+{filt, n} -> MakeImmutable(RandomTournamentCons(IsMutableDigraph, n)));
 
 InstallMethod(RandomTournament, "for an integer", [IsInt],
-function(n)
-  return RandomTournamentCons(IsImmutableDigraph, n);
-end);
+n -> RandomTournamentCons(IsImmutableDigraph, n));
 
 InstallMethod(RandomTournament, "for a func and an integer",
 [IsFunction, IsInt],
-function(func, n)
-  return RandomTournamentCons(func, n);
-end);
+{func, n} -> RandomTournamentCons(func, n));
 
 InstallMethod(RandomLatticeCons, "for IsMutableDigraph and a pos int",
 [IsMutableDigraph, IsPosInt],
@@ -1094,18 +994,12 @@ end);
 
 InstallMethod(RandomLatticeCons, "for IsImmutableDigraph and a pos int",
 [IsImmutableDigraph, IsPosInt],
-function(filt, n)
-  return MakeImmutable(RandomLatticeCons(IsMutableDigraph, n));
-end);
+{filt, n} -> MakeImmutable(RandomLatticeCons(IsMutableDigraph, n)));
 
 InstallMethod(RandomLattice, "for a pos int",
 [IsPosInt],
-function(n)
-  return RandomLatticeCons(IsImmutableDigraph, n);
-end);
+n -> RandomLatticeCons(IsImmutableDigraph, n));
 
 InstallMethod(RandomLattice, "for a func and a pos int",
 [IsFunction, IsPosInt],
-function(func, n)
-  return RandomLatticeCons(func, n);
-end);
+{func, n} -> RandomLatticeCons(func, n));

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -15,7 +15,7 @@
 # 1.  Types
 # 2.  Digraph no-check constructors
 # 3.  Digraph copies
-# 4.  MakeImmutableDigraph
+# 4.  PostMakeImmutable
 # 5.  Digraph constructors
 # 6.  Printing, viewing, strings
 # 7.  Operators
@@ -73,14 +73,14 @@ end);
 
 InstallMethod(ConvertToImmutableDigraphNC, "for a record", [IsRecord],
 function(record)
-  return MakeImmutableDigraph(ConvertToMutableDigraphNC(record));
+  return MakeImmutable(ConvertToMutableDigraphNC(record));
 end);
 
 InstallMethod(ConvertToImmutableDigraphNC,
 "for a dense list of out-neighbours",
 [IsDenseList],
 function(list)
-  return MakeImmutableDigraph(ConvertToMutableDigraphNC(list));
+  return MakeImmutable(ConvertToMutableDigraphNC(list));
 end);
 
 InstallMethod(DigraphConsNC, "for IsMutableDigraph and a record",
@@ -123,7 +123,7 @@ function(filt, record)
       Info(InfoWarning, 1, "ignoring record component \"", nm, "\"!");
     fi;
   od;
-  D := MakeImmutableDigraph(DigraphConsNC(IsMutableDigraph, record));
+  D := MakeImmutable(DigraphConsNC(IsMutableDigraph, record));
   SetDigraphSource(D, StructuralCopy(record.DigraphSource));
   SetDigraphRange(D, StructuralCopy(record.DigraphRange));
   return D;
@@ -133,7 +133,7 @@ InstallMethod(DigraphConsNC,
 "for IsImmutableDigraph and a dense list of adjacencies",
 [IsImmutableDigraph, IsDenseList],
 function(filt, list)
-  return MakeImmutableDigraph(DigraphConsNC(IsMutableDigraph, list));
+  return MakeImmutable(DigraphConsNC(IsMutableDigraph, list));
 end);
 
 InstallMethod(DigraphNC, "for a function and a dense list",
@@ -195,17 +195,15 @@ InstallMethod(DigraphCopyIfImmutable, "for an immutable digraph",
 [IsImmutableDigraph], DigraphCopy);
 
 ########################################################################
-# 4. MakeImmutableDigraph
+# 4. PostMakeImmutable
 ########################################################################
 
-InstallMethod(MakeImmutableDigraph, "for a mutable dense digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(PostMakeImmutable, "for a digraph",
+[IsDigraph and IsDenseDigraphRep],
 function(D)
-  MakeImmutable(D);
-  SetFilterObj(D, IsAttributeStoringRep);
-  SetFilterObj(D, IsImmutableDigraph);
   MakeImmutable(D!.OutNeighbours);
-  return D;
+  SetFilterObj(D, IsImmutableDigraph);
+  SetFilterObj(D, IsAttributeStoringRep);
 end);
 
 ########################################################################
@@ -360,7 +358,7 @@ InstallMethod(DigraphCons, "for IsImmutableDigraph and a record",
 [IsImmutableDigraph, IsRecord],
 function(filt, record)
   local D;
-  D := MakeImmutableDigraph(DigraphCons(IsMutableDigraph, record));
+  D := MakeImmutable(DigraphCons(IsMutableDigraph, record));
   if IsGraph(record) then
     # IsGraph is a function not a filter, so we cannot have a separate method
     # for this.
@@ -380,14 +378,14 @@ InstallMethod(DigraphCons,
 "for IsImmutableDigraph and a dense list of out-neighbours",
 [IsImmutableDigraph, IsDenseList],
 function(filt, list)
-  return MakeImmutableDigraph(DigraphCons(IsMutableDigraph, list));
+  return MakeImmutable(DigraphCons(IsMutableDigraph, list));
 end);
 
 InstallMethod(DigraphCons, "for IsImmutableDigraph, a list, and function",
 [IsImmutableDigraph, IsList, IsFunction],
 function(filt, list, func)
   local D;
-  D := MakeImmutableDigraph(DigraphCons(IsMutableDigraph, list, func));
+  D := MakeImmutable(DigraphCons(IsMutableDigraph, list, func));
   SetDigraphAdjacencyFunction(D, {u, v} -> func(list[u], list[v]));
   SetFilterObj(D, IsDigraphWithAdjacencyFunction);
   SetDigraphVertexLabels(D, list);
@@ -398,14 +396,14 @@ InstallMethod(DigraphCons,
 "for IsImmutableDigraph, a number of vertices, source, and range",
 [IsImmutableDigraph, IsInt, IsList, IsList],
 function(filt, N, src, ran)
-  return MakeImmutableDigraph(DigraphCons(IsMutableDigraph, N, src, ran));
+  return MakeImmutable(DigraphCons(IsMutableDigraph, N, src, ran));
 end);
 
 InstallMethod(DigraphCons,
 "for IsImmutableDigraph, a list of vertices, source, and range",
 [IsImmutableDigraph, IsList, IsList, IsList],
 function(filt, domain, src, ran)
-  return MakeImmutableDigraph(DigraphCons(IsMutableDigraph, domain, src, ran));
+  return MakeImmutable(DigraphCons(IsMutableDigraph, domain, src, ran));
 end);
 
 InstallMethod(Digraph, "for a filter and a record", [IsFunction, IsRecord],
@@ -623,8 +621,7 @@ InstallMethod(DigraphByAdjacencyMatrixCons,
 [IsImmutableDigraph, IsHomogeneousList],
 function(filt, mat)
   local D;
-  D := MakeImmutableDigraph(
-         DigraphByAdjacencyMatrixCons(IsMutableDigraph, mat));
+  D := MakeImmutable(DigraphByAdjacencyMatrixCons(IsMutableDigraph, mat));
   if IsEmpty(mat) or IsInt(mat[1][1]) then
     SetAdjacencyMatrix(D, mat);
   else
@@ -686,7 +683,7 @@ InstallMethod(DigraphByEdgesCons, "for an ImmutableDigraph and a list",
 [IsImmutableDigraph, IsList],
 function(filt, edges)
   local D;
-  D := MakeImmutableDigraph(DigraphByEdges(IsMutableDigraph, edges));
+  D := MakeImmutable(DigraphByEdges(IsMutableDigraph, edges));
   SetDigraphEdges(D, edges);
   SetDigraphNrEdges(D, Length(edges));
   return D;
@@ -697,7 +694,7 @@ InstallMethod(DigraphByEdgesCons,
 [IsImmutableDigraph, IsList, IsInt],
 function(filt, edges, n)
   local D;
-  D := MakeImmutableDigraph(DigraphByEdges(IsMutableDigraph, edges, n));
+  D := MakeImmutable(DigraphByEdges(IsMutableDigraph, edges, n));
   SetDigraphEdges(D, edges);
   SetDigraphNrEdges(D, Length(edges));
   return D;
@@ -744,7 +741,7 @@ InstallMethod(DigraphByInNeighboursCons, "for IsImmutableDigraph and a list",
 [IsImmutableDigraph, IsList],
 function(filt, list)
   local D;
-  D := MakeImmutableDigraph(DigraphByInNeighboursCons(IsMutableDigraph, list));
+  D := MakeImmutable(DigraphByInNeighboursCons(IsMutableDigraph, list));
   SetInNeighbours(D, list);
   return D;
 end);
@@ -759,8 +756,7 @@ InstallMethod(DigraphByInNeighboursConsNC, "for IsImmutableDigraph and a list",
 [IsImmutableDigraph, IsList],
 function(filt, list)
   local D;
-  D := MakeImmutableDigraph(DigraphByInNeighboursConsNC(IsMutableDigraph,
-                                                        list));
+  D := MakeImmutable(DigraphByInNeighboursConsNC(IsMutableDigraph, list));
   SetInNeighbours(D, list);
   return D;
 end);
@@ -800,7 +796,7 @@ InstallMethod(AsDigraphCons, "for IsImmutableDigraph and a binary relation",
 [IsImmutableDigraph, IsBinaryRelation],
 function(filt, rel)
   local D;
-  D := MakeImmutableDigraph(AsDigraph(IsMutableDigraph, rel));
+  D := MakeImmutable(AsDigraph(IsMutableDigraph, rel));
   SetIsMultiDigraph(D, false);
   if HasIsReflexiveBinaryRelation(rel) then
     SetIsReflexiveDigraph(D, IsReflexiveBinaryRelation(rel));
@@ -855,7 +851,7 @@ function(filt, f, n)
   local D;
   D := AsDigraph(IsMutableDigraph, f, n);
   if D <> fail then
-    D := MakeImmutableDigraph(D);
+    D := MakeImmutable(D);
     SetDigraphNrEdges(D, n);
     SetIsMultiDigraph(D, false);
     SetIsFunctionalDigraph(D, true);
@@ -1013,7 +1009,7 @@ InstallMethod(RandomDigraphCons,
 [IsImmutableDigraph, IsPosInt, IsFloat],
 function(filt, n, p)
   local D;
-  D := MakeImmutableDigraph(RandomDigraphCons(IsMutableDigraph, n, p));
+  D := MakeImmutable(RandomDigraphCons(IsMutableDigraph, n, p));
   SetIsMultiDigraph(D, false);
   return D;
 end);
@@ -1091,7 +1087,7 @@ end);
 InstallMethod(RandomTournamentCons, "for IsImmutableDigraph and an integer",
 [IsImmutableDigraph, IsInt],
 function(filt, n)
-  return MakeImmutableDigraph(RandomTournamentCons(IsMutableDigraph, n));
+  return MakeImmutable(RandomTournamentCons(IsMutableDigraph, n));
 end);
 
 InstallMethod(RandomTournament, "for an integer", [IsInt],
@@ -1123,7 +1119,7 @@ end);
 InstallMethod(RandomLatticeCons, "for IsImmutableDigraph and a pos int",
 [IsImmutableDigraph, IsPosInt],
 function(filt, n)
-  return MakeImmutableDigraph(RandomLatticeCons(IsMutableDigraph, n));
+  return MakeImmutable(RandomLatticeCons(IsMutableDigraph, n));
 end);
 
 InstallMethod(RandomLattice, "for a pos int",

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -11,7 +11,6 @@
 ########################################################################
 # This file is organised as follows:
 #
-# 0.  IsValidDigraph
 # 1.  Types
 # 2.  Digraph no-check constructors
 # 3.  Digraph copies
@@ -24,22 +23,6 @@
 # 10. Random digraphs
 #
 ########################################################################
-
-########################################################################
-# 0. IsValidDigraph
-########################################################################
-
-InstallGlobalFunction(IsValidDigraph,
-function(arg)
-  local D;
-  for D in arg do
-    if not (IsMutableDigraph(D) or IsImmutableDigraph(D)) then
-      ErrorNoReturn("digraph in an invalid state! Did you return a ",
-                    "mutable digraph from a method for an attribute, ",
-                    "or MakeImmutable(a mutable digraph)??");
-    fi;
-  od;
-end);
 
 ########################################################################
 # 1. Digraph types
@@ -165,7 +148,6 @@ end);
 InstallMethod(DigraphMutableCopy, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local copy;
-  IsValidDigraph(D);
   copy := ConvertToMutableDigraphNC(OutNeighboursMutableCopy(D));
   SetDigraphVertexLabels(copy, StructuralCopy(DigraphVertexLabels(D)));
   SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
@@ -175,7 +157,6 @@ end);
 InstallMethod(DigraphCopy, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local copy;
-  IsValidDigraph(D);
   copy := ConvertToImmutableDigraphNC(OutNeighboursMutableCopy(D));
   SetDigraphVertexLabels(copy, StructuralCopy(DigraphVertexLabels(D)));
   SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
@@ -467,7 +448,6 @@ end);
 InstallMethod(ViewString, "for a digraph", [IsDigraph],
 function(D)
   local str, n, m;
-  IsValidDigraph(D);
   str := "<";
   if IsMutableDigraph(D) then
     Append(str, "mutable ");
@@ -536,15 +516,11 @@ end);
 
 InstallMethod(\=, "for two digraphs", [IsDigraph, IsDigraph],
 function(C, D)
-  IsValidDigraph(C);
-  IsValidDigraph(D);
   return DIGRAPH_EQUALS(C, D);
 end);
 
 InstallMethod(\<, "for two digraphs", [IsDigraph, IsDigraph],
 function(C, D)
-  IsValidDigraph(C);
-  IsValidDigraph(D);
   return DIGRAPH_LT(C, D);
 end);
 

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -13,7 +13,6 @@
 InstallMethod(DotDigraph, "for a digraph", [IsDigraph],
 function(D)
   local str, out, i, j;
-  IsValidDigraph(D);
   str   := "//dot\n";
   Append(str, "digraph hgn{\n");
   Append(str, "node [shape=circle]\n");
@@ -33,7 +32,6 @@ end);
 InstallMethod(DotVertexLabelledDigraph, "for a digraph", [IsDigraph],
 function(D)
   local out, str, i, j;
-  IsValidDigraph(D);
   out   := OutNeighbours(D);
   str   := "//dot\n";
 
@@ -60,7 +58,6 @@ InstallMethod(DotSymmetricDigraph, "for a digraph",
 [IsDigraph],
 function(D)
   local out, str, i, j;
-  IsValidDigraph(D);
   if not IsSymmetricDigraph(D) then
     ErrorNoReturn("the argument <D> must be a symmetric digraph,");
   fi;
@@ -207,7 +204,6 @@ fi;
 InstallMethod(DotPartialOrderDigraph, "for a partial order digraph",
 [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if not IsPartialOrderDigraph(D) then
     ErrorNoReturn("the argument <D> must be a partial order digraph,");
   fi;
@@ -218,7 +214,6 @@ InstallMethod(DotPreorderDigraph, "for a preorder digraph",
 [IsDigraph],
 function(D)
   local comps, quo, red, str, c, x, e;
-  IsValidDigraph(D);
   if not IsPreorderDigraph(D) then
     ErrorNoReturn("the argument <D> must be a preorder digraph,");
   fi;
@@ -260,7 +255,6 @@ end);
 InstallMethod(DotHighlightedDigraph, "for a digraph and list",
 [IsDigraph, IsList],
 function(D, list)
-  IsValidDigraph(D);
   return DotHighlightedDigraph(D, list, "black", "grey");
 end);
 
@@ -268,7 +262,6 @@ InstallMethod(DotHighlightedDigraph, "for a digraph, list, and two strings",
 [IsDigraph, IsList, IsString, IsString],
 function(D, highverts, highcolour, lowcolour)
   local lowverts, out, str, i, j;
-  IsValidDigraph(D);
 
   if not IsSubset(DigraphVertices(D), highverts) then
     ErrorNoReturn("the 2nd argument <highverts> must be a list of vertices ",

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -254,9 +254,7 @@ end);
 
 InstallMethod(DotHighlightedDigraph, "for a digraph and list",
 [IsDigraph, IsList],
-function(D, list)
-  return DotHighlightedDigraph(D, list, "black", "grey");
-end);
+{D, list} -> DotHighlightedDigraph(D, list, "black", "grey"));
 
 InstallMethod(DotHighlightedDigraph, "for a digraph, list, and two strings",
 [IsDigraph, IsList, IsString, IsString],

--- a/gap/exmpl.gi
+++ b/gap/exmpl.gi
@@ -25,7 +25,7 @@ function(filt, n)
   if n < 0 then
     ErrorNoReturn("the argument <n> must be a non-negative integer,");
   fi;
-  D := MakeImmutableDigraph(EmptyDigraph(IsMutableDigraph, n));
+  D := MakeImmutable(EmptyDigraph(IsMutableDigraph, n));
   SetIsEmptyDigraph(D, true);
   SetIsMultiDigraph(D, false);
   SetAutomorphismGroup(D, SymmetricGroup(n));
@@ -71,7 +71,7 @@ InstallMethod(CompleteBipartiteDigraphCons,
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(filt, m, n)
   local D, aut;
-  D := MakeImmutableDigraph(CompleteBipartiteDigraph(IsMutableDigraph, m, n));
+  D := MakeImmutable(CompleteBipartiteDigraph(IsMutableDigraph, m, n));
   SetIsSymmetricDigraph(D, true);
   SetDigraphNrEdges(D, 2 * m * n);
   SetIsCompleteBipartiteDigraph(D, true);
@@ -137,7 +137,7 @@ InstallMethod(CompleteMultipartiteDigraphCons,
 function(filt, list)
   local D;
   D := CompleteMultipartiteDigraph(IsMutableDigraph, list);
-  D := MakeImmutableDigraph(D);
+  D := MakeImmutable(D);
   SetIsSymmetricDigraph(D, true);
   SetIsBipartiteDigraph(D, Length(list) = 2);
   return D;
@@ -170,7 +170,7 @@ InstallMethod(ChainDigraphCons,
 [IsImmutableDigraph, IsPosInt],
 function(filt, n)
   local D;
-  D := MakeImmutableDigraph(ChainDigraphCons(IsMutableDigraph, n));
+  D := MakeImmutable(ChainDigraphCons(IsMutableDigraph, n));
   if n = 2 then
     SetIsTransitiveDigraph(D, true);
   else
@@ -219,7 +219,7 @@ InstallMethod(CompleteDigraphCons, "for IsImmutableDigraph and an integer",
 [IsImmutableDigraph, IsInt],
 function(filt, n)
   local D;
-  D := MakeImmutableDigraph(CompleteDigraphCons(IsMutableDigraph, n));
+  D := MakeImmutable(CompleteDigraphCons(IsMutableDigraph, n));
   SetIsEmptyDigraph(D, false);
   SetIsAcyclicDigraph(D, false);
   if n > 1 then
@@ -260,7 +260,7 @@ InstallMethod(CycleDigraphCons,
 [IsImmutableDigraph, IsPosInt],
 function(filt, n)
   local D;
-  D := MakeImmutableDigraph(CycleDigraphCons(IsMutableDigraph, n));
+  D := MakeImmutable(CycleDigraphCons(IsMutableDigraph, n));
   if n = 1 then
     SetIsTransitiveDigraph(D, true);
     SetDigraphHasLoops(D, true);
@@ -307,7 +307,7 @@ InstallMethod(JohnsonDigraphCons,
 [IsImmutableDigraph, IsInt, IsInt],
 function(filt, n, k)
   local D;
-  D := MakeImmutableDigraph(JohnsonDigraphCons(IsMutableDigraph, n, k));
+  D := MakeImmutable(JohnsonDigraphCons(IsMutableDigraph, n, k));
   SetIsMultiDigraph(D, false);
   SetIsSymmetricDigraph(D, true);
   return D;
@@ -344,7 +344,7 @@ end);
 InstallMethod(PetersenGraphCons, "for IsImmutableDigraph",
 [IsImmutableDigraph],
 function(filt)
-  return MakeImmutableDigraph(PetersenGraphCons(IsMutableDigraph));
+  return MakeImmutable(PetersenGraphCons(IsMutableDigraph));
 end);
 
 InstallMethod(PetersenGraph, "for a function", [IsFunction],
@@ -395,8 +395,7 @@ InstallMethod(GeneralisedPetersenGraphCons,
 [IsImmutableDigraph, IsInt, IsInt],
 function(filt, n, k)
   local D;
-  D := MakeImmutableDigraph(GeneralisedPetersenGraphCons(
-       IsMutableDigraph, n, k));
+  D := MakeImmutable(GeneralisedPetersenGraphCons(IsMutableDigraph, n, k));
   SetIsMultiDigraph(D, false);
   SetIsSymmetricDigraph(D, true);
   return D;

--- a/gap/exmpl.gi
+++ b/gap/exmpl.gi
@@ -33,15 +33,11 @@ function(filt, n)
 end);
 
 InstallMethod(EmptyDigraph, "for an integer", [IsInt],
-function(n)
-  return EmptyDigraphCons(IsImmutableDigraph, n);
-end);
+n -> EmptyDigraphCons(IsImmutableDigraph, n));
 
 InstallMethod(EmptyDigraph, "for a function and an integer",
 [IsFunction, IsInt],
-function(func, n)
-  return EmptyDigraphCons(func, n);
-end);
+{func, n} -> EmptyDigraphCons(func, n));
 
 InstallMethod(CompleteBipartiteDigraphCons,
 "for IsMutableDigraph and two positive integers",
@@ -86,16 +82,12 @@ end);
 
 InstallMethod(CompleteBipartiteDigraph, "for two positive integers",
 [IsPosInt, IsPosInt],
-function(m, n)
-  return CompleteBipartiteDigraph(IsImmutableDigraph, m, n);
-end);
+{m, n} -> CompleteBipartiteDigraph(IsImmutableDigraph, m, n));
 
 InstallMethod(CompleteBipartiteDigraph,
 "for a functions and two positive integers",
 [IsFunction, IsPosInt, IsPosInt],
-function(filt, m, n)
-  return CompleteBipartiteDigraphCons(filt, m, n);
-end);
+{filt, m, n} -> CompleteBipartiteDigraphCons(filt, m, n));
 
 # For input list <sizes> of length nr_parts, CompleteMultipartiteDigraph
 # returns the complete multipartite digraph containing parts 1, 2, ..., n
@@ -144,14 +136,10 @@ function(filt, list)
 end);
 
 InstallMethod(CompleteMultipartiteDigraph, "for a list", [IsList],
-function(list)
-  return CompleteMultipartiteDigraphCons(IsImmutableDigraph, list);
-end);
+list -> CompleteMultipartiteDigraphCons(IsImmutableDigraph, list));
 
 InstallMethod(CompleteMultipartiteDigraph, "for a list", [IsFunction, IsList],
-function(filt, list)
-  return CompleteMultipartiteDigraphCons(filt, list);
-end);
+{filt, list} -> CompleteMultipartiteDigraphCons(filt, list));
 
 InstallMethod(ChainDigraphCons, "for IsMutableDigraph and a positive integer",
 [IsMutableDigraph, IsPosInt],
@@ -189,14 +177,10 @@ end);
 
 InstallMethod(ChainDigraph, "for a function and a positive integer",
 [IsFunction, IsPosInt],
-function(func, n)
-  return ChainDigraphCons(func, n);
-end);
+{func, n} -> ChainDigraphCons(func, n));
 
 InstallMethod(ChainDigraph, "for a positive integer", [IsPosInt],
-function(n)
-  return ChainDigraphCons(IsImmutableDigraph, n);
-end);
+n -> ChainDigraphCons(IsImmutableDigraph, n));
 
 InstallMethod(CompleteDigraphCons, "for IsMutableDigraph and an integer",
 [IsMutableDigraph, IsInt],
@@ -233,15 +217,11 @@ end);
 
 InstallMethod(CompleteDigraph, "for a function and an integer",
 [IsFunction, IsInt],
-function(func, n)
-  return CompleteDigraphCons(func, n);
-end);
+{func, n} -> CompleteDigraphCons(func, n));
 
 InstallMethod(CompleteDigraph, "for an integer",
 [IsInt],
-function(n)
-  return CompleteDigraphCons(IsImmutableDigraph, n);
-end);
+n -> CompleteDigraphCons(IsImmutableDigraph, n));
 
 InstallMethod(CycleDigraphCons, "for IsMutableDigraph and a positive integer",
 [IsMutableDigraph, IsPosInt],
@@ -280,14 +260,10 @@ end);
 
 InstallMethod(CycleDigraph, "for a function and a positive integer",
 [IsFunction, IsPosInt],
-function(func, n)
-  return CycleDigraphCons(func, n);
-end);
+{func, n} -> CycleDigraphCons(func, n));
 
 InstallMethod(CycleDigraph, "for a positive integer", [IsPosInt],
-function(n)
-  return CycleDigraphCons(IsImmutableDigraph, n);
-end);
+n -> CycleDigraphCons(IsImmutableDigraph, n));
 
 InstallMethod(JohnsonDigraphCons,
 "for IsMutableDigraph, integer, integer",
@@ -315,14 +291,10 @@ end);
 
 InstallMethod(JohnsonDigraph, "for a function, integer, integer",
 [IsFunction, IsInt, IsInt],
-function(func, n, k)
-  return JohnsonDigraphCons(func, n, k);
-end);
+{func, n, k} -> JohnsonDigraphCons(func, n, k));
 
 InstallMethod(JohnsonDigraph, "for integer, integer", [IsInt, IsInt],
-function(n, k)
-  return JohnsonDigraphCons(IsImmutableDigraph, n, k);
-end);
+{n, k} -> JohnsonDigraphCons(IsImmutableDigraph, n, k));
 
 InstallMethod(PetersenGraphCons, "for IsMutableDigraph", [IsMutableDigraph],
 function(filt)
@@ -343,19 +315,13 @@ end);
 
 InstallMethod(PetersenGraphCons, "for IsImmutableDigraph",
 [IsImmutableDigraph],
-function(filt)
-  return MakeImmutable(PetersenGraphCons(IsMutableDigraph));
-end);
+filt -> MakeImmutable(PetersenGraphCons(IsMutableDigraph)));
 
 InstallMethod(PetersenGraph, "for a function", [IsFunction],
-function(func)
-  return PetersenGraphCons(func);
-end);
+PetersenGraphCons);
 
 InstallMethod(PetersenGraph, [],
-function()
-  return PetersenGraphCons(IsImmutableDigraph);
-end);
+{} -> PetersenGraphCons(IsImmutableDigraph));
 
 InstallMethod(GeneralisedPetersenGraphCons,
 "for IsMutableDigraph, integer, integer",
@@ -403,11 +369,7 @@ end);
 
 InstallMethod(GeneralisedPetersenGraph, "for a function, integer, integer",
 [IsFunction, IsInt, IsInt],
-function(func, n, k)
-  return GeneralisedPetersenGraphCons(func, n, k);
-end);
+{func, n, k} -> GeneralisedPetersenGraphCons(func, n, k));
 
 InstallMethod(GeneralisedPetersenGraph, "for integer, integer", [IsInt, IsInt],
-function(n, k)
-  return GeneralisedPetersenGraphCons(IsImmutableDigraph, n, k);
-end);
+{n, k} -> GeneralisedPetersenGraphCons(IsImmutableDigraph, n, k));

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -127,9 +127,7 @@ function(D, n)
 end);
 
 InstallMethod(DigraphGreedyColouring, "for a digraph", [IsDigraph],
-function(D)
-  return DigraphGreedyColouringNC(D, DigraphWelshPowellOrder(D));
-end);
+D -> DigraphGreedyColouringNC(D, DigraphWelshPowellOrder(D)));
 
 InstallMethod(DigraphGreedyColouring, "for a digraph",
 [IsDigraph, IsHomogeneousList],
@@ -183,9 +181,7 @@ end);
 
 InstallMethod(DigraphGreedyColouring, "for a digraph and a function",
 [IsDigraph, IsFunction],
-function(D, func)
-  return DigraphGreedyColouringNC(D, func(D));
-end);
+{D, func} -> DigraphGreedyColouringNC(D, func(D)));
 
 InstallMethod(DigraphWelshPowellOrder, "for a digraph", [IsDigraph],
 function(D)
@@ -500,9 +496,7 @@ end);
 
 InstallMethod(IsDigraphEndomorphism, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
-function(D, x)
-  return IsDigraphHomomorphism(D, D, x);
-end);
+{D, x} -> IsDigraphHomomorphism(D, D, x));
 
 InstallMethod(IsDigraphEpimorphism, "for digraph, digraph, and transformation",
 [IsDigraph, IsDigraph, IsTransformation],

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -20,7 +20,6 @@ function(arg)
   if not IsDigraph(D) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  IsValidDigraph(D);
   D := DigraphCopyIfMutable(D);
   if IsBound(arg[2]) then
     if IsHomogeneousList(arg[2]) then
@@ -98,7 +97,6 @@ function(D, n)
   if n < 0 then
     ErrorNoReturn("the 2nd argument <n> must be a non-negative integer,");
   fi;
-  IsValidDigraph(D);
   if HasDigraphGreedyColouring(D) then
     if DigraphGreedyColouring(D) = fail then
       return fail;
@@ -150,7 +148,6 @@ InstallMethod(DigraphGreedyColouringNC,
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, order)
   local n, colour, colouring, out, inn, empty, all, available, nr_coloured, v;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   if n = 0 then
     return IdentityTransformation;
@@ -193,7 +190,6 @@ end);
 InstallMethod(DigraphWelshPowellOrder, "for a digraph", [IsDigraph],
 function(D)
   local order, deg;
-  IsValidDigraph(D);
   order := [1 .. DigraphNrVertices(D)];
   deg   := ShallowCopy(OutDegrees(D)) + InDegrees(D);
   SortParallel(deg, order, {x, y} -> x > y);
@@ -203,7 +199,6 @@ end);
 InstallMethod(DigraphSmallestLastOrder, "for a digraph", [IsDigraph],
 function(D)
   local order, n, copy, deg, v;
-  IsValidDigraph(D);
   order := [];
   n := DigraphNrVertices(D);
   copy := DigraphCopyIfMutable(D);
@@ -226,7 +221,6 @@ InstallMethod(DigraphHomomorphism, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local out;
-  IsValidDigraph(D1, D2);
   out := HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                 # hook
@@ -253,7 +247,6 @@ InstallMethod(HomomorphismsDigraphsRepresentatives,
 "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
-  IsValidDigraph(D1, D2);
   return HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                  # hook
@@ -274,7 +267,6 @@ InstallMethod(HomomorphismsDigraphs, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local hom, aut;
-  IsValidDigraph(D1, D2);
   hom := HomomorphismsDigraphsRepresentatives(D1, D2);
   D2 := DigraphCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
@@ -291,7 +283,6 @@ InstallMethod(DigraphMonomorphism, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local out;
-  IsValidDigraph(D1, D2);
   out := HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                   # hook
@@ -316,7 +307,6 @@ InstallMethod(MonomorphismsDigraphsRepresentatives,
 "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
-  IsValidDigraph(D1, D2);
   return HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                    # hook
@@ -337,7 +327,6 @@ InstallMethod(MonomorphismsDigraphs, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local hom, aut;
-  IsValidDigraph(D1, D2);
   hom := MonomorphismsDigraphsRepresentatives(D1, D2);
   D2 := DigraphCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
@@ -354,7 +343,6 @@ InstallMethod(DigraphEpimorphism, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local out;
-  IsValidDigraph(D1, D2);
   out := HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                   # hook
@@ -379,7 +367,6 @@ InstallMethod(EpimorphismsDigraphsRepresentatives,
 "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
-  IsValidDigraph(D1, D2);
   return HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                   # hook
@@ -400,7 +387,6 @@ InstallMethod(EpimorphismsDigraphs, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local hom, aut;
-  IsValidDigraph(D1, D2);
   hom := EpimorphismsDigraphsRepresentatives(D1, D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
@@ -415,7 +401,6 @@ InstallMethod(DigraphEmbedding, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local out;
-  IsValidDigraph(D1, D2);
   out := HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                   # hook
@@ -440,7 +425,6 @@ InstallMethod(EmbeddingsDigraphsRepresentatives,
 "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
-  IsValidDigraph(D1, D2);
   return HomomorphismDigraphsFinder(D1,
                                     D2,
                                     fail,                   # hook
@@ -459,7 +443,6 @@ InstallMethod(EmbeddingsDigraphs, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(D1, D2)
   local hom, aut;
-  IsValidDigraph(D1, D2);
   hom := EmbeddingsDigraphsRepresentatives(D1, D2);
   D2 := DigraphCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
@@ -475,7 +458,6 @@ InstallMethod(IsDigraphHomomorphism, "for a dense digraph, digraph, and perm",
 [IsDenseDigraphRep, IsDigraph, IsPerm],
 function(src, ran, x)
   local i, j;
-  IsValidDigraph(src, ran);
   if IsMultiDigraph(src) or IsMultiDigraph(ran) then
     ErrorNoReturn("the 1st and 2nd arguments <src> and <ran> must be digraphs",
                   " with no multiple edges,");
@@ -500,7 +482,6 @@ InstallMethod(IsDigraphHomomorphism,
 [IsDenseDigraphRep, IsDigraph, IsTransformation],
 function(src, ran, x)
   local i, j;
-  IsValidDigraph(src, ran);
   if IsMultiDigraph(src) or IsMultiDigraph(ran) then
     ErrorNoReturn("the 1st and 2nd arguments <src> and <ran> must be digraphs",
                   " with no multiple edges,");
@@ -520,14 +501,12 @@ end);
 InstallMethod(IsDigraphEndomorphism, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 function(D, x)
-  IsValidDigraph(D);
   return IsDigraphHomomorphism(D, D, x);
 end);
 
 InstallMethod(IsDigraphEpimorphism, "for digraph, digraph, and transformation",
 [IsDigraph, IsDigraph, IsTransformation],
 function(src, ran, x)
-  IsValidDigraph(src, ran);
   return IsDigraphHomomorphism(src, ran, x)
     and OnSets(DigraphVertices(src), x) = DigraphVertices(ran);
 end);
@@ -535,7 +514,6 @@ end);
 InstallMethod(IsDigraphEpimorphism, "for digraph, digraph, and perm",
 [IsDigraph, IsDigraph, IsPerm],
 function(src, ran, x)
-  IsValidDigraph(src, ran);
   return IsDigraphHomomorphism(src, ran, x)
     and OnSets(DigraphVertices(src), x) = DigraphVertices(ran);
 end);
@@ -544,7 +522,6 @@ InstallMethod(IsDigraphMonomorphism,
 "for digraph, digraph, and transformation",
 [IsDigraph, IsDigraph, IsTransformation],
 function(src, ran, x)
-  IsValidDigraph(src, ran);
   return IsDigraphHomomorphism(src, ran, x)
     and IsInjectiveListTrans(DigraphVertices(src), x);
 end);
@@ -557,7 +534,6 @@ InstallMethod(IsDigraphEmbedding,
 [IsDigraph, IsDenseDigraphRep, IsTransformation],
 function(src, ran, x)
   local y, induced, i, j;
-  IsValidDigraph(src, ran);
   if not IsDigraphMonomorphism(src, ran, x) then
     return false;
   fi;
@@ -580,7 +556,6 @@ InstallMethod(IsDigraphEmbedding, "for digraph, dense digraph, and perm",
 [IsDigraph, IsDenseDigraphRep, IsPerm],
 function(src, ran, x)
   local y, induced, i, j;
-  IsValidDigraph(src, ran);
   if not IsDigraphHomomorphism(src, ran, x) then
     return false;
   fi;
@@ -602,7 +577,6 @@ InstallMethod(IsDigraphColouring, "for a dense digraph and a list",
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, colours)
   local n, out, v, w;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   if Length(colours) <> n or ForAny(colours, x -> not IsPosInt(x)) then
     return false;
@@ -622,7 +596,6 @@ InstallMethod(IsDigraphColouring, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 function(D, t)
   local n;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   return IsDigraphColouring(D, ImageListOfTransformation(t, n));
 end);

--- a/gap/grape.gi
+++ b/gap/grape.gi
@@ -115,7 +115,6 @@ end);
 InstallMethod(Graph, "for a digraph", [IsDigraph],
 function(D)
   local gamma, i, n;
-  IsValidDigraph(D);
 
   if IsMultiDigraph(D) then
     Info(InfoWarning, 1, "Grape does not support multiple edges, so ",
@@ -215,7 +214,6 @@ InstallMethod(DigraphAddEdgeOrbit, "for a digraph and edge",
 [IsDigraph, IsList],
 function(D, edge)
   local out, G, o, e;
-  IsValidDigraph(D);
 
   if not (Length(edge) = 2 and ForAll(edge, IsPosInt)) then
     ErrorNoReturn("the 2nd argument <edge> must be a list of 2 ",
@@ -249,7 +247,6 @@ InstallMethod(DigraphRemoveEdgeOrbit, "for a digraph and edge",
 [IsDigraph, IsList],
 function(D, edge)
   local out, G, o, pos, e;
-  IsValidDigraph(D);
 
   if not (Length(edge) = 2 and ForAll(edge, IsPosInt)) then
     ErrorNoReturn("the 2nd argument <edge> must be a pair of ",

--- a/gap/grape.gi
+++ b/gap/grape.gi
@@ -108,9 +108,7 @@ end);
 
 InstallMethod(CayleyDigraph, "for a group with generators",
 [IsGroup and HasGeneratorsOfGroup],
-function(G)
-  return CayleyDigraph(G, GeneratorsOfGroup(G));
-end);
+G -> CayleyDigraph(G, GeneratorsOfGroup(G)));
 
 InstallMethod(Graph, "for a digraph", [IsDigraph],
 function(D)

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -101,7 +101,6 @@ InstallMethod(IO_Pickle, "for a digraph with known digraph group",
 [IsFile, IsDigraph and HasDigraphGroup],
 function(file, D)
   local g, out;
-  IsValidDigraph(D);
   g := DigraphGroup(D);
   if IsTrivial(g) then
     TryNextMethod();
@@ -151,7 +150,6 @@ end;
 InstallMethod(IO_Pickle, "for a digraph",
 [IsFile, IsDigraph],
 function(file, D)
-  IsValidDigraph(D);
   if IO_Write(file, "DIGT") = fail then
     return IO_Error;
   fi;
@@ -505,7 +503,6 @@ function(arg)
   elif not mode in ["a", "w"] then
     ErrorNoReturn("the argument <mode> must be \"a\" or \"w\",");
   fi;
-  CallFuncList(IsValidDigraph, digraphs);
 
   if IsString(name) and not IsExistingFile(name) then
     mode := "w";
@@ -1365,7 +1362,6 @@ function(name, D)
   if not IsSymmetricDigraph(D) then
     ErrorNoReturn("the 2nd argument <D> must be a symmetric digraph,");
   fi;
-  IsValidDigraph(D);
 
   file := IO_CompressedFile(UserHomeExpand(name), "w");
   if file = fail then
@@ -1478,7 +1474,6 @@ function(D)
     ErrorNoReturn("the argument <D> must be a symmetric digraph ",
                   "with no loops or multiple edges,");
   fi;
-  IsValidDigraph(D);
 
   list := [];
   adj := OutNeighbours(D);
@@ -1533,7 +1528,6 @@ function(D)
   # matrix, and appends a '&' to the start.  The old '+' format can be read by
   # DigraphFromDigraph6String, but can no longer be written by this function.
 
-  IsValidDigraph(D);
   list := [];
   adj := OutNeighbours(D);
   n := Length(DigraphVertices(D));
@@ -1583,7 +1577,6 @@ function(D)
   if not IsSymmetricDigraph(D) then
     ErrorNoReturn("the argument <D> must be a symmetric digraph,");
   fi;
-  IsValidDigraph(D);
 
   list := [];
   n := Length(DigraphVertices(D));
@@ -1688,7 +1681,6 @@ function(D)
   local list, n, lenlist, adj, source_i, range_i, source_d, range_d, len1,
   len2, sort_d, perm, sort_i, k, blist, v, nextbit, AddBinary, bitstopad,
   pos, block, i, j;
-  IsValidDigraph(D);
 
   list := [];
   n := Length(DigraphVertices(D));
@@ -1843,6 +1835,5 @@ end);
 
 InstallMethod(PlainTextString, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return DigraphPlainTextLineEncoder("  ", " ", -1)(D);
 end);

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -683,9 +683,7 @@ function(func, s)
 end);
 
 InstallMethod(DigraphFromGraph6String, "for a string", [IsString],
-function(s)
-  return DigraphFromGraph6String(DigraphNC, s);
-end);
+s -> DigraphFromGraph6String(DigraphNC, s));
 
 InstallMethod(DigraphFromDigraph6String, "for a function and string",
 [IsFunction, IsString],
@@ -779,9 +777,7 @@ end);
 
 InstallMethod(DigraphFromDigraph6String, "for a string",
 [IsString],
-function(s)
-  return DigraphFromDigraph6String(DigraphNC, s);
-end);
+s -> DigraphFromDigraph6String(DigraphNC, s));
 
 InstallMethod(DigraphFromSparse6String, "for a function and a string",
 [IsFunction, IsString],
@@ -899,9 +895,7 @@ function(func, s)
 end);
 
 InstallMethod(DigraphFromSparse6String, "for a string", [IsString],
-function(s)
-  return DigraphFromSparse6String(DigraphNC, s);
-end);
+s -> DigraphFromSparse6String(DigraphNC, s));
 
 InstallMethod(DigraphFromDiSparse6String, "for a function and a string",
 [IsFunction, IsString],
@@ -1036,20 +1030,14 @@ function(func, s)
 end);
 
 InstallMethod(DigraphFromDiSparse6String, "for a string", [IsString],
-function(s)
-  return DigraphFromDiSparse6String(DigraphNC, s);
-end);
+s -> DigraphFromDiSparse6String(DigraphNC, s));
 
 InstallMethod(DigraphFromPlainTextString, "for a function and a string",
 [IsFunction, IsString],
-function(func, s)
-  return DigraphPlainTextLineDecoder(func, "  ", " ", 1)(Chomp(s));
-end);
+{func, s} -> DigraphPlainTextLineDecoder(func, "  ", " ", 1)(Chomp(s)));
 
 InstallMethod(DigraphFromPlainTextString, "for a string", [IsString],
-function(s)
-  return DigraphFromPlainTextString(DigraphByEdges, s);
-end);
+s -> DigraphFromPlainTextString(DigraphByEdges, s));
 
 # DIMACS format: for symmetric digraphs, one per file, can have loops and
 # multiple edges.
@@ -1180,9 +1168,7 @@ function(func, name)
 end);
 
 InstallMethod(ReadDIMACSDigraph, "for a string", [IsString],
-function(s)
-  return ReadDIMACSDigraph(DigraphNC, s);
-end);
+s -> ReadDIMACSDigraph(DigraphNC, s));
 
 InstallMethod(TournamentLineDecoder, "for a function and string",
 [IsFunction, IsString],
@@ -1205,9 +1191,7 @@ function(func, s)
 end);
 
 InstallMethod(TournamentLineDecoder, "for a string", [IsString],
-function(s)
-  return TournamentLineDecoder(DigraphNC, s);
-end);
+s -> TournamentLineDecoder(DigraphNC, s));
 
 # one graph per line
 InstallMethod(DigraphPlainTextLineDecoder,
@@ -1301,9 +1285,7 @@ end);
 
 InstallMethod(AdjacencyMatrixUpperTriangleLineDecoder, "for a string",
 [IsString],
-function(s)
-  return AdjacencyMatrixUpperTriangleLineDecoder(DigraphNC, s);
-end);
+s -> AdjacencyMatrixUpperTriangleLineDecoder(DigraphNC, s));
 
 InstallMethod(TCodeDecoder, "for a function and string",
 [IsFunction, IsString],
@@ -1335,9 +1317,7 @@ function(func, s)
 end);
 
 InstallMethod(TCodeDecoder, "for a string", [IsString],
-function(s)
-  return TCodeDecoder(DigraphNC, s);
-end);
+s -> TCodeDecoder(DigraphNC, s));
 
 InstallGlobalFunction(TCodeDecoderNC,
 function(str)
@@ -1834,6 +1814,4 @@ function(D)
 end);
 
 InstallMethod(PlainTextString, "for a digraph", [IsDigraph],
-function(D)
-  return DigraphPlainTextLineEncoder("  ", " ", -1)(D);
-end);
+D -> DigraphPlainTextLineEncoder("  ", " ", -1)(D));

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -88,9 +88,7 @@ function(D, colors)
 end);
 
 BindGlobal("BLISS_DATA_NO_COLORS",
-function(D)
-  return BLISS_DATA(D, false);
-end);
+D -> BLISS_DATA(D, false));
 
 if DIGRAPHS_NautyAvailable then
   BindGlobal("NAUTY_DATA",
@@ -141,9 +139,7 @@ end);
 
 InstallMethod(BlissCanonicalLabelling, "for a digraph and vertex coloring",
 [IsDigraph, IsHomogeneousList],
-function(D, colors)
-  return BLISS_DATA(D, colors)[2];
-end);
+{D, colors} -> BLISS_DATA(D, colors)[2]);
 
 InstallMethod(NautyCanonicalLabelling, "for a digraph",
 [IsDigraph],
@@ -243,9 +239,7 @@ end);
 
 InstallMethod(BlissAutomorphismGroup, "for a digraph and vertex coloring",
 [IsDigraph, IsHomogeneousList],
-function(D, colors)
-  return BLISS_DATA(D, colors)[1];
-end);
+{D, colors} -> BLISS_DATA(D, colors)[1]);
 
 InstallMethod(NautyAutomorphismGroup, "for a digraph and vertex coloring",
 [IsDigraph, IsHomogeneousList],
@@ -549,9 +543,7 @@ end);
 
 InstallMethod(IsDigraphAutomorphism, "for a digraph and a permutation",
 [IsDigraph, IsPerm],
-function(D, x)
-  return IsDigraphIsomorphism(D, D, x);
-end);
+{D, x} -> IsDigraphIsomorphism(D, D, x));
 
 InstallMethod(IsDigraphIsomorphism, "for digraph, digraph, and transformation",
 [IsDigraph, IsDigraph, IsTransformation],
@@ -566,6 +558,4 @@ end);
 
 InstallMethod(IsDigraphAutomorphism, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
-function(D, x)
-  return IsDigraphIsomorphism(D, D, x);
-end);
+{D, x} -> IsDigraphIsomorphism(D, D, x));

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -134,7 +134,6 @@ InstallMethod(BlissCanonicalLabelling, "for a digraph",
 [IsDigraph],
 function(D)
   local data;
-  IsValidDigraph(D);
   data := BLISS_DATA_NO_COLORS(D);
   SetBlissAutomorphismGroup(D, data[1]);
   return data[2];
@@ -143,7 +142,6 @@ end);
 InstallMethod(BlissCanonicalLabelling, "for a digraph and vertex coloring",
 [IsDigraph, IsHomogeneousList],
 function(D, colors)
-  IsValidDigraph(D);
   return BLISS_DATA(D, colors)[2];
 end);
 
@@ -155,7 +153,6 @@ function(D)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  IsValidDigraph(D);
   data := NAUTY_DATA_NO_COLORS(D);
   SetNautyAutomorphismGroup(D, data[1]);
   return data[2];
@@ -169,7 +166,6 @@ function(D, colors)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  IsValidDigraph(D);
   return NAUTY_DATA(D, colors)[2];
 end);
 
@@ -198,7 +194,6 @@ function(D)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  IsValidDigraph(D);
   return OnDigraphs(D, NautyCanonicalLabelling(D));
 end);
 
@@ -209,7 +204,6 @@ function(D, colors)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  IsValidDigraph(D);
   return OnDigraphs(D, NautyCanonicalLabelling(D, colors));
 end);
 
@@ -218,7 +212,6 @@ end);
 InstallMethod(BlissAutomorphismGroup, "for a digraph", [IsDigraph],
 function(D)
   local data;
-  IsValidDigraph(D);
   data := BLISS_DATA_NO_COLORS(D);
   SetBlissCanonicalLabelling(D, data[2]);
   if not HasDigraphGroup(D) then
@@ -238,7 +231,6 @@ function(D)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  IsValidDigraph(D);
 
   data := NAUTY_DATA_NO_COLORS(D);
   SetNautyCanonicalLabelling(D, data[2]);
@@ -262,7 +254,6 @@ function(D, colors)
     Info(InfoWarning, 1, "NautyTracesInterface is not available");
     return fail;
   fi;
-  IsValidDigraph(D);
   return NAUTY_DATA(D, colors)[1];
 end);
 
@@ -284,7 +275,6 @@ InstallMethod(IsIsomorphicDigraph, "for digraphs", [IsDigraph, IsDigraph],
 function(C, D)
   local act;
 
-  IsValidDigraph(C, D);
   if C = D then
     return true;
   elif DigraphNrVertices(C) <> DigraphNrVertices(D)
@@ -319,7 +309,6 @@ InstallMethod(IsIsomorphicDigraph, "for digraphs and homogeneous lists",
 [IsDigraph, IsDigraph, IsHomogeneousList, IsHomogeneousList],
 function(C, D, c1, c2)
   local m, colour1, n, colour2, max, class_sizes, act, i;
-  IsValidDigraph(C, D);
   m := DigraphNrVertices(C);
   colour1 := DIGRAPHS_ValidateVertexColouring(m, c1);
   n := DigraphNrVertices(D);
@@ -368,7 +357,6 @@ end);
 InstallMethod(IsomorphismDigraphs, "for digraphs", [IsDigraph, IsDigraph],
 function(C, D)
   local label1, label2;
-  IsValidDigraph(C, D);
 
   if not IsIsomorphicDigraph(C, D) then
     return fail;
@@ -400,7 +388,6 @@ InstallMethod(IsomorphismDigraphs, "for digraphs and homogeneous lists",
 [IsDigraph, IsDigraph, IsHomogeneousList, IsHomogeneousList],
 function(C, D, c1, c2)
   local m, colour1, n, colour2, max, class_sizes, label1, label2, i;
-  IsValidDigraph(C, D);
 
   m := DigraphNrVertices(C);
   colour1 := DIGRAPHS_ValidateVertexColouring(m, c1);
@@ -556,7 +543,6 @@ function(src, ran, x)
     ErrorNoReturn("the 1st and 2nd arguments <src> and <ran> must not have ",
                   "multiple edges,");
   fi;
-  IsValidDigraph(src, ran);
   return IsDigraphHomomorphism(src, ran, x)
     and IsDigraphHomomorphism(ran, src, x ^ -1);
 end);
@@ -564,7 +550,6 @@ end);
 InstallMethod(IsDigraphAutomorphism, "for a digraph and a permutation",
 [IsDigraph, IsPerm],
 function(D, x)
-  IsValidDigraph(D);
   return IsDigraphIsomorphism(D, D, x);
 end);
 
@@ -572,7 +557,6 @@ InstallMethod(IsDigraphIsomorphism, "for digraph, digraph, and transformation",
 [IsDigraph, IsDigraph, IsTransformation],
 function(src, ran, x)
   local y;
-  IsValidDigraph(src, ran);
   y := AsPermutation(RestrictedTransformation(x, DigraphVertices(src)));
   if y = fail then
     return false;
@@ -583,6 +567,5 @@ end);
 InstallMethod(IsDigraphAutomorphism, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 function(D, x)
-  IsValidDigraph(D);
   return IsDigraphIsomorphism(D, D, x);
 end);

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -20,7 +20,6 @@ InstallMethod(SetDigraphVertexLabel,
 "for a digraph, pos int, object",
 [IsDigraph, IsPosInt, IsObject],
 function(D, v, name)
-  IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then
     D!.vertexlabels := [1 .. DigraphNrVertices(D)];
   fi;
@@ -34,7 +33,6 @@ end);
 InstallMethod(DigraphVertexLabel, "for a digraph and pos int",
 [IsDigraph, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then
     D!.vertexlabels := [1 .. DigraphNrVertices(D)];
   fi;
@@ -48,7 +46,6 @@ end);
 InstallMethod(RemoveDigraphVertexLabel, "for a digraph and positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then
     DigraphVertexLabels(D);
   fi;
@@ -58,7 +55,6 @@ end);
 InstallMethod(SetDigraphVertexLabels, "for a digraph and list",
 [IsDigraph, IsList],
 function(D, names)
-  IsValidDigraph(D);
   if Length(names) <> DigraphNrVertices(D) then
     ErrorNoReturn("the 2nd arument <names> must be a list with length equal ",
                   "to the number of vertices of the digraph <D> that is the ",
@@ -69,7 +65,6 @@ end);
 
 InstallMethod(DigraphVertexLabels, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if not IsBound(D!.vertexlabels) then
     D!.vertexlabels := [1 .. DigraphNrVertices(D)];
   fi;
@@ -86,7 +81,6 @@ InstallMethod(SetDigraphEdgeLabel,
 [IsDigraph, IsPosInt, IsPosInt, IsObject],
 function(D, v, w, label)
   local p, list;
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must be a digraph with no multiple ",
                   "edges, edge labels are not supported on digraphs with ",
@@ -109,7 +103,6 @@ InstallMethod(DigraphEdgeLabel, "for a digraph, a pos int, and a pos int",
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, v, w)
   local p;
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must be a digraph with no multiple ",
                   "edges, edge labels are not supported on digraphs with ",
@@ -126,7 +119,6 @@ end);
 
 InstallMethod(DigraphEdgeLabelsNC, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   DIGRAPHS_InitEdgeLabels(D);
   return StructuralCopy(D!.edgelabels);
 end);
@@ -134,7 +126,6 @@ end);
 InstallMethod(DigraphEdgeLabels, "for a digraph",
 [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     ErrorNoReturn("the argument <D> must be a digraph with no multiple ",
                   "edges, edge labels are not supported on digraphs with ",
@@ -149,7 +140,6 @@ end);
 InstallMethod(SetDigraphEdgeLabelsNC, "for a digraph and a list",
 [IsDigraph, IsList],
 function(D, labels)
-  IsValidDigraph(D);
   if not IsMultiDigraph(D) then
     D!.edgelabels := List(labels, ShallowCopy);
   fi;
@@ -158,7 +148,6 @@ end);
 InstallMethod(SetDigraphEdgeLabels, "for a digraph and a list",
 [IsDigraph, IsList],
 function(D, labels)
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     ErrorNoReturn("the argument <D> must be a digraph with no multiple ",
                   "edges, edge labels are not supported on digraphs with ",
@@ -179,7 +168,6 @@ InstallMethod(SetDigraphEdgeLabels, "for a digraph, and a function",
 [IsDigraph, IsFunction],
 function(D, wtf)
   local adj, i, j;
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     ErrorNoReturn("the argument <D> must be a digraph with no multiple ",
                   "edges, edge labels are not supported on digraphs with ",

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -39,7 +39,7 @@ end);
 InstallMethod(DigraphAddVertex, "for a immutable digraph and an object",
 [IsImmutableDigraph, IsObject],
 function(D, label)
-  return MakeImmutableDigraph(DigraphAddVertex(DigraphMutableCopy(D), label));
+  return MakeImmutable(DigraphAddVertex(DigraphMutableCopy(D), label));
 end);
 
 InstallMethod(DigraphAddVertex, "for a mutable digraph",
@@ -51,7 +51,7 @@ end);
 InstallMethod(DigraphAddVertex, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
-  return MakeImmutableDigraph(DigraphAddVertex(DigraphMutableCopy(D)));
+  return MakeImmutable(DigraphAddVertex(DigraphMutableCopy(D)));
 end);
 
 InstallMethod(DigraphAddVertices, "for a mutable digraph and list",
@@ -67,8 +67,7 @@ end);
 InstallMethod(DigraphAddVertices, "for an immutable digraph and list",
 [IsImmutableDigraph, IsList],
 function(D, labels)
-  return MakeImmutableDigraph(DigraphAddVertices(DigraphMutableCopy(D),
-                                                 labels));
+  return MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), labels));
 end);
 
 InstallMethod(DigraphAddVertices, "for a mutable digraph and an integer",
@@ -85,7 +84,7 @@ end);
 InstallMethod(DigraphAddVertices, "for an immutable digraph and an integer",
 [IsImmutableDigraph, IsInt],
 function(D, m)
-  return MakeImmutableDigraph(DigraphAddVertices(DigraphMutableCopy(D), m));
+  return MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), m));
 end);
 
 InstallMethod(DigraphRemoveVertex,
@@ -121,7 +120,7 @@ InstallMethod(DigraphRemoveVertex,
 "for an immutable digraph and positive integer",
 [IsImmutableDigraph, IsPosInt],
 function(D, m)
-  return MakeImmutableDigraph(DigraphRemoveVertex(DigraphMutableCopy(D), m));
+  return MakeImmutable(DigraphRemoveVertex(DigraphMutableCopy(D), m));
 end);
 
 InstallMethod(DigraphRemoveVertices, "for a mutable digraph and a list",
@@ -153,7 +152,7 @@ InstallMethod(DigraphRemoveVertices, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
 function(D, list)
   D := DigraphRemoveVertices(DigraphMutableCopy(D), list);
-  return MakeImmutableDigraph(D);
+  return MakeImmutable(D);
 end);
 
 #############################################################################
@@ -181,7 +180,7 @@ InstallMethod(DigraphAddAllLoops, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   local E;
-  E := MakeImmutableDigraph(DigraphAddAllLoops(DigraphMutableCopy(D)));
+  E := MakeImmutable(DigraphAddAllLoops(DigraphMutableCopy(D)));
   SetDigraphHasLoops(E, DigraphNrVertices(E) > 1);
   return E;
 end);
@@ -207,7 +206,7 @@ InstallMethod(DigraphRemoveLoops, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   local E;
-  E := MakeImmutableDigraph(DigraphRemoveLoops(DigraphMutableCopy(D)));
+  E := MakeImmutable(DigraphRemoveLoops(DigraphMutableCopy(D)));
   SetDigraphHasLoops(E, false);
   return E;
 end);
@@ -238,7 +237,7 @@ InstallMethod(DigraphAddEdge,
 "for an immutable digraph, a positive integer, and a positive integer",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, src, ran)
-  return MakeImmutableDigraph(DigraphAddEdge(DigraphMutableCopy(D), src, ran));
+  return MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), src, ran));
 end);
 
 InstallMethod(DigraphAddEdge, "for a mutable digraph and a list",
@@ -253,7 +252,7 @@ end);
 InstallMethod(DigraphAddEdge, "for a mutable digraph and a list",
 [IsImmutableDigraph, IsList],
 function(D, edge)
-  return MakeImmutableDigraph(DigraphAddEdge(DigraphMutableCopy(D), edge));
+  return MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), edge));
 end);
 
 InstallMethod(DigraphAddEdges, "for a mutable digraph and a list",
@@ -269,7 +268,7 @@ end);
 InstallMethod(DigraphAddEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
 function(D, edges)
-  return MakeImmutableDigraph(DigraphAddEdges(DigraphMutableCopy(D), edges));
+  return MakeImmutable(DigraphAddEdges(DigraphMutableCopy(D), edges));
 end);
 
 InstallMethod(DigraphRemoveEdge,
@@ -300,7 +299,7 @@ InstallMethod(DigraphRemoveEdge,
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, src, ran)
   D := DigraphRemoveEdge(DigraphMutableCopy(D), src, ran);
-  return MakeImmutableDigraph(D);
+  return MakeImmutable(D);
 end);
 
 InstallMethod(DigraphRemoveEdge, "for a mutable digraph and a list",
@@ -317,7 +316,7 @@ InstallMethod(DigraphRemoveEdge,
 [IsImmutableDigraph, IsList],
 function(D, edge)
   D := DigraphRemoveEdge(DigraphMutableCopy(D), edge);
-  return MakeImmutableDigraph(D);
+  return MakeImmutable(D);
 end);
 
 InstallMethod(DigraphRemoveEdges, "for a digraph and a list",
@@ -333,8 +332,7 @@ end);
 InstallMethod(DigraphRemoveEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
 function(D, edges)
-  return MakeImmutableDigraph(DigraphRemoveEdges(DigraphMutableCopy(D),
-                                                 edges));
+  return MakeImmutable(DigraphRemoveEdges(DigraphMutableCopy(D), edges));
 end);
 
 InstallMethod(DigraphRemoveAllMultipleEdges, "for a mutable dense digraph",
@@ -367,7 +365,7 @@ InstallMethod(DigraphRemoveAllMultipleEdges, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   D := DigraphMutableCopy(D);
-  D := MakeImmutableDigraph(DigraphRemoveAllMultipleEdges(D));
+  D := MakeImmutable(DigraphRemoveAllMultipleEdges(D));
   SetIsMultiDigraph(D, false);
   return D;
 end);
@@ -412,7 +410,7 @@ InstallMethod(DigraphClosure,
 "for an immutable dense digraph and a positive integer",
 [IsImmutableDigraph, IsPosInt],
 function(D, k)
-  return MakeImmutableDigraph(DigraphClosure(DigraphMutableCopy(D), k));
+  return MakeImmutable(DigraphClosure(DigraphMutableCopy(D), k));
 end);
 
 InstallGlobalFunction(DigraphDisjointUnion,
@@ -596,7 +594,7 @@ InstallMethod(DigraphReflexiveTransitiveReduction, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   D := DigraphReflexiveTransitiveReduction(DigraphMutableCopy(D));
-  return MakeImmutableDigraph(D);
+  return MakeImmutable(D);
 end);
 
 InstallMethod(DigraphTransitiveReduction, "for a dense mutable digraph",
@@ -622,7 +620,7 @@ InstallMethod(DigraphTransitiveReduction, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   D := DigraphTransitiveReduction(DigraphMutableCopy(D));
-  return MakeImmutableDigraph(D);
+  return MakeImmutable(D);
 end);
 
 InstallMethod(DigraphReverse, "for a mutable dense digraph",
@@ -639,7 +637,7 @@ end);
 InstallMethod(DigraphReverse, "for a immutable digraph",
 [IsImmutableDigraph],
 function(D)
-  return MakeImmutableDigraph(DigraphReverse(DigraphMutableCopy(D)));
+  return MakeImmutable(DigraphReverse(DigraphMutableCopy(D)));
 end);
 
 InstallMethod(DigraphReverseEdge,
@@ -668,7 +666,7 @@ InstallMethod(DigraphReverseEdge,
 "for an immutable digraph, positive integer, and positive integer",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
-  return MakeImmutableDigraph(DigraphReverseEdge(DigraphMutableCopy(D), u, v));
+  return MakeImmutable(DigraphReverseEdge(DigraphMutableCopy(D), u, v));
 end);
 
 InstallMethod(DigraphReverseEdge, "for a mutable digraph and list",
@@ -683,7 +681,7 @@ end);
 InstallMethod(DigraphReverseEdge, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
 function(D, e)
-  return MakeImmutableDigraph(DigraphReverseEdge(DigraphMutableCopy(D), e));
+  return MakeImmutable(DigraphReverseEdge(DigraphMutableCopy(D), e));
 end);
 
 InstallMethod(DigraphReverseEdges, "for a mutable digraph and a list",
@@ -699,7 +697,7 @@ end);
 InstallMethod(DigraphReverseEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
 function(D, E)
-  return MakeImmutableDigraph(DigraphReverseEdges(DigraphMutableCopy(D), E));
+  return MakeImmutable(DigraphReverseEdges(DigraphMutableCopy(D), E));
 end);
 
 ###############################################################################
@@ -724,7 +722,7 @@ end);
 InstallMethod(OnDigraphs, "for a immutable digraph and a perm",
 [IsImmutableDigraph, IsPerm],
 function(D, p)
-  return MakeImmutableDigraph(OnDigraphs(DigraphMutableCopy(D), p));
+  return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), p));
 end);
 
 InstallMethod(OnDigraphs, "for a mutable dense digraph and a transformation",
@@ -749,7 +747,7 @@ end);
 InstallMethod(OnDigraphs, "for a immutable digraph and a transformation",
 [IsImmutableDigraph, IsTransformation],
 function(D, t)
-  return MakeImmutableDigraph(OnDigraphs(DigraphMutableCopy(D), t));
+  return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), t));
 end);
 
 # Not revising the following because multi-digraphs are being withdrawn in the
@@ -836,7 +834,7 @@ InstallMethod(InducedSubdigraph,
 "for an immutable digraph and a homogeneous list",
 [IsImmutableDigraph, IsHomogeneousList],
 function(D, list)
-  return MakeImmutableDigraph(InducedSubdigraph(DigraphMutableCopy(D), list));
+  return MakeImmutable(InducedSubdigraph(DigraphMutableCopy(D), list));
 end);
 
 InstallMethod(QuotientDigraph,
@@ -904,8 +902,7 @@ InstallMethod(QuotientDigraph,
 "for an immutable digraph and a homogeneous list",
 [IsImmutableDigraph, IsHomogeneousList],
 function(D, partition)
-  return MakeImmutableDigraph(QuotientDigraph(DigraphMutableCopy(D),
-                                              partition));
+  return MakeImmutable(QuotientDigraph(DigraphMutableCopy(D), partition));
 end);
 
 #############################################################################

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -38,21 +38,15 @@ end);
 
 InstallMethod(DigraphAddVertex, "for a immutable digraph and an object",
 [IsImmutableDigraph, IsObject],
-function(D, label)
-  return MakeImmutable(DigraphAddVertex(DigraphMutableCopy(D), label));
-end);
+{D, label} -> MakeImmutable(DigraphAddVertex(DigraphMutableCopy(D), label)));
 
 InstallMethod(DigraphAddVertex, "for a mutable digraph",
 [IsMutableDigraph],
-function(D)
-  return DigraphAddVertex(D, DigraphNrVertices(D) + 1);
-end);
+D -> DigraphAddVertex(D, DigraphNrVertices(D) + 1));
 
 InstallMethod(DigraphAddVertex, "for an immutable digraph",
 [IsImmutableDigraph],
-function(D)
-  return MakeImmutable(DigraphAddVertex(DigraphMutableCopy(D)));
-end);
+D -> MakeImmutable(DigraphAddVertex(DigraphMutableCopy(D))));
 
 InstallMethod(DigraphAddVertices, "for a mutable digraph and list",
 [IsMutableDigraph, IsList],
@@ -66,9 +60,7 @@ end);
 
 InstallMethod(DigraphAddVertices, "for an immutable digraph and list",
 [IsImmutableDigraph, IsList],
-function(D, labels)
-  return MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), labels));
-end);
+{D, labels} -> MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), labels)));
 
 InstallMethod(DigraphAddVertices, "for a mutable digraph and an integer",
 [IsMutableDigraph, IsInt],
@@ -83,9 +75,7 @@ end);
 
 InstallMethod(DigraphAddVertices, "for an immutable digraph and an integer",
 [IsImmutableDigraph, IsInt],
-function(D, m)
-  return MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), m));
-end);
+{D, m} -> MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), m)));
 
 InstallMethod(DigraphRemoveVertex,
 "for a mutable dense digraph and positive integer",
@@ -119,9 +109,7 @@ end);
 InstallMethod(DigraphRemoveVertex,
 "for an immutable digraph and positive integer",
 [IsImmutableDigraph, IsPosInt],
-function(D, m)
-  return MakeImmutable(DigraphRemoveVertex(DigraphMutableCopy(D), m));
-end);
+{D, m} -> MakeImmutable(DigraphRemoveVertex(DigraphMutableCopy(D), m)));
 
 InstallMethod(DigraphRemoveVertices, "for a mutable digraph and a list",
 [IsMutableDigraph, IsList],
@@ -236,9 +224,7 @@ end);
 InstallMethod(DigraphAddEdge,
 "for an immutable digraph, a positive integer, and a positive integer",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
-function(D, src, ran)
-  return MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), src, ran));
-end);
+{D, src, ran} -> MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), src, ran)));
 
 InstallMethod(DigraphAddEdge, "for a mutable digraph and a list",
 [IsMutableDigraph, IsList],
@@ -251,9 +237,7 @@ end);
 
 InstallMethod(DigraphAddEdge, "for a mutable digraph and a list",
 [IsImmutableDigraph, IsList],
-function(D, edge)
-  return MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), edge));
-end);
+{D, edge} -> MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), edge)));
 
 InstallMethod(DigraphAddEdges, "for a mutable digraph and a list",
 [IsMutableDigraph, IsList],
@@ -267,9 +251,7 @@ end);
 
 InstallMethod(DigraphAddEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
-function(D, edges)
-  return MakeImmutable(DigraphAddEdges(DigraphMutableCopy(D), edges));
-end);
+{D, edges} -> MakeImmutable(DigraphAddEdges(DigraphMutableCopy(D), edges)));
 
 InstallMethod(DigraphRemoveEdge,
 "for a mutable dense digraph, a positive integer, and a positive integer",
@@ -331,9 +313,7 @@ end);
 
 InstallMethod(DigraphRemoveEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
-function(D, edges)
-  return MakeImmutable(DigraphRemoveEdges(DigraphMutableCopy(D), edges));
-end);
+{D, edges} -> MakeImmutable(DigraphRemoveEdges(DigraphMutableCopy(D), edges)));
 
 InstallMethod(DigraphRemoveAllMultipleEdges, "for a mutable dense digraph",
 [IsMutableDigraph and IsDenseDigraphRep],
@@ -409,9 +389,7 @@ end);
 InstallMethod(DigraphClosure,
 "for an immutable dense digraph and a positive integer",
 [IsImmutableDigraph, IsPosInt],
-function(D, k)
-  return MakeImmutable(DigraphClosure(DigraphMutableCopy(D), k));
-end);
+{D, k} -> MakeImmutable(DigraphClosure(DigraphMutableCopy(D), k)));
 
 InstallGlobalFunction(DigraphDisjointUnion,
 function(arg)
@@ -636,9 +614,7 @@ end);
 
 InstallMethod(DigraphReverse, "for a immutable digraph",
 [IsImmutableDigraph],
-function(D)
-  return MakeImmutable(DigraphReverse(DigraphMutableCopy(D)));
-end);
+D -> MakeImmutable(DigraphReverse(DigraphMutableCopy(D))));
 
 InstallMethod(DigraphReverseEdge,
 "for a mutable dense digraph, positive integer, and positive integer",
@@ -665,9 +641,7 @@ end);
 InstallMethod(DigraphReverseEdge,
 "for an immutable digraph, positive integer, and positive integer",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
-function(D, u, v)
-  return MakeImmutable(DigraphReverseEdge(DigraphMutableCopy(D), u, v));
-end);
+{D, u, v} -> MakeImmutable(DigraphReverseEdge(DigraphMutableCopy(D), u, v)));
 
 InstallMethod(DigraphReverseEdge, "for a mutable digraph and list",
 [IsMutableDigraph, IsList],
@@ -680,9 +654,7 @@ end);
 
 InstallMethod(DigraphReverseEdge, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
-function(D, e)
-  return MakeImmutable(DigraphReverseEdge(DigraphMutableCopy(D), e));
-end);
+{D, e} -> MakeImmutable(DigraphReverseEdge(DigraphMutableCopy(D), e)));
 
 InstallMethod(DigraphReverseEdges, "for a mutable digraph and a list",
 [IsMutableDigraph, IsList],
@@ -696,9 +668,7 @@ end);
 
 InstallMethod(DigraphReverseEdges, "for an immutable digraph and a list",
 [IsImmutableDigraph, IsList],
-function(D, E)
-  return MakeImmutable(DigraphReverseEdges(DigraphMutableCopy(D), E));
-end);
+{D, E} -> MakeImmutable(DigraphReverseEdges(DigraphMutableCopy(D), E)));
 
 ###############################################################################
 # 4. Actions
@@ -721,9 +691,7 @@ end);
 
 InstallMethod(OnDigraphs, "for a immutable digraph and a perm",
 [IsImmutableDigraph, IsPerm],
-function(D, p)
-  return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), p));
-end);
+{D, p} -> MakeImmutable(OnDigraphs(DigraphMutableCopy(D), p)));
 
 InstallMethod(OnDigraphs, "for a mutable dense digraph and a transformation",
 [IsMutableDigraph and IsDenseDigraphRep, IsTransformation],
@@ -746,18 +714,14 @@ end);
 
 InstallMethod(OnDigraphs, "for a immutable digraph and a transformation",
 [IsImmutableDigraph, IsTransformation],
-function(D, t)
-  return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), t));
-end);
+{D, t} -> MakeImmutable(OnDigraphs(DigraphMutableCopy(D), t)));
 
 # Not revising the following because multi-digraphs are being withdrawn in the
 # near future.
 
 InstallMethod(OnMultiDigraphs, "for a digraph, perm and perm",
 [IsDigraph, IsPerm, IsPerm],
-function(D, perm1, perm2)
-  return OnMultiDigraphs(D, [perm1, perm2]);
-end);
+{D, perm1, perm2} -> OnMultiDigraphs(D, [perm1, perm2]));
 
 InstallMethod(OnMultiDigraphs, "for a digraph and perm coll",
 [IsDigraph, IsPermCollection],
@@ -831,9 +795,7 @@ end);
 InstallMethod(InducedSubdigraph,
 "for an immutable digraph and a homogeneous list",
 [IsImmutableDigraph, IsHomogeneousList],
-function(D, list)
-  return MakeImmutable(InducedSubdigraph(DigraphMutableCopy(D), list));
-end);
+{D, list} -> MakeImmutable(InducedSubdigraph(DigraphMutableCopy(D), list)));
 
 InstallMethod(QuotientDigraph,
 "for a dense mutable digraph and a homogeneous list",
@@ -921,9 +883,7 @@ InstallMethod(InNeighboursOfVertexNC,
 "for a digraph with in-neighbours and a vertex",
 [IsDigraph and HasInNeighbours, IsPosInt],
 2,  # to beat the next method for IsDenseDigraphRep
-function(D, v)
-  return InNeighbours(D)[v];
-end);
+{D, v} -> InNeighbours(D)[v]);
 
 InstallMethod(InNeighboursOfVertexNC, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
@@ -956,9 +916,7 @@ end);
 
 InstallMethod(OutNeighboursOfVertexNC, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
-function(D, v)
-  return OutNeighbours(D)[v];
-end);
+{D, v} -> OutNeighbours(D)[v]);
 
 InstallMethod(InDegreeOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
@@ -972,17 +930,13 @@ end);
 
 InstallMethod(InDegreeOfVertexNC, "for a digraph with in-degrees and a vertex",
 [IsDigraph and HasInDegrees, IsPosInt], 4,
-function(D, v)
-  return InDegrees(D)[v];
-end);
+{D, v} -> InDegrees(D)[v]);
 
 InstallMethod(InDegreeOfVertexNC,
 "for a digraph with in-neighbours and a vertex",
 [IsDigraph and HasInNeighbours, IsPosInt],
 2,  # to beat the next method for IsDenseDigraphRep
-function(D, v)
-  return Length(InNeighbours(D)[v]);
-end);
+{D, v} -> Length(InNeighbours(D)[v]));
 
 InstallMethod(InDegreeOfVertexNC, "for a digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
@@ -1014,15 +968,11 @@ InstallMethod(OutDegreeOfVertexNC,
 "for a digraph with out-degrees and a vertex",
 [IsDigraph and HasOutDegrees, IsPosInt],
 2,  # to beat the next method for IsDenseDigraphRep
-function(D, v)
-  return OutDegrees(D)[v];
-end);
+{D, v} -> OutDegrees(D)[v]);
 
 InstallMethod(OutDegreeOfVertexNC, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
-function(D, v)
-  return Length(OutNeighbours(D)[v]);
-end);
+{D, v} -> Length(OutNeighbours(D)[v]));
 
 InstallMethod(DigraphOutEdges, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
@@ -1050,24 +1000,16 @@ end);
 
 InstallMethod(OutNeighboursMutableCopy, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return List(OutNeighbours(D), ShallowCopy);
-end);
+D -> List(OutNeighbours(D), ShallowCopy));
 
 InstallMethod(InNeighboursMutableCopy, "for a digraph", [IsDigraph],
-function(D)
-  return List(InNeighbours(D), ShallowCopy);
-end);
+D -> List(InNeighbours(D), ShallowCopy));
 
 InstallMethod(AdjacencyMatrixMutableCopy, "for a digraph", [IsDigraph],
-function(D)
-  return List(AdjacencyMatrix(D), ShallowCopy);
-end);
+D -> List(AdjacencyMatrix(D), ShallowCopy));
 
 InstallMethod(BooleanAdjacencyMatrixMutableCopy, "for a digraph", [IsDigraph],
-function(D)
-  return List(BooleanAdjacencyMatrix(D), ShallowCopy);
-end);
+D -> List(BooleanAdjacencyMatrix(D), ShallowCopy));
 
 #############################################################################
 # 8.  IsSomething
@@ -1199,9 +1141,7 @@ end);
 
 InstallMethod(IsMatching, "for a digraph and a list",
 [IsDigraph, IsHomogeneousList],
-function(D, edges)
-  return DIGRAPHS_Matching(D, edges) <> false;
-end);
+{D, edges} -> DIGRAPHS_Matching(D, edges) <> false);
 
 InstallMethod(IsPerfectMatching, "for a digraph and a list",
 [IsDigraph, IsHomogeneousList],
@@ -1623,9 +1563,7 @@ function(D, v)
 end);
 
 InstallMethod(DIGRAPHS_Layers, "for a digraph", [IsDigraph],
-function(D)
-  return [];
-end);
+D -> EmptyPlist(0));
 
 InstallMethod(DigraphDistanceSet,
 "for a digraph, a vertex, and a non-negative integers",

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -756,14 +756,12 @@ end);
 InstallMethod(OnMultiDigraphs, "for a digraph, perm and perm",
 [IsDigraph, IsPerm, IsPerm],
 function(D, perm1, perm2)
-  IsValidDigraph(D);
   return OnMultiDigraphs(D, [perm1, perm2]);
 end);
 
 InstallMethod(OnMultiDigraphs, "for a digraph and perm coll",
 [IsDigraph, IsPermCollection],
 function(D, perms)
-  IsValidDigraph(D);
   if Length(perms) <> 2 then
     ErrorNoReturn("the 2nd argument <perms> must be a pair of permutations,");
   fi;
@@ -912,7 +910,6 @@ end);
 InstallMethod(InNeighboursOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -925,7 +922,6 @@ InstallMethod(InNeighboursOfVertexNC,
 [IsDigraph and HasInNeighbours, IsPosInt],
 2,  # to beat the next method for IsDenseDigraphRep
 function(D, v)
-  IsValidDigraph(D);
   return InNeighbours(D)[v];
 end);
 
@@ -951,7 +947,6 @@ end);
 InstallMethod(OutNeighboursOfVertex, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -968,7 +963,6 @@ end);
 InstallMethod(InDegreeOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -1009,7 +1003,6 @@ end);
 InstallMethod(OutDegreeOfVertex, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -1028,14 +1021,12 @@ end);
 InstallMethod(OutDegreeOfVertexNC, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   return Length(OutNeighbours(D)[v]);
 end);
 
 InstallMethod(DigraphOutEdges, "for a dense digraph and a vertex",
 [IsDenseDigraphRep, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -1046,7 +1037,6 @@ end);
 InstallMethod(DigraphInEdges, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -1061,25 +1051,21 @@ end);
 InstallMethod(OutNeighboursMutableCopy, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return List(OutNeighbours(D), ShallowCopy);
 end);
 
 InstallMethod(InNeighboursMutableCopy, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return List(InNeighbours(D), ShallowCopy);
 end);
 
 InstallMethod(AdjacencyMatrixMutableCopy, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return List(AdjacencyMatrix(D), ShallowCopy);
 end);
 
 InstallMethod(BooleanAdjacencyMatrixMutableCopy, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return List(BooleanAdjacencyMatrix(D), ShallowCopy);
 end);
 
@@ -1090,7 +1076,6 @@ end);
 InstallMethod(IsDigraphEdge, "for a digraph and a list",
 [IsDigraph, IsList],
 function(D, edge)
-  IsValidDigraph(D);
   if Length(edge) <> 2 or not IsPosInt(edge[1]) or not IsPosInt(edge[2]) then
     return false;
   fi;
@@ -1101,7 +1086,6 @@ InstallMethod(IsDigraphEdge, "for a dense digraph, int, int",
 [IsDenseDigraphRep, IsInt, IsInt],
 function(D, u, v)
   local n;
-  IsValidDigraph(D);
 
   n := DigraphNrVertices(D);
 
@@ -1119,7 +1103,6 @@ InstallMethod(IsSubdigraph, "for a dense digraph and dense digraph",
 [IsDenseDigraphRep, IsDenseDigraphRep],
 function(super, sub)
   local n, x, y, i, j;
-  IsValidDigraph(super, sub);
 
   n := DigraphNrVertices(super);
   if n <> DigraphNrVertices(sub)
@@ -1158,7 +1141,6 @@ InstallMethod(IsUndirectedSpanningForest, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(super, sub)
   local sym, comps1, comps2;
-  IsValidDigraph(super, sub);
 
   if not IsUndirectedForest(sub) then
     return false;
@@ -1183,7 +1165,6 @@ end);
 InstallMethod(IsUndirectedSpanningTree, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(super, sub)
-  IsValidDigraph(super, sub);
   super := DigraphCopyIfMutable(super);
   return IsConnectedDigraph(MaximalSymmetricSubdigraph(super))
     and IsUndirectedSpanningForest(super, sub);
@@ -1219,7 +1200,6 @@ end);
 InstallMethod(IsMatching, "for a digraph and a list",
 [IsDigraph, IsHomogeneousList],
 function(D, edges)
-  IsValidDigraph(D);
   return DIGRAPHS_Matching(D, edges) <> false;
 end);
 
@@ -1227,7 +1207,6 @@ InstallMethod(IsPerfectMatching, "for a digraph and a list",
 [IsDigraph, IsHomogeneousList],
 function(D, edges)
   local seen;
-  IsValidDigraph(D);
 
   seen := DIGRAPHS_Matching(D, edges);
   if seen = false then
@@ -1240,7 +1219,6 @@ InstallMethod(IsMaximalMatching, "for a digraph and a list",
 [IsDenseDigraphRep, IsHomogeneousList],
 function(D, edges)
   local seen, nbs, i, j;
-  IsValidDigraph(D);
 
   seen := DIGRAPHS_Matching(D, edges);
   if seen = false then
@@ -1268,7 +1246,6 @@ InstallMethod(DigraphFloydWarshall,
 [IsDenseDigraphRep, IsFunction, IsObject, IsObject],
 function(D, func, nopath, edge)
   local vertices, n, mat, out, i, j, k;
-  IsValidDigraph(D);
 
   vertices := DigraphVertices(D);
   n := DigraphNrVertices(D);
@@ -1303,7 +1280,6 @@ InstallMethod(DigraphStronglyConnectedComponent, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
   local scc;
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -1319,7 +1295,6 @@ InstallMethod(DigraphConnectedComponent, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
   local wcc;
-  IsValidDigraph(D);
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
                   "1st argument <D>,");
@@ -1332,7 +1307,6 @@ InstallMethod(IsReachable, "for a digraph and two pos ints",
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
   local verts, scc;
-  IsValidDigraph(D);
 
   verts := DigraphVertices(D);
   if not (u in verts and v in verts) then
@@ -1358,7 +1332,6 @@ InstallMethod(DigraphPath, "for a dense digraph and two pos ints",
 [IsDenseDigraphRep, IsPosInt, IsPosInt],
 function(D, u, v)
   local verts;
-  IsValidDigraph(D);
 
   verts := DigraphVertices(D);
   if not (u in verts and v in verts) then
@@ -1383,7 +1356,6 @@ InstallMethod(DigraphShortestPath, "for a dense digraph and two pos ints",
 function(D, u, v)
   local current, next, parent, distance, falselist, verts, nbs, path, edge,
   n, a, b, i;
-  IsValidDigraph(D);
 
   verts := DigraphVertices(D);
   if not (u in verts and v in verts) then
@@ -1448,7 +1420,6 @@ end);
 InstallMethod(IteratorOfPaths, "for a dense digraph and two pos ints",
 [IsDenseDigraphRep, IsPosInt, IsPosInt],
 function(D, u, v)
-  IsValidDigraph(D);
   if not (u in DigraphVertices(D) and v in DigraphVertices(D)) then
     ErrorNoReturn("the 2nd and 3rd arguments <u> and <v> must be ",
                   "vertices of the 1st argument <D>,");
@@ -1588,7 +1559,6 @@ InstallMethod(DigraphLongestDistanceFromVertex, "for a digraph and a pos int",
 [IsDenseDigraphRep, IsPosInt],
 function(D, v)
   local dist;
-  IsValidDigraph(D);
 
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> must be a vertex of the 1st ",
@@ -1606,7 +1576,6 @@ InstallMethod(DigraphLayers, "for a digraph, and a vertex",
 function(D, v)
   local layers, gens, sch, trace, rep, word, orbs, layers_with_orbnums,
         layers_of_v, i, x;
-  IsValidDigraph(D);
 
   # TODO: make use of known distances matrix
   if v > DigraphNrVertices(D) then
@@ -1662,7 +1631,6 @@ InstallMethod(DigraphDistanceSet,
 "for a digraph, a vertex, and a non-negative integers",
 [IsDigraph, IsPosInt, IsInt],
 function(D, vertex, distance)
-  IsValidDigraph(D);
   if vertex > DigraphNrVertices(D) then
     ErrorNoReturn("the 2nd argument <vertex> must be a vertex of the ",
                   "digraph,");
@@ -1678,7 +1646,6 @@ InstallMethod(DigraphDistanceSet,
 [IsDigraph, IsPosInt, IsList],
 function(D, vertex, distances)
   local layers;
-  IsValidDigraph(D);
   if vertex > DigraphNrVertices(D) then
     ErrorNoReturn("the 2nd argument <vertex> must be a vertex of ",
                   "the digraph,");
@@ -1697,7 +1664,6 @@ InstallMethod(DigraphShortestDistance,
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
   local dist;
-  IsValidDigraph(D);
 
   if u > DigraphNrVertices(D) or v > DigraphNrVertices(D) then
     ErrorNoReturn("the 2nd and 3rd arguments <u> and <v> must be ",
@@ -1719,7 +1685,6 @@ InstallMethod(DigraphShortestDistance, "for a digraph, a list, and a list",
 [IsDigraph, IsList, IsList],
 function(D, list1, list2)
   local shortest, u, v;
-  IsValidDigraph(D);
 
   # TODO: can this be improved?
   shortest := infinity;
@@ -1736,7 +1701,6 @@ end);
 InstallMethod(DigraphShortestDistance, "for a digraph, and a list",
 [IsDigraph, IsList],
 function(D, list)
-  IsValidDigraph(D);
 
   if Length(list) <> 2 then
     ErrorNoReturn("the 2nd argument <list> must be a list of length 2,");
@@ -1761,7 +1725,6 @@ InstallMethod(PartialOrderDigraphJoinOfVertices,
 function(D, i, j)
   local x, nbs, intr;
 
-  IsValidDigraph(D);
   if not IsPartialOrderDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must satisfy ",
                   "IsPartialOrderDigraph,");
@@ -1789,7 +1752,6 @@ InstallMethod(PartialOrderDigraphMeetOfVertices,
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, i, j)
   local x, nbs, intr;
-  IsValidDigraph(D);
 
   if not IsPartialOrderDigraph(D) then
     ErrorNoReturn("the 1st argument <D> must satisfy ",

--- a/gap/orbits.gi
+++ b/gap/orbits.gi
@@ -125,9 +125,7 @@ function(D)
 end);
 
 InstallMethod(DigraphOrbitReps, "for a digraph", [IsDigraph],
-function(D)
-  return List(DigraphOrbits(D), Representative);
-end);
+D -> List(DigraphOrbits(D), Representative));
 
 InstallMethod(DigraphStabilizer, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],

--- a/gap/orbits.gi
+++ b/gap/orbits.gi
@@ -72,7 +72,6 @@ InstallMethod(RepresentativeOutNeighbours, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local reps, out, nbs, i;
-  IsValidDigraph(D);
 
   if IsTrivial(DigraphGroup(D)) then
     return OutNeighbours(D);
@@ -99,7 +98,6 @@ end);
 InstallMethod(DigraphGroup, "for a digraph",
 [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsMultiDigraph(D) then
     return Range(Projection(AutomorphismGroup(D), 1));
   fi;
@@ -110,7 +108,6 @@ InstallMethod(DigraphOrbits, "for a digraph",
 [IsDigraph],
 function(D)
   local record;
-  IsValidDigraph(D);
   record := DIGRAPHS_Orbits(DigraphGroup(D),
                             DigraphVertices(D));
   SetDigraphSchreierVector(D, record.schreier);
@@ -121,7 +118,6 @@ InstallMethod(DigraphSchreierVector, "for a digraph",
 [IsDigraph],
 function(D)
   local record;
-  IsValidDigraph(D);
   record := DIGRAPHS_Orbits(DigraphGroup(D),
                             DigraphVertices(D));
   SetDigraphOrbits(D, record.orbits);
@@ -130,7 +126,6 @@ end);
 
 InstallMethod(DigraphOrbitReps, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return List(DigraphOrbits(D), Representative);
 end);
 
@@ -138,7 +133,6 @@ InstallMethod(DigraphStabilizer, "for a digraph and a vertex",
 [IsDigraph, IsPosInt],
 function(D, v)
   local pos, gens, sch, trace, word, stabs;
-  IsValidDigraph(D);
 
   if v > DigraphNrVertices(D) then
     ErrorNoReturn("the 2nd argument <v> must not exceed ",

--- a/gap/planar.gi
+++ b/gap/planar.gi
@@ -32,7 +32,6 @@
 
 InstallMethod(PlanarEmbedding, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if DigraphNrEdges(D) = 0 or DigraphNrVertices(D) < 3 then
     return [];
   elif HasIsPlanarDigraph(D) and not IsPlanarDigraph(D) then
@@ -45,7 +44,6 @@ end);
 
 InstallMethod(OuterPlanarEmbedding, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if DigraphNrEdges(D) = 0 or DigraphNrVertices(D) < 3 then
     return [];
   elif HasIsOuterPlanarDigraph(D) and not IsOuterPlanarDigraph(D) then
@@ -58,7 +56,6 @@ end);
 
 InstallMethod(KuratowskiPlanarSubdigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsPlanarDigraph(D) then
     return fail;
   fi;
@@ -69,7 +66,6 @@ end);
 
 InstallMethod(KuratowskiOuterPlanarSubdigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
@@ -80,7 +76,6 @@ end);
 
 InstallMethod(SubdigraphHomeomorphicToK23, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
@@ -91,7 +86,6 @@ end);
 
 InstallMethod(SubdigraphHomeomorphicToK4, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
@@ -102,7 +96,6 @@ end);
 
 InstallMethod(SubdigraphHomeomorphicToK33, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsPlanarDigraph(D) then
     return fail;
   fi;
@@ -118,7 +111,6 @@ end);
 InstallMethod(IsPlanarDigraph, "for a digraph", [IsDigraph],
 function(D)
   local C, v, e;
-  IsValidDigraph(D);
   C := DigraphCopyIfMutable(D);
   C := DigraphRemoveAllMultipleEdges(C);
   C := MaximalAntiSymmetricSubdigraph(C);
@@ -136,7 +128,6 @@ end);
 InstallMethod(IsOuterPlanarDigraph, "for a digraph", [IsDigraph],
 function(D)
   local C, v, e;
-  IsValidDigraph(D);
   if HasIsPlanarDigraph(D) and not IsPlanarDigraph(D) then
     return false;
   fi;

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -14,20 +14,17 @@ IS_MULTI_DIGRAPH);
 
 InstallMethod(IsChainDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return IsDirectedTree(D) and IsSubset([0, 1], OutDegreeSet(D));
 end);
 
 InstallMethod(IsCycleDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return DigraphNrVertices(D) > 0 and IsStronglyConnectedDigraph(D)
          and DigraphNrEdges(D) = DigraphNrVertices(D);
 end);
 
 InstallMethod(IsBiconnectedDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return IsEmpty(ArticulationPoints(D)) and IsConnectedDigraph(D);
 end);
 
@@ -62,7 +59,6 @@ InstallMethod(IsJoinSemilatticeDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local topo, list;
-  IsValidDigraph(D);
   if not IsPartialOrderDigraph(D) then
     return false;
   fi;
@@ -78,7 +74,6 @@ InstallMethod(IsMeetSemilatticeDigraph, "for a digraph",
 [IsDigraph],
 function(D)
   local topo, list;
-  IsValidDigraph(D);
   if not IsPartialOrderDigraph(D) then
     return false;
   fi;
@@ -92,7 +87,6 @@ end);
 InstallMethod(IsStronglyConnectedDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return IS_STRONGLY_CONNECTED_DIGRAPH(OutNeighbours(D));
 end);
 
@@ -100,7 +94,6 @@ InstallMethod(IsCompleteDigraph, "for a digraph",
 [IsDigraph],
 function(D)
   local n;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   if n = 0 then
     return true;
@@ -116,7 +109,6 @@ InstallMethod(IsCompleteBipartiteDigraph, "for a digraph",
 [IsDigraph],
 function(D)
   local bicomps;
-  IsValidDigraph(D);
 
   if IsMultiDigraph(D) then
     return false;
@@ -133,7 +125,6 @@ end);
 InstallMethod(IsConnectedDigraph, "for a digraph", [IsDigraph],
 function(D)
   # Check for easy answers
-  IsValidDigraph(D);
   if DigraphNrVertices(D) < 2 then
     return true;
   elif HasIsStronglyConnectedDigraph(D)
@@ -158,7 +149,6 @@ end);
 InstallImmediateMethod(IsAcyclicDigraph, "for a strongly connected digraph",
 IsStronglyConnectedDigraph, 0,
 function(D)
-  IsValidDigraph(D);
   if DigraphNrVertices(D) > 1 then
     return false;
   fi;
@@ -169,7 +159,6 @@ InstallMethod(IsAcyclicDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local n, scc;
-  IsValidDigraph(D);
   n := DigraphNrVertices(D);
   if n = 0 then
     return true;
@@ -198,7 +187,6 @@ InstallMethod(IsSymmetricDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local out, inn, new, i;
-  IsValidDigraph(D);
 
   out := OutNeighbours(D);
   inn := InNeighbours(D);
@@ -219,14 +207,12 @@ end);
 InstallMethod(IsFunctionalDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return ForAll(OutNeighbours(D), x -> Length(x) = 1);
 end);
 
 InstallMethod(IsTournament, "for a digraph", [IsDigraph],
 function(D)
   local n;
-  IsValidDigraph(D);
 
   if IsMultiDigraph(D) then
     return false;
@@ -253,14 +239,12 @@ InstallMethod(IsEmptyDigraph, "for a digraph with known number of edges",
 [IsDigraph and HasDigraphNrEdges],
 2,  # to beat the method for IsDenseDigraphRep
 function(D)
-  IsValidDigraph(D);
   return DigraphNrEdges(D) = 0;
 end);
 
 InstallMethod(IsEmptyDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return ForAll(OutNeighbours(D), IsEmpty);
 end);
 
@@ -269,7 +253,6 @@ InstallMethod(IsReflexiveDigraph, "for a digraph with adjacency matrix",
 2,  # to beat the method for IsDenseDigraphRep
 function(D)
   local mat, i;
-  IsValidDigraph(D);
   mat := AdjacencyMatrix(D);
   for i in DigraphVertices(D) do
     if mat[i][i] = 0 then
@@ -283,7 +266,6 @@ InstallMethod(IsReflexiveDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
   local list;
-  IsValidDigraph(D);
   list := OutNeighbours(D);
   return ForAll(DigraphVertices(D), x -> x in list[x]);
 end);
@@ -302,7 +284,6 @@ InstallMethod(DigraphHasLoops, "for a digraph with adjacency matrix",
 2,  # to beat the method for IsDenseDigraphRep
 function(D)
   local mat, i;
-  IsValidDigraph(D);
   mat := AdjacencyMatrix(D);
   for i in DigraphVertices(D) do
     if mat[i][i] <> 0 then
@@ -315,7 +296,6 @@ end);
 InstallMethod(DigraphHasLoops, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local list, i;
-  IsValidDigraph(D);
   list := OutNeighbours(D);
   for i in DigraphVertices(D) do
     if i in list[i] then
@@ -327,21 +307,18 @@ end);
 
 InstallMethod(IsAperiodicDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return DigraphPeriod(D) = 1;
 end);
 
 InstallMethod(IsAntisymmetricDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
 function(D)
-  IsValidDigraph(D);
   return IS_ANTISYMMETRIC_DIGRAPH(OutNeighbours(D));
 end);
 
 InstallMethod(IsTransitiveDigraph, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
   local n, m, sorted, verts, out, trans, reflex, v, u;
-  IsValidDigraph(D);
 
   n := DigraphNrVertices(D);
   m := DigraphNrEdges(D);
@@ -383,7 +360,6 @@ end);
 
 InstallMethod(IsBipartiteDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if HasDigraphHasLoops(D) and DigraphHasLoops(D) then
     return false;
   fi;
@@ -392,25 +368,21 @@ end);
 
 InstallMethod(IsInRegularDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Length(InDegreeSet(D)) = 1;
 end);
 
 InstallMethod(IsOutRegularDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return Length(OutDegreeSet(D)) = 1;
 end);
 
 InstallMethod(IsRegularDigraph, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return IsInRegularDigraph(D) and IsOutRegularDigraph(D);
 end);
 
 InstallMethod(IsUndirectedTree, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   return DigraphNrEdges(D) = 2 * (DigraphNrVertices(D) - 1)
            and IsSymmetricDigraph(D) and IsConnectedDigraph(D);
 end);
@@ -418,7 +390,6 @@ end);
 InstallMethod(IsUndirectedForest, "for a digraph", [IsDigraph],
 function(D)
   local comps, comp;
-  IsValidDigraph(D);
   if not IsSymmetricDigraph(D) or DigraphNrVertices(D) = 0
       or IsMultiDigraph(D) then
     return false;
@@ -436,7 +407,6 @@ end);
 InstallMethod(IsDistanceRegularDigraph, "for a digraph", [IsDigraph],
 function(D)
   local reps, record, localParameters, localDiameter, i;
-  IsValidDigraph(D);
   if IsEmptyDigraph(D) then
     return true;
   elif not IsSymmetricDigraph(D) or not IsConnectedDigraph(D) then
@@ -460,7 +430,6 @@ end);
 
 InstallMethod(IsDirectedTree, "for a digraph", [IsDigraph],
 function(D)
-  IsValidDigraph(D);
   if IsNullDigraph(D) then
     return DigraphNrVertices(D) = 1;
   else
@@ -471,7 +440,6 @@ end);
 InstallMethod(IsEulerianDigraph, "for a digraph", [IsDigraph],
 function(D)
   local i;
-  IsValidDigraph(D);
   if not IsStronglyConnectedDigraph(ReducedDigraph(D)) then
      return false;
   fi;
@@ -507,7 +475,6 @@ InstallMethod(IsHamiltonianDigraph, "for a digraph", [IsDigraph],
 function(D)
   local indegs, fulldegs, outdegs, n, checkMT, check41, check42,
         dominatedcheck, dominatingcheck, adjmatrix, i, j, k, tempblist;
-  IsValidDigraph(D);
   if DigraphNrVertices(D) <= 1 and IsEmptyDigraph(D) then
     return true;
   elif not IsStronglyConnectedDigraph(D) then

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -13,9 +13,7 @@ InstallMethod(IsMultiDigraph, "for a dense digraph", [IsDenseDigraphRep],
 IS_MULTI_DIGRAPH);
 
 InstallMethod(IsChainDigraph, "for a digraph", [IsDigraph],
-function(D)
-  return IsDirectedTree(D) and IsSubset([0, 1], OutDegreeSet(D));
-end);
+D -> IsDirectedTree(D) and IsSubset([0, 1], OutDegreeSet(D)));
 
 InstallMethod(IsCycleDigraph, "for a digraph", [IsDigraph],
 function(D)
@@ -24,9 +22,7 @@ function(D)
 end);
 
 InstallMethod(IsBiconnectedDigraph, "for a digraph", [IsDigraph],
-function(D)
-  return IsEmpty(ArticulationPoints(D)) and IsConnectedDigraph(D);
-end);
+D -> IsEmpty(ArticulationPoints(D)) and IsConnectedDigraph(D));
 
 InstallMethod(DIGRAPHS_IsMeetJoinSemilatticeDigraph,
 "for a homogeneous list and a positive integer",
@@ -86,9 +82,7 @@ end);
 
 InstallMethod(IsStronglyConnectedDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return IS_STRONGLY_CONNECTED_DIGRAPH(OutNeighbours(D));
-end);
+D -> IS_STRONGLY_CONNECTED_DIGRAPH(OutNeighbours(D)));
 
 InstallMethod(IsCompleteDigraph, "for a digraph",
 [IsDigraph],
@@ -206,9 +200,7 @@ end);
 
 InstallMethod(IsFunctionalDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return ForAll(OutNeighbours(D), x -> Length(x) = 1);
-end);
+D -> ForAll(OutNeighbours(D), x -> Length(x) = 1));
 
 InstallMethod(IsTournament, "for a digraph", [IsDigraph],
 function(D)
@@ -238,15 +230,11 @@ end);
 InstallMethod(IsEmptyDigraph, "for a digraph with known number of edges",
 [IsDigraph and HasDigraphNrEdges],
 2,  # to beat the method for IsDenseDigraphRep
-function(D)
-  return DigraphNrEdges(D) = 0;
-end);
+D -> DigraphNrEdges(D) = 0);
 
 InstallMethod(IsEmptyDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return ForAll(OutNeighbours(D), IsEmpty);
-end);
+D -> ForAll(OutNeighbours(D), IsEmpty));
 
 InstallMethod(IsReflexiveDigraph, "for a digraph with adjacency matrix",
 [IsDigraph and HasAdjacencyMatrix],
@@ -306,15 +294,11 @@ function(D)
 end);
 
 InstallMethod(IsAperiodicDigraph, "for a digraph", [IsDigraph],
-function(D)
-  return DigraphPeriod(D) = 1;
-end);
+D -> DigraphPeriod(D) = 1);
 
 InstallMethod(IsAntisymmetricDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
-function(D)
-  return IS_ANTISYMMETRIC_DIGRAPH(OutNeighbours(D));
-end);
+D -> IS_ANTISYMMETRIC_DIGRAPH(OutNeighbours(D)));
 
 InstallMethod(IsTransitiveDigraph, "for a dense digraph", [IsDenseDigraphRep],
 function(D)
@@ -367,19 +351,13 @@ function(D)
 end);
 
 InstallMethod(IsInRegularDigraph, "for a digraph", [IsDigraph],
-function(D)
-  return Length(InDegreeSet(D)) = 1;
-end);
+D -> Length(InDegreeSet(D)) = 1);
 
 InstallMethod(IsOutRegularDigraph, "for a digraph", [IsDigraph],
-function(D)
-  return Length(OutDegreeSet(D)) = 1;
-end);
+D -> Length(OutDegreeSet(D)) = 1);
 
 InstallMethod(IsRegularDigraph, "for a digraph", [IsDigraph],
-function(D)
-  return IsInRegularDigraph(D) and IsOutRegularDigraph(D);
-end);
+D -> IsInRegularDigraph(D) and IsOutRegularDigraph(D));
 
 InstallMethod(IsUndirectedTree, "for a digraph", [IsDigraph],
 function(D)

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2001,7 +2001,7 @@ gap> DigraphTransitiveClosure(D);
 Error, the argument <D> must be a digraph with no multiple edges,
 gap> DigraphReflexiveTransitiveClosure(D);
 Error, the argument <D> must be a digraph with no multiple edges,
-gap> MakeImmutableDigraph(D);
+gap> MakeImmutable(D);
 <immutable multidigraph with 2 vertices, 2 edges>
 gap> DigraphTransitiveClosure(D);
 Error, the argument <D> must be a digraph with no multiple edges,
@@ -2019,7 +2019,7 @@ gap> D := DigraphMutableCopy(DigraphSymmetricClosure(D));
 <mutable digraph with 2 vertices, 2 edges>
 gap> MaximalSymmetricSubdigraphWithoutLoops(D);
 <mutable digraph with 2 vertices, 2 edges>
-gap> MaximalSymmetricSubdigraphWithoutLoops(MakeImmutableDigraph(D));
+gap> MaximalSymmetricSubdigraphWithoutLoops(MakeImmutable(D));
 <immutable digraph with 2 vertices, 2 edges>
 gap> MaximalSymmetricSubdigraphWithoutLoops(D);
 <immutable digraph with 2 vertices, 2 edges>

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1201,7 +1201,7 @@ gap> IsIdenticalObj(DigraphSinks(D), DigraphSinks(D));
 false
 gap> IsIdenticalObj(list, D!.OutNeighbours);
 true
-gap> D := DigraphNC(IsMutableDigraph, OutNeighbours(MakeImmutableDigraph(D)));
+gap> D := DigraphNC(IsMutableDigraph, OutNeighbours(MakeImmutable(D)));
 <mutable digraph with 2 vertices, 2 edges>
 gap> D := DigraphNC(rec(xxx := 1, DigraphRange := [], DigraphSource := [],
 >  DigraphNrVertices := 1000));
@@ -1358,8 +1358,6 @@ gap> D := NullDigraph(IsMutableDigraph, 10);
 <mutable digraph with 10 vertices, 0 edges>
 gap> MakeImmutable(D);;
 gap> IsValidDigraph(D);
-Error, digraph in an invalid state! Did you return a mutable digraph from a me\
-thod for an attribute, or MakeImmutable(a mutable digraph)??
 
 # 
 gap> D := NullDigraph(10);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1353,11 +1353,11 @@ gap> S := AsMonoid(IsTransformation, di);;
 Error, the 1st argument <filt> must be IsPartialPermMonoid or IsPartialPermSem\
 igroup,
 
-#
+# MakeImmutable
 gap> D := NullDigraph(IsMutableDigraph, 10);
 <mutable digraph with 10 vertices, 0 edges>
-gap> MakeImmutable(D);;
-gap> IsValidDigraph(D);
+gap> MakeImmutable(D);
+<immutable digraph with 10 vertices, 0 edges>
 
 # 
 gap> D := NullDigraph(10);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1913,7 +1913,7 @@ gap> DigraphReverseEdge(D, 1, 1);
 gap> DigraphReverseEdge(D, 1, 4);
 Error, there is no edge from 1 to 
 4 in the digraph <D> that is the 1st argument,
-gap> D := MakeImmutableDigraph(D);
+gap> D := MakeImmutable(D);
 <immutable digraph with 3 vertices, 7 edges>
 gap> D := DigraphReverseEdge(D, 1, 2);
 <immutable multidigraph with 3 vertices, 7 edges>
@@ -1934,7 +1934,7 @@ gap> DD := QuotientDigraph(D, [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]);
 gap> InNeighboursOfVertexNC(DD, 1);
 [ 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 
   4, 4 ]
-gap> MakeImmutableDigraph(DD);
+gap> MakeImmutable(DD);
 <immutable multidigraph with 4 vertices, 90 edges>
 gap> InNeighbours(DD);;
 gap> InNeighboursOfVertexNC(DD, 1);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -341,12 +341,11 @@ gap> gr := DigraphFromDigraph6String(str);
 gap> str = Digraph6String(gr);
 true
 
-# IsDigraphValid
+# IsValidDigraph
 gap> D := NullDigraph(IsMutableDigraph, 10);
 <mutable digraph with 10 vertices, 0 edges>
 gap> MakeImmutable(D);
-Error, digraph in an invalid state! Did you return a mutable digraph from a me\
-thod for an attribute, or MakeImmutable(a mutable digraph)??
+<immutable digraph with 10 vertices, 0 edges>
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -341,7 +341,7 @@ gap> gr := DigraphFromDigraph6String(str);
 gap> str = Digraph6String(gr);
 true
 
-# IsValidDigraph
+# MakeImmutable
 gap> D := NullDigraph(IsMutableDigraph, 10);
 <mutable digraph with 10 vertices, 0 edges>
 gap> MakeImmutable(D);


### PR DESCRIPTION
Using the function `PostMakeImmutable` to do the important stuff previously done in `MakeImmutableDigraph`.