### PR TITLE
GAP Days 3: Sanity-checking and changes for digraph.g* and oper.g* (mostly related to mutability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Licensing information can be found in the LICENSE file.
 
 Version 1.0.0!
 DigraphColoring (american spelling) was removed.
-Changed IsEulerian
+Changed IsEulerian.
+QuotientDigraph is changed.
 
 ## Version 0.15.4 (released 06/08/2019)
 

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -162,7 +162,7 @@ rec( adjacencies := [ [ 1, 2 ], [ 3 ], [  ] ], group := Group(()),
 gap> gr := Digraph([[1], [3], [2]]);
 <immutable digraph with 3 vertices, 3 edges>
 gap> gr := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> AsTransformation(gr);
 Transformation( [ 2, 3, 1 ] )
 gap> AsPermutation(last);
@@ -287,7 +287,7 @@ gap> CharacteristicPolynomial(gr);
 x_1^10-3*x_1^9-7*x_1^8-x_1^7+14*x_1^6+x_1^5-26*x_1^4+51*x_1^3-10*x_1^2\
 +18*x_1-30
 gap> gr := CompleteDigraph(5);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> CharacteristicPolynomial(gr);
 x_1^5-10*x_1^3-20*x_1^2-15*x_1-4
 ]]></Example>
@@ -718,7 +718,7 @@ rec( comps := [ [ 1, 2 ], [ 3 ] ], id := [ 1, 1, 2 ] )
 gap> DigraphNrConnectedComponents(gr);
 2
 gap> gr := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphConnectedComponents(gr);
 rec( comps := [  ], id := [  ] )
 ]]></Example>
@@ -825,7 +825,7 @@ gap> gr := Digraph([[2], [3, 5], [4], [5], [1, 2]]);
 gap> DigraphPeriod(gr);
 1
 gap> gr := ChainDigraph(2);
-<immutable digraph with 2 vertices, 1 edge>
+<immutable chain digraph with 2 vertices>
 gap> DigraphPeriod(gr);
 0
 gap> IsAcyclicDigraph(gr);
@@ -856,7 +856,7 @@ gap> gr := Digraph([[2], [3], [4, 5], [5], [1, 2, 3, 4, 5]]);
 gap> DigraphDiameter(gr);
 3
 gap> gr := ChainDigraph(2);
-<immutable digraph with 2 vertices, 1 edge>
+<immutable chain digraph with 2 vertices>
 gap> DigraphDiameter(gr);
 fail
 gap> IsStronglyConnectedDigraph(gr);
@@ -965,7 +965,7 @@ gap> gr := Digraph([[2], [3, 1], [1]]);
 gap> DigraphOddGirth(gr);
 3
 gap> gr := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> DigraphOddGirth(gr);
 infinity
 gap> gr := Digraph([[2], [3], [], [3], [4]]);
@@ -1035,7 +1035,7 @@ gap> DigraphVertexLabel(r, 2);
 gap> gr := Digraph([[1, 2, 3], [2, 4], [1], [3, 4]]);
 <immutable digraph with 4 vertices, 8 edges>
 gap> gr1 := DigraphSymmetricClosure(gr);
-<immutable digraph with 4 vertices, 11 edges>
+<immutable symmetric digraph with 4 vertices, 11 edges>
 gap> IsSymmetricDigraph(gr1);
 true
 gap> List(OutNeighbours(gr1), AsSet);
@@ -1043,7 +1043,7 @@ gap> List(OutNeighbours(gr1), AsSet);
 gap> gr := Digraph([[2, 2], [1]]);
 <immutable multidigraph with 2 vertices, 3 edges>
 gap> gr1 := DigraphSymmetricClosure(gr);
-<immutable multidigraph with 2 vertices, 4 edges>
+<immutable symmetric multidigraph with 2 vertices, 4 edges>
 gap> OutNeighbours(gr1);
 [ [ 2, 2 ], [ 1, 1 ] ]
 ]]></Example>
@@ -1087,12 +1087,12 @@ gap> OutNeighbours(gr);
 [ [ 4, 6 ], [ 1, 3 ], [  ], [ 5 ], [  ], [ 7, 8, 9 ], [  ], [  ], 
   [  ] ]
 gap> trans := DigraphTransitiveClosure(gr);
-<immutable digraph with 9 vertices, 18 edges>
+<immutable transitive digraph with 9 vertices, 18 edges>
 gap> OutNeighbours(trans);
 [ [ 4, 6, 5, 7, 8, 9 ], [ 1, 3, 4, 5, 6, 7, 8, 9 ], [  ], [ 5 ], 
   [  ], [ 7, 8, 9 ], [  ], [  ], [  ] ]
 gap> reflextrans := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 9 vertices, 27 edges>
+<immutable preorder digraph with 9 vertices, 27 edges>
 gap> OutNeighbours(reflextrans);
 [ [ 4, 6, 5, 7, 8, 9, 1 ], [ 1, 3, 4, 5, 6, 7, 8, 9, 2 ], [ 3 ], 
   [ 5, 4 ], [ 5 ], [ 7, 8, 9, 6 ], [ 7 ], [ 8 ], [ 9 ] ]
@@ -1122,11 +1122,11 @@ gap> OutNeighbours(reflextrans);
       Prop="IsConnectedDigraph"/> for more information.
     <Example><![CDATA[
 gap> gr := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> DigraphBicomponents(gr);
 fail
 gap> gr := ChainDigraph(5);
-<immutable digraph with 5 vertices, 4 edges>
+<immutable chain digraph with 5 vertices>
 gap> DigraphBicomponents(gr);
 [ [ 1, 3, 5 ], [ 2, 4 ] ]
 gap> gr := Digraph([[5], [1, 4], [5], [5], []]);
@@ -1261,7 +1261,7 @@ gap> DigraphLoops(gr);
 
     <Example><![CDATA[
 gap> D := CycleDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable cycle digraph with 2 vertices>
 gap> ChromaticNumber(D);
 2
 gap> D := DigraphMycielskian(D);
@@ -1368,7 +1368,7 @@ true
 gap> OutNeighbours(gr);
 [ [ 2, 2 ], [ 1, 3 ], [ 4 ], [ 3, 1 ] ]
 gap> sym := MaximalSymmetricSubdigraph(gr);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable symmetric digraph with 4 vertices, 4 edges>
 gap> IsSymmetricDigraph(sym) and not IsMultiDigraph(sym);
 true
 gap> OutNeighbours(sym);
@@ -1450,7 +1450,7 @@ gap> LaplacianMatrix(EmptyDigraph(0));
     for more information. 
     <Example><![CDATA[
 gap> gr := CompleteDigraph(5);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> NrSpanningTrees(gr);
 125
 gap> gr := DigraphSymmetricClosure(CycleDigraph(24));;
@@ -1494,7 +1494,7 @@ gap> gr := Digraph([[1, 2, 1, 3], [1], [4], [3, 4, 3]]);
 gap> UndirectedSpanningTree(gr);
 fail
 gap> forest := UndirectedSpanningForest(gr);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable symmetric digraph with 4 vertices, 4 edges>
 gap> OutNeighbours(forest);
 [ [ 2 ], [ 1 ], [ 4 ], [ 3 ] ]
 gap> IsUndirectedSpanningForest(gr, forest);
@@ -1507,9 +1507,9 @@ gap> UndirectedSpanningForest(MaximalSymmetricSubdigraph(gr))
 > = forest;
 true
 gap> gr := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> tree := UndirectedSpanningTree(gr);
-<immutable digraph with 4 vertices, 6 edges>
+<immutable symmetric digraph with 4 vertices, 6 edges>
 gap> IsUndirectedSpanningTree(gr, tree);
 true
 gap> tree = UndirectedSpanningForest(gr);
@@ -1539,7 +1539,7 @@ fail]]></Example>
 
     <Example><![CDATA[
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> HamiltonianPath(g);
 [ 1 ]
 gap> g := Digraph([[2], [1]]);
@@ -1573,7 +1573,7 @@ gap> HamiltonianPath(g);
     is unique up to isomorphism.
       <Example><![CDATA[
 gap> D := DigraphSymmetricClosure(CycleDigraph(8));
-<immutable digraph with 8 vertices, 16 edges>
+<immutable symmetric digraph with 8 vertices, 16 edges>
 gap> DigraphCore(D);
 [ 1, 2 ]
 gap> D := PetersenGraph();
@@ -1612,7 +1612,7 @@ true
 gap> OutNeighbours(D);
 [ [ 2, 2 ], [ 1, 3 ], [ 4 ], [ 3, 1 ] ]
 gap> D := MaximalAntiSymmetricSubdigraph(D);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable antisymmetric digraph with 4 vertices, 4 edges>
 gap> IsAntiSymmetricDigraph(D) and not IsMultiDigraph(D);
 true
 gap> OutNeighbours(D);

--- a/doc/cliques.xml
+++ b/doc/cliques.xml
@@ -352,7 +352,7 @@ gap> DigraphCliques(gr, [1], [5, 6], infinity, 2);
     </List>
     <Example><![CDATA[
 gap> gr := ChainDigraph(6);
-<immutable digraph with 6 vertices, 5 edges>
+<immutable chain digraph with 6 vertices>
 gap> DigraphIndependentSet(gr);
 [ 6, 4, 2 ]
 gap> DigraphMaximalIndependentSet(gr);
@@ -450,7 +450,7 @@ gap> DigraphMaximalIndependentSet(gr, [1], [], 3);
 
     <Example><![CDATA[
 gap> gr := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> DigraphMaximalIndependentSetsReps(gr);
 [ [ 1, 3 ] ]
 gap> DigraphIndependentSetsReps(gr);
@@ -569,7 +569,7 @@ gap> DigraphIndependentSets(gr, [], [4, 5], 1, 2);
     This function uses a version of the Bron-Kerbosch algorithm.
     <Example><![CDATA[
 gap> gr := CompleteDigraph(5);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> user_param := [];;
 gap> f := function(a, b)  # Calculate size of clique
 >   AddSet(user_param, Size(b));

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -159,12 +159,12 @@ true
 </ManSection>
 <#/GAPDoc>
 
-<#GAPDoc Label="DenseDigraphType">
+<#GAPDoc Label="DigraphByOutNeighboursType">
 <ManSection>
-  <Var Name="DenseDigraphType"/>
+  <Var Name="DigraphByOutNeighboursType"/>
   <Fam Name="DigraphFamily"/>
   <Description>
-    The type of all digraphs is <C>DenseDigraphType</C>.
+    The type of all digraphs is <C>DigraphByOutNeighboursType</C>.
     The family of all digraphs is <C>DigraphFamily</C>.
   </Description>
 </ManSection>

--- a/doc/digraph.xml
+++ b/doc/digraph.xml
@@ -198,14 +198,14 @@ gap> gr := DigraphFromDigraph6String("&DHUEe_");
 gap> DigraphVertexLabels(gr);
 [ 1 .. 5 ]
 gap> gr := Digraph(["a", "b", "c"], [], []);
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> DigraphVertexLabels(gr);
 [ "a", "b", "c" ]
 gap> SetDigraphVertexLabel(gr, 2, "d");
 gap> DigraphVertexLabels(gr);
 [ "a", "d", "c" ]
 gap> gr := InducedSubdigraph(gr, [1, 3]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> DigraphVertexLabels(gr);
 [ "a", "c" ]]]></Example>
   </Description>
@@ -239,14 +239,14 @@ gap> gr := DigraphFromDigraph6String("&DHUEe_");
 gap> DigraphVertexLabel(gr, 3);
 3
 gap> gr := Digraph(["a", "b", "c"], [], []);
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> DigraphVertexLabel(gr, 2);
 "b"
 gap> SetDigraphVertexLabel(gr, 2, "d");
 gap> DigraphVertexLabel(gr, 2);
 "d"
 gap> gr := InducedSubdigraph(gr, [1, 2]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> DigraphVertexLabel(gr, 2);
 "d"]]></Example>
   </Description>
@@ -676,9 +676,9 @@ gap> gr := DigraphByInNeighbours([[2, 3, 2], [1], [1, 2, 3]]);
 gap> f := Transformation([4, 3, 3, 1, 7, 9, 10, 4, 2, 3]);
 Transformation( [ 4, 3, 3, 1, 7, 9, 10, 4, 2, 3 ] )
 gap> AsDigraph(f);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable functional digraph with 10 vertices>
 gap> AsDigraph(f, 4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable functional digraph with 4 vertices>
 gap> AsDigraph(f, 5);
 fail
 gap> b := BinaryRelationOnPoints(
@@ -700,7 +700,7 @@ gap> gr := AsDigraph(b);
     attributes or properties of <A>digraph</A>.
 <Example><![CDATA[
 gap> gr := CycleDigraph(10);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable cycle digraph with 10 vertices>
 gap> DigraphCopy(gr) = gr;
 true
 ]]></Example>
@@ -768,7 +768,7 @@ gap> RandomMultiDigraph(1000, 950);
     tournament with <A>n</A> vertices. See <Ref Prop="IsTournament"/>. <P/>
     <Example><![CDATA[
 gap> RandomTournament(10);
-<immutable digraph with 10 vertices, 45 edges>
+<immutable tournament with 10 vertices>
 ]]></Example>
   </Description>
 </ManSection>
@@ -801,7 +801,7 @@ gap> RandomTournament(10);
     total order.<P/>
     <Example><![CDATA[
 gap> ChainDigraph(42);
-<immutable digraph with 42 vertices, 41 edges>
+<immutable chain digraph with 42 vertices>
 ]]></Example>
   </Description>
 </ManSection>
@@ -816,7 +816,7 @@ gap> ChainDigraph(42);
     digraph with <A>n</A> vertices. See <Ref Prop="IsCompleteDigraph"/>. <P/>
     <Example><![CDATA[
 gap> CompleteDigraph(20);
-<immutable digraph with 20 vertices, 380 edges>
+<immutable complete digraph with 20 vertices>
 ]]></Example>
   </Description>
 </ManSection>
@@ -838,7 +838,7 @@ gap> CompleteDigraph(20);
     <A>n</A> (containing the vertices <C>[m + 1 .. m + n]</C>).
     <Example><![CDATA[
 gap> CompleteBipartiteDigraph(2, 3);
-<immutable digraph with 5 vertices, 12 edges>
+<immutable complete bipartite digraph with bicomponent sizes 2 and 3>
 ]]></Example>
   </Description>
 </ManSection>
@@ -856,7 +856,7 @@ gap> CompleteBipartiteDigraph(2, 3);
         same independent set.
       <Example><![CDATA[
 gap> CompleteMultipartiteDigraph([5, 4, 2]);
-<immutable digraph with 11 vertices, 76 edges>
+<immutable multipartite symmetric digraph with 11 vertices, 76 edges>
 ]]></Example>
   </Description>
 </ManSection>
@@ -877,9 +877,9 @@ gap> CompleteMultipartiteDigraph([5, 4, 2]);
 
     <Example><![CDATA[
 gap> EmptyDigraph(20);
-<immutable digraph with 20 vertices, 0 edges>
+<immutable empty digraph with 20 vertices>
 gap> NullDigraph(10);
-<immutable digraph with 10 vertices, 0 edges>]]></Example>
+<immutable empty digraph with 10 vertices>]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -898,7 +898,7 @@ gap> NullDigraph(10);
 gap> CycleDigraph(1);
 <immutable digraph with 1 vertex, 1 edge>
 gap> CycleDigraph(123);
-<immutable digraph with 123 vertices, 123 edges>
+<immutable cycle digraph with 123 vertices>
 ]]></Example>
   </Description>
 </ManSection>
@@ -1122,16 +1122,16 @@ gap> DistanceDigraph(digraph, [1, 2]);
     <A>digraph</A>.
     <Example><![CDATA[
 gap> gr := EmptyDigraph(13);
-<immutable digraph with 13 vertices, 0 edges>
+<immutable empty digraph with 13 vertices>
 gap> gr := DigraphAddAllLoops(gr);
-<immutable digraph with 13 vertices, 13 edges>
+<immutable reflexive digraph with 13 vertices, 13 edges>
 gap> OutNeighbours(gr);
 [ [ 1 ], [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ], [ 9 ], 
   [ 10 ], [ 11 ], [ 12 ], [ 13 ] ]
 gap> gr := Digraph([[1, 2, 3], [1, 3], [1]]);
 <immutable digraph with 3 vertices, 6 edges>
 gap> gr := DigraphAddAllLoops(gr);
-<immutable digraph with 3 vertices, 8 edges>
+<immutable reflexive digraph with 3 vertices, 8 edges>
 gap> OutNeighbours(gr);
 [ [ 1, 2, 3 ], [ 1, 3, 2 ], [ 1, 3 ] ]
 ]]></Example>

--- a/doc/examples.xml
+++ b/doc/examples.xml
@@ -57,11 +57,11 @@ gap> ChromaticNumber(PetersenGraph());
 
 <Example><![CDATA[
 gap> GeneralisedPetersenGraph(7, 2);
-<immutable digraph with 14 vertices, 42 edges>
+<immutable symmetric digraph with 14 vertices, 42 edges>
 gap> GeneralisedPetersenGraph(40, 1);
-<immutable digraph with 80 vertices, 240 edges>
+<immutable symmetric digraph with 80 vertices, 240 edges>
 gap> D := GeneralisedPetersenGraph(5, 2);
-<immutable digraph with 10 vertices, 30 edges>
+<immutable symmetric digraph with 10 vertices, 30 edges>
 gap> IsIsomorphicDigraph(D, PetersenGraph());
 true
 gap> GeneralisedPetersenGraph(IsMutableDigraph, 9, 4);
@@ -86,16 +86,16 @@ gap> GeneralisedPetersenGraph(IsMutableDigraph, 9, 4);
 
     <Example><![CDATA[
 gap> gr := JohnsonDigraph(3, 1);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable symmetric digraph with 3 vertices, 6 edges>
 gap> OutNeighbours(gr);
 [ [ 2, 3 ], [ 1, 3 ], [ 1, 2 ] ]
 gap> gr := JohnsonDigraph(4, 2);
-<immutable digraph with 6 vertices, 24 edges>
+<immutable symmetric digraph with 6 vertices, 24 edges>
 gap> OutNeighbours(gr);
 [ [ 2, 3, 4, 5 ], [ 1, 3, 4, 6 ], [ 1, 2, 5, 6 ], [ 1, 2, 5, 6 ], 
   [ 1, 3, 4, 6 ], [ 2, 3, 4, 5 ] ]
 gap> JohnsonDigraph(1, 0);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 ]]></Example>
   </Description>
 </ManSection>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -136,9 +136,9 @@
 
     <Example><![CDATA[
 gap> D := ChainDigraph(10);
-<immutable digraph with 10 vertices, 9 edges>
+<immutable chain digraph with 10 vertices>
 gap> D := DigraphSymmetricClosure(D);
-<immutable digraph with 10 vertices, 18 edges>
+<immutable symmetric digraph with 10 vertices, 18 edges>
 gap> HomomorphismDigraphsFinder(D, D, fail, [], infinity, 2, 0,
 > [3, 4], [], fail, fail);
 [ Transformation( [ 3, 4, 3, 4, 3, 4, 3, 4, 3, 4 ] ), 
@@ -303,7 +303,7 @@ Transformation( [ 3, 1, 2, 3 ] )
 gap> gr1 := DigraphReverse(ChainDigraph(4));
 <immutable digraph with 4 vertices, 3 edges>
 gap> gr2 := DigraphSymmetricClosure(CycleDigraph(3));
-<immutable digraph with 3 vertices, 6 edges>
+<immutable symmetric digraph with 3 vertices, 6 edges>
 gap> EpimorphismsDigraphsRepresentatives(gr1, gr2);
 [ Transformation( [ 3, 1, 2, 1 ] ), Transformation( [ 3, 1, 2, 3 ] ), 
   Transformation( [ 2, 1, 2, 3 ] ) ]
@@ -516,7 +516,7 @@ gap> DigraphWelshPowellOrder(Digraph([[4], [9], [9], [],
     it returns <K>fail</K>.
     <Example><![CDATA[
 gap> gr := ChainDigraph(3);
-<immutable digraph with 3 vertices, 2 edges>
+<immutable chain digraph with 3 vertices>
 gap> DigraphEmbedding(gr, CompleteDigraph(4));
 fail
 gap> DigraphEmbedding(gr, Digraph([[3], [1, 4], [1], [3]]));
@@ -539,9 +539,9 @@ Transformation( [ 2, 4, 3, 4 ] )
     See also <Ref Oper="IsDigraphEmbedding"/>.
     <Example><![CDATA[
 gap> D1 := NullDigraph(2);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> D2 := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> EmbeddingsDigraphsRepresentatives(D1, D2);
 [ Transformation( [ 1, 3, 3 ] ), Transformation( [ 1, 4, 3, 4 ] ) ]
 gap> EmbeddingsDigraphs(D1, D2);
@@ -692,7 +692,7 @@ false]]></Example>
       
       <Example><![CDATA[
 gap> D := JohnsonDigraph(5, 3);
-<immutable digraph with 10 vertices, 60 edges>
+<immutable symmetric digraph with 10 vertices, 60 edges>
 gap> IsDigraphColouring(D, [1, 2, 3, 3, 2, 1, 4, 5, 6, 7]);
 true
 gap> IsDigraphColouring(D, [1, 2, 3, 3, 2, 1, 2, 5, 6, 7]);

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -368,7 +368,7 @@ gap> GeneratorsOfEndomorphismMonoid(gr, 3);
   IdentityTransformation ]
 gap> gr := CompleteDigraph(3);;
 gap> GeneratorsOfEndomorphismMonoid(gr);
-[ Transformation( [ 1, 3, 2 ] ), Transformation( [ 2, 1 ] ), 
+[ Transformation( [ 2, 3, 1 ] ), Transformation( [ 2, 1 ] ), 
   IdentityTransformation ]
 gap> GeneratorsOfEndomorphismMonoid(gr, [1, 2, 2]);
 [ Transformation( [ 1, 3, 2 ] ), IdentityTransformation ]

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -172,13 +172,13 @@ gap> ReadDigraphs(file, 9);
     the opposite direction is also present.
     <Example><![CDATA[
 gap> DigraphFromGraph6String("?");
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphFromGraph6String("C]");
 <immutable digraph with 4 vertices, 8 edges>
 gap> DigraphFromGraph6String("H?AAEM{");
 <immutable digraph with 9 vertices, 22 edges>
 gap> DigraphFromDigraph6String("&?");
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphFromDigraph6String("&CQFG");
 <immutable digraph with 4 vertices, 6 edges>
 gap> DigraphFromDigraph6String("&IM[SrKLc~lhesbU[F_");
@@ -377,7 +377,7 @@ gap> ReadDigraphs(
     <Example><![CDATA[
 gap> grs := [];;
 gap> grs[1] := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> grs[2] := Digraph([[1, 3], [2], [1, 2]]);
 <immutable digraph with 3 vertices, 5 edges>
 gap> grs[3] := Digraph([
@@ -390,7 +390,7 @@ gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/man.d6.gz");;
 gap> WriteDigraphs(filename, grs, "w");
 IO_OK
 gap> ReadDigraphs(filename);
-[ <immutable digraph with 0 vertices, 0 edges>, 
+[ <immutable empty digraph with 0 vertices>, 
   <immutable digraph with 3 vertices, 5 edges>, 
   <immutable digraph with 10 vertices, 51 edges> ]]]></Example>
     </Description>

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -144,7 +144,7 @@ gap> johnson := DigraphFromGraph6String("E}lw");
 gap> G := AutomorphismGroup(johnson);
 Group([ (3,4), (2,3)(4,5), (1,2)(5,6) ])
 gap> cycle := CycleDigraph(9);
-<immutable digraph with 9 vertices, 9 edges>
+<immutable cycle digraph with 9 vertices>
 gap> G := AutomorphismGroup(cycle);
 Group([ (1,2,3,4,5,6,7,8,9) ])
 gap> IsCyclic(G) and Size(G) = 9;
@@ -254,7 +254,7 @@ Group([ (2,3) ])]]></Example>
 
   <Example><![CDATA[
 gap> cycle := CycleDigraph(9);
-<immutable digraph with 9 vertices, 9 edges>
+<immutable cycle digraph with 9 vertices>
 gap> G := AutomorphismGroup(cycle);;
 gap> IsCyclic(G) and Size(G) = 9;
 true
@@ -512,9 +512,9 @@ gap> List(DigraphVertices(digraph), i -> colours[i / p]);
 
     <Example><![CDATA[
 gap> digraph1 := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> digraph2 := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> IsIsomorphicDigraph(digraph1, digraph2);
 false
 gap> digraph2 := DigraphReverse(digraph1);
@@ -578,9 +578,9 @@ true]]></Example>
 
     <Example><![CDATA[
 gap> digraph1 := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> digraph2 := ChainDigraph(3);
-<immutable digraph with 3 vertices, 2 edges>
+<immutable chain digraph with 3 vertices>
 gap> IsIsomorphicDigraph(digraph1, digraph2,
 >  [[1, 4], [2, 3]], [[1, 2], [3]]);
 false
@@ -659,15 +659,15 @@ false]]></Example>
 
     <Example><![CDATA[
 gap> digraph1 := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> digraph2 := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> IsomorphismDigraphs(digraph1, digraph2);
 fail
 gap> digraph1 := CompleteBipartiteDigraph(10, 5);
-<immutable digraph with 15 vertices, 100 edges>
+<immutable complete bipartite digraph with bicomponent sizes 10 and 5>
 gap> digraph2 := CompleteBipartiteDigraph(5, 10);
-<immutable digraph with 15 vertices, 100 edges>
+<immutable complete bipartite digraph with bicomponent sizes 5 and 10>
 gap> p := IsomorphismDigraphs(digraph1, digraph2);
 (1,6,11)(2,7,12)(3,8,13)(4,9,14)(5,10,15)
 gap> OnDigraphs(digraph1, p) = digraph2;
@@ -738,9 +738,9 @@ gap> IsomorphismDigraphs(digraph1, digraph2);
 
     <Example><![CDATA[
 gap> digraph1 := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> digraph2 := ChainDigraph(3);
-<immutable digraph with 3 vertices, 2 edges>
+<immutable chain digraph with 3 vertices>
 gap> IsomorphismDigraphs(digraph1, digraph2,
 >  [[1, 4], [2, 3]], [[1, 2], [3]]);
 fail

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -829,12 +829,11 @@ gap> DigraphEdges(gr);
 gap> p := [[1], [2, 4], [3]];
 [ [ 1 ], [ 2, 4 ], [ 3 ] ]
 gap> qr := QuotientDigraph(gr, p);
-<immutable multidigraph with 3 vertices, 7 edges>
+<immutable digraph with 3 vertices, 6 edges>
 gap> DigraphVertices(qr);
 [ 1 .. 3 ]
 gap> DigraphEdges(qr);
-[ [ 1, 2 ], [ 1, 1 ], [ 2, 2 ], [ 2, 1 ], [ 2, 3 ], [ 2, 2 ], 
-  [ 3, 1 ] ]
+[ [ 1, 1 ], [ 1, 2 ], [ 2, 1 ], [ 2, 2 ], [ 2, 3 ], [ 3, 1 ] ]
 gap> QuotientDigraph(EmptyDigraph(0), []);
 <immutable digraph with 0 vertices, 0 edges>
 ]]></Example>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -85,7 +85,7 @@ false]]></Example>
 
     <Example><![CDATA[
 gap> gr := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> tree := Digraph([[3], [4], [1, 4], [2, 3]]);
 <immutable digraph with 4 vertices, 6 edges>
 gap> IsSubdigraph(gr, tree) and IsUndirectedTree(tree);
@@ -93,7 +93,7 @@ true
 gap> IsUndirectedSpanningTree(gr, tree);
 true
 gap> forest := EmptyDigraph(4);
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> IsSubdigraph(gr, forest) and IsUndirectedForest(forest);
 true
 gap> IsUndirectedSpanningForest(gr, forest);
@@ -314,7 +314,7 @@ gap> OutNeighbours(gr2);
     <P/>
     <Example><![CDATA[
 gap> gr := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> new := DigraphAddVertex(gr);
 <immutable digraph with 4 vertices, 6 edges>
 gap> DigraphVertices(new);
@@ -341,7 +341,7 @@ gap> DigraphVertexLabels(new);
     labelled according to this list. <P/>
     <Example><![CDATA[
 gap> gr := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> new := DigraphAddVertices(gr, 3);
 <immutable digraph with 6 vertices, 6 edges>
 gap> DigraphVertices(new);
@@ -503,7 +503,7 @@ gap> gr := DigraphAddEdges(gr,
 
     <Example><![CDATA[
 gap> gr := CycleDigraph(250000);
-<immutable digraph with 250000 vertices, 250000 edges>
+<immutable cycle digraph with 250000 vertices>
 gap> gr := DigraphRemoveEdges(gr, [[250000, 1]]);
 <immutable digraph with 250000 vertices, 249999 edges>]]></Example>
   </Description>
@@ -525,7 +525,7 @@ gap> gr := DigraphRemoveEdges(gr, [[250000, 1]]);
 
     <Example><![CDATA[
 gap> gr := CycleDigraph(250000);
-<immutable digraph with 250000 vertices, 250000 edges>
+<immutable cycle digraph with 250000 vertices>
 gap> gr := DigraphRemoveEdge(gr, [250000, 1]);
 <immutable digraph with 250000 vertices, 249999 edges>]]></Example>
   </Description>
@@ -835,7 +835,7 @@ gap> DigraphVertices(qr);
 gap> DigraphEdges(qr);
 [ [ 1, 1 ], [ 1, 2 ], [ 2, 1 ], [ 2, 2 ], [ 2, 3 ], [ 3, 1 ] ]
 gap> QuotientDigraph(EmptyDigraph(0), []);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 ]]></Example>
   </Description>
 </ManSection>
@@ -982,7 +982,7 @@ Binary Relation on 4 points
 
 <Example><![CDATA[
 gap> gr := CycleDigraph(10);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable cycle digraph with 10 vertices>
 gap> DigraphEdgeUnion(gr, gr);
 <immutable multidigraph with 10 vertices, 20 edges>
 gap> gr1 := Digraph([[2], [1]]);
@@ -1037,11 +1037,11 @@ true
 
 <Example><![CDATA[
 gap> gr1 := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> OutNeighbours(gr1);
 [ [ 2 ], [ 3 ], [ 1 ] ]
 gap> gr2 := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> OutNeighbours(gr2);
 [ [ 2, 3 ], [ 1, 3 ], [ 1, 2 ] ]
 gap> union := DigraphDisjointUnion(gr1, gr2);
@@ -1087,11 +1087,11 @@ gap> OutNeighbours(union);
 
 <Example><![CDATA[
 gap> gr := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> IsCompleteDigraph(DigraphJoin(gr, gr));
 true
 gap> gr2 := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> DigraphJoin(gr, gr2);
 <immutable digraph with 6 vertices, 27 edges>
 ]]></Example>
@@ -1461,7 +1461,7 @@ fail
     <A>digraph</A>.
     <Example><![CDATA[
 gap> D := CompleteDigraph(6);
-<immutable digraph with 6 vertices, 30 edges>
+<immutable complete digraph with 6 vertices>
 gap> D := DigraphRemoveEdges(D, [[1, 2], [2, 1]]);
 <immutable digraph with 6 vertices, 28 edges>
 gap> closure := DigraphClosure(D, 6);

--- a/doc/prop.xml
+++ b/doc/prop.xml
@@ -28,7 +28,7 @@ gap> gr := Digraph([[1, 3], [2, 3], [3]]);
 gap> IsChainDigraph(gr);
 false
 gap> gr := ChainDigraph(5);
-<immutable digraph with 5 vertices, 4 edges>
+<immutable chain digraph with 5 vertices>
 gap> IsChainDigraph(gr);
 true
 gap> gr := DigraphReverse(gr);
@@ -58,7 +58,7 @@ gap> gr := Digraph([[1, 3], [2, 3], [3]]);
 gap> IsCycleDigraph(gr);
 false
 gap> gr := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> IsCycleDigraph(gr);
 true
 gap> gr := OnDigraphs(gr, (1, 2, 3));
@@ -120,7 +120,7 @@ gap> gr := Digraph([[1, 3], [2, 3], [3]]);
 gap> IsPartialOrderDigraph(gr);
 true
 gap> gr := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> IsPartialOrderDigraph(gr);
 false
 gap> gr := Digraph([[1, 1], [1, 1, 2], [3], [3, 3, 4, 4]]);
@@ -342,11 +342,11 @@ false
 
     <Example><![CDATA[
 gap> gr := CycleDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable cycle digraph with 2 vertices>
 gap> IsCompleteBipartiteDigraph(gr);
 true
 gap> gr := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> IsBipartiteDigraph(gr);
 true
 gap> IsCompleteBipartiteDigraph(gr);
@@ -370,7 +370,7 @@ false
 
     <Example><![CDATA[
 gap> gr := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsEmptyDigraph(gr);
 true
 gap> IsNullDigraph(gr);
@@ -484,7 +484,7 @@ false]]></Example>
 
     <Example><![CDATA[
 gap> gr := CycleDigraph(250000);
-<immutable digraph with 250000 vertices, 250000 edges>
+<immutable cycle digraph with 250000 vertices>
 gap> IsStronglyConnectedDigraph(gr);
 true
 gap> gr := DigraphRemoveEdges(gr, [[250000, 1]]);
@@ -676,11 +676,11 @@ true
   See also <Ref Attr="DigraphBicomponents"/>.
     <Example><![CDATA[
 gap> gr := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> IsBipartiteDigraph(gr);
 true
 gap> gr := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> IsBipartiteDigraph(gr);
 false]]></Example>
   </Description>
@@ -896,7 +896,7 @@ false]]></Example>
 
     <Example><![CDATA[
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsEulerianDigraph(gr);
 true
 gap> gr := Digraph([[2], []]);
@@ -935,7 +935,7 @@ true
 
     <Example><![CDATA[
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := Digraph([[2], [1]]);
@@ -970,11 +970,11 @@ true
 
     <Example><![CDATA[
 gap> D := CompleteDigraph(6);
-<immutable digraph with 6 vertices, 30 edges>
+<immutable complete digraph with 6 vertices>
 gap> IsDigraphCore(D);
 true
 gap> D := DigraphSymmetricClosure(CycleDigraph(6));
-<immutable digraph with 6 vertices, 12 edges>
+<immutable symmetric digraph with 6 vertices, 12 edges>
 gap> DigraphHomomorphism(D, CompleteDigraph(2));
 Transformation( [ 1, 2, 1, 2, 1, 2 ] )
 gap> IsDigraphCore(D);

--- a/doc/z-chap2.xml
+++ b/doc/z-chap2.xml
@@ -6,7 +6,7 @@
     <#Include Label="IsDigraph">
     <#Include Label="IsCayleyDigraph">
     <#Include Label="IsDigraphWithAdjacencyFunction">
-    <#Include Label="DenseDigraphType">
+    <#Include Label="DigraphByOutNeighboursType">
     <#Include Label="Digraph">
     <#Include Label="DigraphByAdjacencyMatrix">
     <#Include Label="DigraphByEdges">

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1203,9 +1203,8 @@ function(digraph)
   if IsEmptyDigraph(digraph) then
     if N >= 1 then
       return [1];
-    else
-      return [];
     fi;
+    return [];
   fi;
   SetDigraphVertexLabels(digraph, [1 .. N]);
   digraph := ReducedDigraph(digraph);  # isolated verts are not in core
@@ -1455,8 +1454,10 @@ InstallMethod(DigraphRemoveAllMultipleEdges, "for an immutable digraph",
 InstallMethod(DigraphRemoveAllMultipleEdgesAttr, "for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
-  D := MakeImmutable(DigraphRemoveAllMultipleEdges(DigraphMutableCopy(D)));
-  SetIsMultiDigraph(D, false);
+  if IsMultiDigraph(D) then
+    D := MakeImmutable(DigraphRemoveAllMultipleEdges(DigraphMutableCopy(D)));
+    SetIsMultiDigraph(D, false);
+  fi;
   return D;
 end);
 

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -25,7 +25,7 @@ function(D)
       or DigraphNrVertices(D) <= 1 then
     return [];
   elif not IsSymmetricDigraph(D) then
-    copy := DigraphSymmetricClosure(DigraphImmutableCopyIfMutable(D));
+    copy := DigraphSymmetricClosure(DigraphMutableCopyIfMutable(D));
   else
     copy := D;
   fi;
@@ -954,7 +954,8 @@ function(D)
   endofstack := 0;
 
   # Reduce the D, remove loops, and store the correct vertex labels
-  C := DigraphRemoveLoops(ReducedDigraph(DigraphImmutableCopyIfMutable(D)));
+  C := DigraphRemoveLoops(ReducedDigraph(DigraphMutableCopyIfMutable(D)));
+  MakeImmutable(C);
   if DigraphVertexLabels(D) <> DigraphVertices(D) then
     SetDigraphVertexLabels(C, Filtered(DigraphVertices(D),
                                        x -> OutDegrees(D) <> 0));
@@ -974,13 +975,12 @@ function(D)
     if n = 1 then
       continue;
     fi;
-    c_comp := InducedSubdigraph(DigraphImmutableCopyIfMutable(C), c_comp);
+    c_comp := InducedSubdigraph(C, c_comp);  # C is definitely immutable
     comp := c_comp;
     s := 1;
     while s < n do
       if s <> 1 then
-        comp := InducedSubdigraph(DigraphImmutableCopyIfMutable(c_comp),
-                                  [s .. n]);
+        comp := InducedSubdigraph(c_comp, [s .. n]);
         comp := InducedSubdigraph(comp,
                                   DigraphStronglyConnectedComponent(comp, 1));
       fi;

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -25,7 +25,7 @@ function(D)
       or DigraphNrVertices(D) <= 1 then
     return [];
   elif not IsSymmetricDigraph(D) then
-    copy := DigraphSymmetricClosure(DigraphCopyIfMutable(D));
+    copy := DigraphSymmetricClosure(DigraphImmutableCopyIfMutable(D));
   else
     copy := D;
   fi;
@@ -954,7 +954,7 @@ function(D)
   endofstack := 0;
 
   # Reduce the D, remove loops, and store the correct vertex labels
-  C := DigraphRemoveLoops(ReducedDigraph(DigraphCopyIfMutable(D)));
+  C := DigraphRemoveLoops(ReducedDigraph(DigraphImmutableCopyIfMutable(D)));
   if DigraphVertexLabels(D) <> DigraphVertices(D) then
     SetDigraphVertexLabels(C, Filtered(DigraphVertices(D),
                                        x -> OutDegrees(D) <> 0));
@@ -974,12 +974,13 @@ function(D)
     if n = 1 then
       continue;
     fi;
-    c_comp := InducedSubdigraph(DigraphCopyIfMutable(C), c_comp);
+    c_comp := InducedSubdigraph(DigraphImmutableCopyIfMutable(C), c_comp);
     comp := c_comp;
     s := 1;
     while s < n do
       if s <> 1 then
-        comp := InducedSubdigraph(DigraphCopyIfMutable(c_comp), [s .. n]);
+        comp := InducedSubdigraph(DigraphImmutableCopyIfMutable(c_comp),
+                                  [s .. n]);
         comp := InducedSubdigraph(comp,
                                   DigraphStronglyConnectedComponent(comp, 1));
       fi;

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -8,16 +8,17 @@
 #############################################################################
 ##
 
-InstallMethod(DigraphNrVertices, "for a dense digraph", [IsDenseDigraphRep],
-DIGRAPH_NR_VERTICES);
+InstallMethod(DigraphNrVertices, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep], DIGRAPH_NR_VERTICES);
 
-InstallMethod(OutNeighbours, "for a dense digraph", [IsDenseDigraphRep],
-DIGRAPH_OUT_NEIGHBOURS);
+InstallMethod(OutNeighbours, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep], DIGRAPH_OUT_NEIGHBOURS);
 
 # The next method is (yet another) DFS as described in
 # http://www.eecs.wsu.edu/~holder/courses/CptS223/spr08/slides/graphapps.pdf
 
-InstallMethod(ArticulationPoints, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(ArticulationPoints, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local copy, nbs, counter, visited, num, low, parent, points, points_seen,
         stack, depth, v, w, i;
@@ -97,7 +98,8 @@ function(D)
   fi;
 end);
 
-InstallMethod(ChromaticNumber, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(ChromaticNumber, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local nr, comps, upper, chrom, tmp_comps, tmp_upper, n, comp, bound, clique,
   c, i;
@@ -245,10 +247,11 @@ end);
 #   return out;
 # end);
 
-InstallMethod(DigraphAdjacencyFunction, "for a dense digraph", [IsDigraph],
-D -> {u, v} -> IsDigraphEdge(D, u, v));
+InstallMethod(DigraphAdjacencyFunction, "for a digraph by out-neighbours",
+[IsDigraph], D -> {u, v} -> IsDigraphEdge(D, u, v));
 
-InstallMethod(AsTransformation, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(AsTransformation, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   if not IsFunctionalDigraph(D) then
     return fail;
@@ -256,10 +259,11 @@ function(D)
   return Transformation(Concatenation(OutNeighbours(D)));
 end);
 
-InstallMethod(DigraphNrEdges, "for a digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphNrEdges, "for a digraph", [IsDigraphByOutNeighboursRep],
 DIGRAPH_NREDGES);
 
-InstallMethod(DigraphEdges, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphEdges, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local out, adj, nr, i, j;
   out := EmptyPlist(DigraphNrEdges(D));
@@ -282,8 +286,9 @@ InstallMethod(AsGraph, "for a digraph", [IsDigraph], Graph);
 InstallMethod(DigraphVertices, "for a digraph", [IsDigraph],
 D -> [1 .. DigraphNrVertices(D)]);
 
-InstallMethod(DigraphRange, "for a dense digraph attribute storing digraph",
-[IsDenseDigraphRep and IsImmutableDigraph],
+InstallMethod(DigraphRange,
+"for an immutable digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep and IsImmutableDigraph],
 function(D)
   if not IsBound(D!.DigraphRange) then
     DIGRAPH_SOURCE_RANGE(D);
@@ -292,12 +297,14 @@ function(D)
   return D!.DigraphRange;
 end);
 
-InstallMethod(DigraphRange, "for a dense digraph attribute storing digraph",
-[IsDenseDigraphRep and IsMutableDigraph],
+InstallMethod(DigraphRange,
+"for a mutable digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep and IsMutableDigraph],
 D -> DIGRAPH_SOURCE_RANGE(D).DigraphRange);
 
-InstallMethod(DigraphSource, "for a dense digraph attribute storing digraph",
-[IsDenseDigraphRep and IsImmutableDigraph],
+InstallMethod(DigraphSource,
+"for an immutable digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep and IsImmutableDigraph],
 function(D)
   if not IsBound(D!.DigraphSource) then
     DIGRAPH_SOURCE_RANGE(D);
@@ -306,18 +313,19 @@ function(D)
   return D!.DigraphSource;
 end);
 
-InstallMethod(DigraphSource, "for a dense digraph attribute storing digraph",
-[IsDenseDigraphRep and IsMutableDigraph],
+InstallMethod(DigraphSource,
+"for a mutable digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep and IsMutableDigraph],
 D -> DIGRAPH_SOURCE_RANGE(D).DigraphSource);
 
-InstallMethod(InNeighbours, "for a digraph", [IsDenseDigraphRep],
+InstallMethod(InNeighbours, "for a digraph", [IsDigraphByOutNeighboursRep],
 D -> DIGRAPH_IN_OUT_NBS(OutNeighbours(D)));
 
-InstallMethod(AdjacencyMatrix, "for a digraph", [IsDenseDigraphRep],
+InstallMethod(AdjacencyMatrix, "for a digraph", [IsDigraphByOutNeighboursRep],
 ADJACENCY_MATRIX);
 
-InstallMethod(BooleanAdjacencyMatrix, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(BooleanAdjacencyMatrix, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local n, nbs, mat, i, j;
   n := DigraphNrVertices(D);
@@ -331,8 +339,8 @@ function(D)
   return mat;
 end);
 
-InstallMethod(DigraphShortestDistances, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphShortestDistances, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local vertices, data, sum, distances, v, u;
   if HasDIGRAPHS_ConnectivityData(D) then
@@ -364,12 +372,13 @@ end);
 # returns the vertices (i.e. numbers) of <D> ordered so that there are no
 # edges from <out[j]> to <out[i]> for all <i> greater than <j>.
 
-InstallMethod(DigraphTopologicalSort, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphTopologicalSort, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 D -> DIGRAPH_TOPO_SORT(OutNeighbours(D)));
 
-InstallMethod(DigraphStronglyConnectedComponents, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphStronglyConnectedComponents,
+"for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local verts;
 
@@ -390,15 +399,16 @@ InstallMethod(DigraphNrStronglyConnectedComponents, "for a digraph",
 [IsDigraph],
 D -> Length(DigraphStronglyConnectedComponents(D).comps));
 
-InstallMethod(DigraphConnectedComponents, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphConnectedComponents, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 DIGRAPH_CONNECTED_COMPONENTS);
 
 InstallMethod(DigraphNrConnectedComponents, "for a digraph",
 [IsDigraph],
 D -> Length(DigraphConnectedComponents(D).comps));
 
-InstallMethod(OutDegrees, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(OutDegrees, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local adj, degs, i;
   adj := OutNeighbours(D);
@@ -411,7 +421,7 @@ end);
 
 InstallMethod(InDegrees, "for a digraph with in neighbours",
 [IsDigraph and HasInNeighbours],
-2,  # to beat the method for IsDenseDigraphRep
+2,  # to beat the method for IsDigraphByOutNeighboursRep
 function(D)
   local inn, degs, i;
   inn := InNeighbours(D);
@@ -422,7 +432,8 @@ function(D)
   return degs;
 end);
 
-InstallMethod(InDegrees, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(InDegrees, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local adj, degs, x, i;
   adj := OutNeighbours(D);
@@ -444,8 +455,8 @@ function(D)
 end);
 
 InstallMethod(OutDegreeSequence,
-"for a dense digraph with known digraph group",
-[IsDenseDigraphRep and HasDigraphGroup],
+"for a digraph by out-neighbours with known digraph group",
+[IsDigraphByOutNeighboursRep and HasDigraphGroup],
 function(D)
   local out, adj, orbs, orb;
   out := [];
@@ -497,7 +508,7 @@ end);
 
 InstallMethod(DigraphSources, "for a digraph with in-neighbours",
 [IsDigraph and HasInNeighbours],
-2,  # to beat the method for IsDenseDigraphRep
+2,  # to beat the method for IsDigraphByOutNeighboursRep
 function(D)
   local inn, sources, count, i;
 
@@ -514,7 +525,8 @@ function(D)
   return sources;
 end);
 
-InstallMethod(DigraphSources, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphSources, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local out, seen, tmp, next, v;
   out  := OutNeighbours(D);
@@ -532,14 +544,15 @@ end);
 
 InstallMethod(DigraphSinks, "for a digraph with out-degrees",
 [IsDigraph and HasOutDegrees],
-2,  # to beat the method for IsDenseDigraphRep
+2,  # to beat the method for IsDigraphByOutNeighboursRep
 function(D)
   local degs;
   degs := OutDegrees(D);
   return Filtered(DigraphVertices(D), x -> degs[x] = 0);
 end);
 
-InstallMethod(DigraphSinks, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphSinks, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local out, sinks, count, i;
 
@@ -555,7 +568,7 @@ function(D)
   return sinks;
 end);
 
-InstallMethod(DigraphPeriod, "for a digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphPeriod, "for a digraph", [IsDigraphByOutNeighboursRep],
 function(D)
   local comps, out, deg, nrvisited, period, stack, len, depth, current,
         olddepth, i;
@@ -800,7 +813,8 @@ function(D)
   return DIGRAPHS_DiameterAndUndirectedGirth(D).girth;
 end);
 
-InstallMethod(DigraphGirth, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphGirth, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local verts, girth, out, dist, i, j;
   if DigraphHasLoops(D) then
@@ -892,8 +906,8 @@ function(D)
   return circs[Position(lens, max)];
 end);
 
-InstallMethod(DigraphAllSimpleCircuits, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphAllSimpleCircuits, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local UNBLOCK, CIRCUIT, out, stack, endofstack, C, scc, n, blocked, B,
   c_comp, comp, s, loops, i;
@@ -1006,7 +1020,8 @@ end);
 # It is the backend to IsBipartiteDigraph, Bicomponents, and DigraphColouring
 # for a 2-colouring
 
-InstallMethod(DIGRAPHS_Bipartite, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DIGRAPHS_Bipartite, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local n, t, colours, in_nbrs, stack, pop, v, pos, nbrs, w, i;
   n := DigraphNrVertices(D);
@@ -1061,7 +1076,8 @@ function(D)
   return b;
 end);
 
-InstallMethod(DigraphLoops, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphLoops, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   if HasDigraphHasLoops(D) and not DigraphHasLoops(D) then
     return [];
@@ -1087,7 +1103,8 @@ function(D)
   return DIGRAPHS_Degeneracy(DigraphRemoveLoops(D))[2];
 end);
 
-InstallMethod(DIGRAPHS_Degeneracy, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DIGRAPHS_Degeneracy, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local nbs, n, out, deg_vert, m, verts_deg, k, i, v, d, w;
 
@@ -1217,7 +1234,8 @@ function(digraph)
   elif IsCompleteDigraph(digraph) then
     return DigraphVertexLabels(digraph);
   elif IsSymmetricDigraph(digraph) and IsBipartiteDigraph(digraph) then
-    i := First(DigraphVertices(digraph), i -> OutDegreeOfVertex(digraph, i) > 0);
+    i := First(DigraphVertices(digraph),
+               i -> OutDegreeOfVertex(digraph, i) > 0);
     return DigraphVertexLabels(digraph){
     [i, OutNeighboursOfVertex(digraph, i)[1]]};
   elif not IsConnectedDigraph(digraph) then
@@ -1331,8 +1349,8 @@ end);
 
 # Things that are attributes for immutable digraphs, but operations for mutable.
 
-InstallMethod(DigraphReverse, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphReverse, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local inn, C;
   if IsSymmetricDigraph(D) then
@@ -1357,8 +1375,8 @@ InstallMethod(DigraphReverse, "for a digraph with known digraph reverse",
 InstallMethod(DigraphReverseAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphReverse);
 
-InstallMethod(DigraphDual, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphDual, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local nodes, C, list, i;
   if IsMultiDigraph(D) then
@@ -1390,8 +1408,8 @@ InstallMethod(DigraphDual, "for a digraph with known dual",
 InstallMethod(DigraphDualAttr, "for an immutable digraph", [IsImmutableDigraph],
 DigraphDual);
 
-InstallMethod(ReducedDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(ReducedDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local v, niv, old, C, i;
   if IsConnectedDigraph(D) then
@@ -1423,8 +1441,9 @@ InstallMethod(ReducedDigraph, "for a digraph with known reduced digraph",
 InstallMethod(ReducedDigraphAttr, "for an immutable digraph",
 [IsImmutableDigraph], ReducedDigraph);
 
-InstallMethod(DigraphRemoveAllMultipleEdges, "for a mutable dense digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(DigraphRemoveAllMultipleEdges,
+"for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   local nodes, list, empty, seen, keep, v, u, pos;
 
@@ -1462,8 +1481,8 @@ function(D)
   return D;
 end);
 
-InstallMethod(DigraphAddAllLoops, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphAddAllLoops, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local ismulti, C, list, v;
   if HasIsReflexiveDigraph(D) and IsReflexiveDigraph(D) then
@@ -1497,8 +1516,8 @@ InstallMethod(DigraphAddAllLoops, "for a digraph with known add-all-loops",
 InstallMethod(DigraphAddAllLoopsAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphAddAllLoops);
 
-InstallMethod(DigraphRemoveLoops, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphRemoveLoops, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local C, out, lbl, pos, v;
   C := DigraphMutableCopyIfImmutable(D);
@@ -1527,8 +1546,8 @@ InstallMethod(DigraphRemoveLoopsAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphRemoveLoops);
 
 # TODO (FLS): I've just added 1 as the edge label here, is this really desired?
-InstallMethod(DigraphSymmetricClosure, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphSymmetricClosure, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local n, m, verts, C, mat, out, x, i, j, k;
 
@@ -1622,8 +1641,8 @@ DigraphSymmetricClosureAttr);
 InstallMethod(DigraphSymmetricClosureAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphSymmetricClosure);
 
-InstallMethod(MaximalSymmetricSubdigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(MaximalSymmetricSubdigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local C, inn, out, i;
 
@@ -1691,8 +1710,8 @@ function(D)
   return D;
 end);
 
-InstallMethod(MaximalAntiSymmetricSubdigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(MaximalAntiSymmetricSubdigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local n, C, m, out, i, j;
 
@@ -1757,8 +1776,9 @@ MaximalAntiSymmetricSubdigraphAttr);
 InstallMethod(MaximalAntiSymmetricSubdigraphAttr, "for an immutable digraph",
 [IsImmutableDigraph], MaximalAntiSymmetricSubdigraph);
 
-InstallMethod(DigraphTransitiveClosure, "for a mutable dense digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(DigraphTransitiveClosure,
+"for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   local list, m, n, nodes, sorted, trans, tmp, mat, v, u, i;
 
@@ -1849,8 +1869,8 @@ DigraphReflexiveTransitiveClosureAttr);
 InstallMethod(DigraphReflexiveTransitiveClosureAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphReflexiveTransitiveClosure);
 
-InstallMethod(DigraphTransitiveReduction, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphTransitiveReduction, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local topo, p, C;
   if IsMultiDigraph(D) then
@@ -1886,8 +1906,9 @@ InstallMethod(DigraphTransitiveReductionAttr, "for an immutable digraph",
 
 # For a topologically sortable digraph G, this returns the least subgraph G'
 # of G such that the (reflexive) transitive closures of G and G' are equal.
-InstallMethod(DigraphReflexiveTransitiveReduction, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphReflexiveTransitiveReduction,
+"for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local C;
   if IsMultiDigraph(D) then
@@ -1923,8 +1944,8 @@ InstallMethod(DigraphReflexiveTransitiveReductionAttr,
 "for an immutable digraph",
 [IsImmutableDigraph], DigraphReflexiveTransitiveReduction);
 
-InstallMethod(UndirectedSpanningForest, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(UndirectedSpanningForest, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local C;
   if DigraphNrVertices(D) = 0 then

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -13,8 +13,9 @@
 InstallMethod(CliqueNumber, "for a digraph", [IsDigraph],
 D -> Maximum(List(DigraphMaximalCliquesReps(D), Length)));
 
-InstallMethod(IsIndependentSet, "for a dense digraph and a homogeneous list",
-[IsDenseDigraphRep, IsHomogeneousList],
+InstallMethod(IsIndependentSet,
+"for a digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, list)
   local x;
   if not IsDuplicateFreeList(list)
@@ -31,8 +32,8 @@ function(D, list)
 end);
 
 InstallMethod(IsMaximalIndependentSet,
-"for a dense digraph and a homogeneous list",
-[IsDenseDigraphRep, IsHomogeneousList],
+"for a digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, set)
   local nbs, vtx, try, i;
 
@@ -56,8 +57,8 @@ function(D, set)
   return not ForAny(try, x -> IsEmpty(Intersection(set, nbs[x])));
 end);
 
-InstallMethod(IsClique, "for a dense digraph and a homogeneous list",
-[IsDenseDigraphRep, IsHomogeneousList],
+InstallMethod(IsClique, "for a digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, clique)
   local nbs, v;
   if not IsDuplicateFreeList(clique)
@@ -74,8 +75,9 @@ function(D, clique)
   return true;
 end);
 
-InstallMethod(IsMaximalClique, "for a dense digraph and a homogeneous list",
-[IsDenseDigraphRep, IsHomogeneousList],
+InstallMethod(IsMaximalClique,
+"for a digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, clique)
   local nbs, try, n, i;
 
@@ -244,8 +246,8 @@ function(arg)
 
   # Validate arg[2]
   D := arg[2];
-  if not IsDenseDigraphRep(D) then
-    ErrorNoReturn("the 1st argument <D> must be a dense digraph,");
+  if not IsDigraphByOutNeighboursRep(D) then
+    ErrorNoReturn("the 1st argument <D> must be a digraph by out-neighbours,");
   fi;
 
   # Validate arg[3]

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -110,7 +110,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
+  arg[1] := DigraphMutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DIGRAPHS_Clique,
                       Concatenation([true],
@@ -125,7 +125,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
+  arg[1] := DigraphMutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DIGRAPHS_Clique,
                       Concatenation([false],
@@ -142,7 +142,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
+  arg[1] := DigraphMutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DigraphCliquesReps, arg);
 end);
@@ -156,7 +156,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
+  arg[1] := DigraphMutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DigraphCliques, arg);
 end);
@@ -179,7 +179,7 @@ function(arg)
     return DigraphMaximalIndependentSetsRepsAttr(arg[1]);
   fi;
   D      := arg[1];
-  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
+  arg[1] := DigraphMutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   out    := CallFuncList(DigraphMaximalCliquesReps, arg);
   # Store the result if appropriate
@@ -207,7 +207,7 @@ function(arg)
     return DigraphMaximalIndependentSetsAttr(arg[1]);
   fi;
   D      := arg[1];
-  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
+  arg[1] := DigraphMutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   out := CallFuncList(DigraphMaximalCliques, arg);
   # Store the result if appropriate
@@ -313,7 +313,7 @@ function(arg)
 
   # Do a greedy search to find a clique of <D> containing <include> and
   # excluding <exclude> (which is necessarily maximal if <exclude> is empty)
-  D := MaximalSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   out := OutNeighbours(D);
   try := Difference(DigraphVertices(D), Concatenation(include, exclude));
   include_copy := ShallowCopy(include);
@@ -511,7 +511,7 @@ function(arg)
       return DigraphMaximalCliquesAttr(D);
     fi;
     cliques := DigraphMaximalCliquesReps(D);
-    sub := DigraphImmutableCopyIfMutable(D);
+    sub := DigraphMutableCopyIfMutable(D);
     sub := MaximalSymmetricSubdigraphWithoutLoops(sub);
     G := AutomorphismGroup(sub);
     if IsTrivial(G) then
@@ -591,7 +591,7 @@ function(digraph, hook, user_param, limit, include, exclude, max, size, reps)
   fi;
 
   # Investigate whether <include> and <exclude> are invariant under <grp>
-  sub := DigraphImmutableCopyIfMutable(digraph);
+  sub := DigraphMutableCopyIfMutable(digraph);
   sub := MaximalSymmetricSubdigraphWithoutLoops(sub);
   group := AutomorphismGroup(sub);
 
@@ -691,7 +691,8 @@ function(D, hook, param, lim, inc, exc, max, size, reps, inc_var, exc_var)
     hook := Add;
   fi;
 
-  D := MaximalSymmetricSubdigraphWithoutLoops(DigraphImmutableCopyIfMutable(D));
+  D := MaximalSymmetricSubdigraphWithoutLoops(DigraphMutableCopyIfMutable(D));
+  MakeImmutable(D);
   vtx := DigraphVertices(D);
 
   invariant_inc := Length(inc_var) = 0;

--- a/gap/cliques.gi
+++ b/gap/cliques.gi
@@ -110,7 +110,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphCopyIfMutable(arg[1]);
+  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DIGRAPHS_Clique,
                       Concatenation([true],
@@ -125,7 +125,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphCopyIfMutable(arg[1]);
+  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DIGRAPHS_Clique,
                       Concatenation([false],
@@ -142,7 +142,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphCopyIfMutable(arg[1]);
+  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DigraphCliquesReps, arg);
 end);
@@ -156,7 +156,7 @@ function(arg)
   elif not IsDigraph(arg[1]) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  arg[1] := DigraphCopyIfMutable(arg[1]);
+  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   return CallFuncList(DigraphCliques, arg);
 end);
@@ -179,7 +179,7 @@ function(arg)
     return DigraphMaximalIndependentSetsRepsAttr(arg[1]);
   fi;
   D      := arg[1];
-  arg[1] := DigraphCopyIfMutable(arg[1]);
+  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   out    := CallFuncList(DigraphMaximalCliquesReps, arg);
   # Store the result if appropriate
@@ -207,7 +207,7 @@ function(arg)
     return DigraphMaximalIndependentSetsAttr(arg[1]);
   fi;
   D      := arg[1];
-  arg[1] := DigraphCopyIfMutable(arg[1]);
+  arg[1] := DigraphImmutableCopyIfMutable(arg[1]);
   arg[1] := DigraphDual(DigraphRemoveAllMultipleEdges(arg[1]));
   out := CallFuncList(DigraphMaximalCliques, arg);
   # Store the result if appropriate
@@ -313,7 +313,7 @@ function(arg)
 
   # Do a greedy search to find a clique of <D> containing <include> and
   # excluding <exclude> (which is necessarily maximal if <exclude> is empty)
-  D := MaximalSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   out := OutNeighbours(D);
   try := Difference(DigraphVertices(D), Concatenation(include, exclude));
   include_copy := ShallowCopy(include);
@@ -511,7 +511,8 @@ function(arg)
       return DigraphMaximalCliquesAttr(D);
     fi;
     cliques := DigraphMaximalCliquesReps(D);
-    sub := MaximalSymmetricSubdigraphWithoutLoops(DigraphCopyIfMutable(D));
+    sub := DigraphImmutableCopyIfMutable(D);
+    sub := MaximalSymmetricSubdigraphWithoutLoops(sub);
     G := AutomorphismGroup(sub);
     if IsTrivial(G) then
       out := cliques;
@@ -590,7 +591,8 @@ function(digraph, hook, user_param, limit, include, exclude, max, size, reps)
   fi;
 
   # Investigate whether <include> and <exclude> are invariant under <grp>
-  sub := MaximalSymmetricSubdigraphWithoutLoops(DigraphCopyIfMutable(digraph));
+  sub := DigraphImmutableCopyIfMutable(digraph);
+  sub := MaximalSymmetricSubdigraphWithoutLoops(sub);
   group := AutomorphismGroup(sub);
 
   invariant_include := true;
@@ -689,7 +691,7 @@ function(D, hook, param, lim, inc, exc, max, size, reps, inc_var, exc_var)
     hook := Add;
   fi;
 
-  D  := MaximalSymmetricSubdigraphWithoutLoops(DigraphCopyIfMutable(D));
+  D := MaximalSymmetricSubdigraphWithoutLoops(DigraphImmutableCopyIfMutable(D));
   vtx := DigraphVertices(D);
 
   invariant_inc := Length(inc_var) = 0;

--- a/gap/constructors.gi
+++ b/gap/constructors.gi
@@ -11,8 +11,8 @@
 # This file contains constructions of certain types of digraphs, from other
 # digraphs.
 
-InstallMethod(BipartiteDoubleDigraph, "for a dense mutable digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(BipartiteDoubleDigraph, "for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   local list, N, i, j;
   list := D!.OutNeighbours;
@@ -43,8 +43,8 @@ function(D)
   return C;
 end);
 
-InstallMethod(DoubleDigraph, "for a dense mutable digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(DoubleDigraph, "for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   local list, N, i, j;
   list := D!.OutNeighbours;
@@ -76,8 +76,8 @@ function(D)
 end);
 
 InstallMethod(DistanceDigraph,
-"for a dense mutable digraph and a list of distances",
-[IsMutableDigraph and IsDenseDigraphRep, IsList],
+"for a mutable digraph by out-neighbours and a list of distances",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsList],
 function(D, distances)
   local list, x;
   # Can't change D!.OutNeighbours in-place, since it is used by

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -19,7 +19,8 @@ DeclareSynonym("IsMutableDigraph", IsDigraph and IsMutable);
 BindGlobal("DigraphFamily", NewFamily("DigraphFamily", IsDigraph));
 
 # Representations
-DeclareRepresentation("IsDenseDigraphRep", IsDigraph and IsComponentObjectRep,
+DeclareRepresentation("IsDigraphByOutNeighboursRep",
+                      IsDigraph and IsComponentObjectRep,
                       ["OutNeighbours"]);
 
 # 2.  Digraph no-check constructors . . .

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -40,9 +40,11 @@ DeclareOperation("DigraphNC", [IsDenseList]);
 
 # 3.  Digraph copies . . .
 DeclareOperation("DigraphMutableCopyIfImmutable", [IsDigraph]);
+DeclareOperation("DigraphMutableCopyIfMutable", [IsDigraph]);
 DeclareOperation("DigraphMutableCopy", [IsDigraph]);
 DeclareOperation("DigraphImmutableCopy", [IsDigraph]);
 DeclareOperation("DigraphImmutableCopyIfMutable", [IsDigraph]);
+DeclareOperation("DigraphImmutableCopyIfImmutable", [IsDigraph]);
 DeclareOperation("DigraphCopySameMutability", [IsDigraph]);
 DeclareSynonym("DigraphCopy", DigraphCopySameMutability);
 

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -11,19 +11,18 @@
 # Categories
 DeclareCategory("IsDigraph", IsObject);
 DeclareCategory("IsDigraphWithAdjacencyFunction", IsDigraph);
+DeclareCategory("IsImmutableDigraph", IsDigraph);
 
 DeclareSynonym("IsMutableDigraph", IsDigraph and IsMutable);
-DeclareCategory("IsImmutableDigraph", IsDigraph);
 
 # Family
 BindGlobal("DigraphFamily", NewFamily("DigraphFamily", IsDigraph));
 
 # Representations
-DeclareRepresentation("IsDenseDigraphRep",
-                      IsDigraph and IsComponentObjectRep,
+DeclareRepresentation("IsDenseDigraphRep", IsDigraph and IsComponentObjectRep,
                       ["OutNeighbours"]);
 
-# No check constructors
+# 2.  Digraph no-check constructors . . .
 DeclareOperation("ConvertToMutableDigraphNC", [IsRecord]);
 DeclareOperation("ConvertToMutableDigraphNC", [IsDenseList]);
 
@@ -39,15 +38,15 @@ DeclareOperation("DigraphNC", [IsFunction, IsDenseList]);
 DeclareOperation("DigraphNC", [IsRecord]);
 DeclareOperation("DigraphNC", [IsDenseList]);
 
-# Copies
+# 3.  Digraph copies . . .
 DeclareOperation("DigraphMutableCopyIfImmutable", [IsDigraph]);
 DeclareOperation("DigraphMutableCopy", [IsDigraph]);
-DeclareOperation("DigraphCopy", [IsDigraph]);
-DeclareSynonym("DigraphImmutableCopy", DigraphCopy);
-DeclareOperation("DigraphCopyIfMutable", [IsDigraph]);
-DeclareOperation("DigraphCopyIfImmutable", [IsDigraph]);
+DeclareOperation("DigraphImmutableCopy", [IsDigraph]);
+DeclareOperation("DigraphImmutableCopyIfMutable", [IsDigraph]);
+DeclareOperation("DigraphCopySameMutability", [IsDigraph]);
+DeclareSynonym("DigraphCopy", DigraphCopySameMutability);
 
-# Constructors
+# 5.  Digraph constructors . . .
 DeclareConstructor("DigraphCons", [IsDigraph, IsRecord]);
 DeclareConstructor("DigraphCons", [IsDigraph, IsDenseList]);
 DeclareConstructor("DigraphCons", [IsDigraph, IsList, IsFunction]);
@@ -66,7 +65,7 @@ DeclareOperation("Digraph", [IsList, IsFunction]);
 DeclareOperation("Digraph", [IsInt, IsList, IsList]);
 DeclareOperation("Digraph", [IsList, IsList, IsList]);
 
-# Constructors "by" something . . .
+# 8.  Digraph by-something constructors . . .
 DeclareConstructor("DigraphByAdjacencyMatrixCons",
                   [IsDigraph, IsHomogeneousList]);
 DeclareConstructor("DigraphByAdjacencyMatrixConsNC",
@@ -94,7 +93,7 @@ DeclareOperation("DigraphByInNeighbours", [IsList]);
 
 DeclareSynonym("DigraphByInNeighbors", DigraphByInNeighbours);
 
-# Converters to and from other types . . .
+# 9.  Converters to/from other types -> digraph . . .
 DeclareConstructor("AsDigraphCons", [IsDigraph, IsBinaryRelation]);
 DeclareConstructor("AsDigraphCons", [IsDigraph, IsTransformation]);
 DeclareConstructor("AsDigraphCons", [IsDigraph, IsTransformation, IsInt]);
@@ -113,6 +112,7 @@ DeclareOperation("AsMonoid", [IsFunction, IsDigraph]);
 DeclareOperation("AsSemigroup",
                  [IsFunction, IsDigraph, IsDenseList, IsDenseList]);
 
+# 10. Random digraphs . . .
 DeclareConstructor("RandomDigraphCons", [IsDigraph, IsInt]);
 DeclareConstructor("RandomDigraphCons", [IsDigraph, IsInt, IsRat]);
 DeclareConstructor("RandomDigraphCons", [IsDigraph, IsInt, IsFloat]);

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -153,11 +153,23 @@ InstallMethod(DigraphImmutableCopyIfMutable, "for a mutable digraph",
 InstallMethod(DigraphImmutableCopyIfMutable, "for an immutable digraph",
 [IsImmutableDigraph], IdFunc);
 
+InstallMethod(DigraphImmutableCopyIfImmutable, "for a mutable digraph",
+[IsMutableDigraph], IdFunc);
+
+InstallMethod(DigraphImmutableCopyIfImmutable, "for an immutable digraph",
+[IsImmutableDigraph], DigraphImmutableCopy);
+
 InstallMethod(DigraphMutableCopyIfImmutable, "for a mutable digraph",
 [IsMutableDigraph], IdFunc);
 
 InstallMethod(DigraphMutableCopyIfImmutable, "for an immutable digraph",
 [IsImmutableDigraph], DigraphMutableCopy);
+
+InstallMethod(DigraphMutableCopyIfMutable, "for a mutable digraph",
+[IsMutableDigraph], DigraphMutableCopy);
+
+InstallMethod(DigraphMutableCopyIfMutable, "for an immutable digraph",
+[IsImmutableDigraph], IdFunc);
 
 ########################################################################
 # 4. PostMakeImmutable
@@ -931,13 +943,13 @@ function(filt, D)
   elif not IsJoinSemilatticeDigraph(D) then
     if IsMeetSemilatticeDigraph(D) then
       return AsSemigroup(IsPartialPermSemigroup,
-                         DigraphReverse(DigraphImmutableCopyIfMutable(D)));
+                         DigraphReverse(DigraphMutableCopyIfMutable(D)));
     fi;
     ErrorNoReturn("the 2nd argument <D> must be digraph that is a join or ",
                   "meet semilattice,");
   fi;
 
-  D   := DigraphImmutableCopyIfMutable(D);
+  D   := DigraphMutableCopyIfMutable(D);
   red := DigraphReflexiveTransitiveReduction(D);
   top := DigraphTopologicalSort(D);
   # im[i] will store the image of the idempotent partial perm corresponding to
@@ -988,7 +1000,7 @@ function(filt, digraph, gps, homs)
   elif not IsJoinSemilatticeDigraph(digraph) then
     if IsMeetSemilatticeDigraph(digraph) then
       return AsSemigroup(IsPartialPermSemigroup,
-                         DigraphReverse(DigraphImmutableCopyIfMutable(digraph)),
+                         DigraphReverse(DigraphMutableCopyIfMutable(digraph)),
                          gps,
                          homs);
     else
@@ -1005,8 +1017,9 @@ function(filt, digraph, gps, homs)
                   "of vertices in the second argument,");
   fi;
 
-  digraph := DigraphImmutableCopyIfMutable(digraph);
+  digraph := DigraphMutableCopyIfMutable(digraph);
   red := DigraphReflexiveTransitiveReduction(digraph);
+  MakeImmutable(digraph);
   if not Length(homs) = DigraphNrEdges(red) or
        not ForAll(homs, x -> Length(x) = 3 and
                              IsPosInt(x[1]) and

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -28,8 +28,8 @@
 # 1. Digraph types
 ########################################################################
 
-BindGlobal("DenseDigraphType", NewType(DigraphFamily,
-                                       IsDenseDigraphRep));
+BindGlobal("DigraphByOutNeighboursType", NewType(DigraphFamily,
+                                         IsDigraphByOutNeighboursRep));
 
 ########################################################################
 # 2. Digraph no-check constructors
@@ -40,7 +40,7 @@ function(record)
   local D;
   Assert(1, IsBound(record.OutNeighbours));
   Assert(1, Length(NamesOfComponents(record)) = 1);
-  D := Objectify(DenseDigraphType, record);
+  D := Objectify(DigraphByOutNeighboursType, record);
   SetFilterObj(D, IsMutable);
   return D;
 end);
@@ -122,7 +122,8 @@ record -> DigraphConsNC(IsImmutableDigraph, record));
 # 3. Digraph copies
 ########################################################################
 
-InstallMethod(DigraphMutableCopy, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DigraphMutableCopy, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local copy;
   copy := ConvertToMutableDigraphNC(OutNeighboursMutableCopy(D));
@@ -131,8 +132,8 @@ function(D)
   return copy;
 end);
 
-InstallMethod(DigraphImmutableCopy, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DigraphImmutableCopy, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local copy;
   copy := ConvertToImmutableDigraphNC(OutNeighboursMutableCopy(D));
@@ -176,7 +177,7 @@ InstallMethod(DigraphMutableCopyIfMutable, "for an immutable digraph",
 ########################################################################
 
 InstallMethod(PostMakeImmutable, "for a digraph",
-[IsDigraph and IsDenseDigraphRep],
+[IsDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   MakeImmutable(D!.OutNeighbours);
   SetFilterObj(D, IsImmutableDigraph);
@@ -570,32 +571,32 @@ function(D)
   return str;
 end);
 
-InstallMethod(PrintString, "for a dense immutable digraph",
-[IsImmutableDigraph and IsDenseDigraphRep],
+InstallMethod(PrintString, "for an immutable digraph by out-neighbours",
+[IsImmutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   return Concatenation("Digraph( IsImmutableDigraph, ",
                        PrintString(OutNeighbours(D)),
                        " )");
 end);
 
-InstallMethod(PrintString, "for a dense mutable digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(PrintString, "for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   return Concatenation("Digraph( IsMutableDigraph, ",
                        PrintString(OutNeighbours(D)),
                        " )");
 end);
 
-InstallMethod(String, "for a dense immutable digraph",
-[IsImmutableDigraph and IsDenseDigraphRep],
+InstallMethod(String, "for an immutable digraph by out-neighbours",
+[IsImmutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   return Concatenation("Digraph( IsImmutableDigraph, ",
                        String(OutNeighbours(D)),
                        " )");
 end);
 
-InstallMethod(String, "for a dense mutable digraph",
-[IsMutableDigraph and IsDenseDigraphRep],
+InstallMethod(String, "for a mutable digraph by out-neighbours",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   return Concatenation("Digraph( IsMutableDigraph, ",
                        String(OutNeighbours(D)),
@@ -907,7 +908,7 @@ InstallMethod(AsDigraph, "for a function and a transformation",
 InstallMethod(AsDigraph, "for a transformation", [IsTransformation],
 t -> AsDigraphCons(IsImmutableDigraph, t, DegreeOfTransformation(t)));
 
-InstallMethod(AsBinaryRelation, "for a digraph", [IsDenseDigraphRep],
+InstallMethod(AsBinaryRelation, "for a digraph", [IsDigraphByOutNeighboursRep],
 function(D)
   local rel;
   if DigraphNrVertices(D) = 0 then

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -10,7 +10,8 @@
 
 # AN's code, adapted by WW
 
-InstallMethod(DotDigraph, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DotDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local str, out, i, j;
   str   := "//dot\n";
@@ -29,8 +30,8 @@ function(D)
   return str;
 end);
 
-InstallMethod(DotVertexLabelledDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DotVertexLabelledDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local out, str, i, j;
   out   := OutNeighbours(D);
@@ -55,8 +56,8 @@ function(D)
   return str;
 end);
 
-InstallMethod(DotSymmetricDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(DotSymmetricDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local out, str, i, j;
   if not IsSymmetricDigraph(D) then
@@ -259,8 +260,8 @@ InstallMethod(DotHighlightedDigraph, "for a digraph and list",
 {D, list} -> DotHighlightedDigraph(D, list, "black", "grey"));
 
 InstallMethod(DotHighlightedDigraph,
-"for a dense digraph, list, and two strings",
-[IsDenseDigraphRep, IsList, IsString, IsString],
+"for a digraph by out-neighbours, list, and two strings",
+[IsDigraphByOutNeighboursRep, IsList, IsString, IsString],
 function(D, highverts, highcolour, lowcolour)
   local lowverts, out, str, i, j;
 

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -221,7 +221,7 @@ function(D)
 
   # Quotient by the strongly connected components to get a partial order
   # D and draw this without loops or edges implied by transitivity.
-  D      := DigraphImmutableCopyIfMutable(D);
+  D      := DigraphMutableCopyIfMutable(D);
   comps  := DigraphStronglyConnectedComponents(D).comps;
   quo    := DigraphRemoveAllMultipleEdges(QuotientDigraph(D, comps));
   red    := DigraphReflexiveTransitiveReduction(quo);

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -221,7 +221,7 @@ function(D)
 
   # Quotient by the strongly connected components to get a partial order
   # D and draw this without loops or edges implied by transitivity.
-  D      := DigraphCopyIfMutable(D);
+  D      := DigraphImmutableCopyIfMutable(D);
   comps  := DigraphStronglyConnectedComponents(D).comps;
   quo    := DigraphRemoveAllMultipleEdges(QuotientDigraph(D, comps));
   red    := DigraphReflexiveTransitiveReduction(quo);

--- a/gap/examples.gi
+++ b/gap/examples.gi
@@ -129,7 +129,11 @@ function(filt, list)
   local D;
   D := MakeImmutable(CompleteMultipartiteDigraph(IsMutableDigraph, list));
   SetIsSymmetricDigraph(D, true);
-  SetIsBipartiteDigraph(D, Length(list) = 2);
+  SetIsCompleteBipartiteDigraph(D, Length(list) = 2);
+  if Length(list) = 2 then
+    SetDigraphBicomponents(D, [[1 .. list[1]], [list[1] + 1 .. Sum(list)]]);
+  fi;
+  SetIsMultipartiteDigraph(D, Length(list) > 2);
   return D;
 end);
 
@@ -157,6 +161,7 @@ InstallMethod(ChainDigraphCons,
 function(filt, n)
   local D;
   D := MakeImmutable(ChainDigraphCons(IsMutableDigraph, n));
+  SetIsChainDigraph(D, true);
   SetIsTransitiveDigraph(D, n = 2);
   SetDigraphHasLoops(D, false);
   SetIsAcyclicDigraph(D, true);
@@ -241,6 +246,7 @@ function(filt, n)
     SetDigraphHasLoops(D, false);
   fi;
   SetIsAcyclicDigraph(D, false);
+  SetIsCycleDigraph(D, true);
   SetIsEmptyDigraph(D, false);
   SetIsMultiDigraph(D, false);
   SetDigraphNrEdges(D, n);

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -20,7 +20,7 @@ function(arg)
   if not IsDigraph(D) then
     ErrorNoReturn("the 1st argument must be a digraph,");
   fi;
-  D := DigraphCopyIfMutable(D);
+  D := DigraphImmutableCopyIfMutable(D);
   if IsBound(arg[2]) then
     if IsHomogeneousList(arg[2]) then
       colours := arg[2];
@@ -198,7 +198,7 @@ function(D)
   local order, n, deg, v;
   order := [];
   n := DigraphNrVertices(D);
-  D := DigraphCopyIfMutable(D);
+  D := DigraphImmutableCopyIfMutable(D);
   while n > 0 do
     deg := ShallowCopy(OutDegrees(D)) + InDegrees(D);
     v := PositionMinimum(deg);
@@ -265,7 +265,7 @@ InstallMethod(HomomorphismsDigraphs, "for a digraph and a digraph",
 function(D1, D2)
   local hom, aut;
   hom := HomomorphismsDigraphsRepresentatives(D1, D2);
-  D2 := DigraphCopyIfMutable(D2);
+  D2 := DigraphImmutableCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
   return Union(List(aut, x -> hom * x));
@@ -325,7 +325,7 @@ InstallMethod(MonomorphismsDigraphs, "for a digraph and a digraph",
 function(D1, D2)
   local hom, aut;
   hom := MonomorphismsDigraphsRepresentatives(D1, D2);
-  D2 := DigraphCopyIfMutable(D2);
+  D2 := DigraphImmutableCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
   return Union(List(aut, x -> hom * x));
@@ -441,7 +441,7 @@ InstallMethod(EmbeddingsDigraphs, "for a digraph and a digraph",
 function(D1, D2)
   local hom, aut;
   hom := EmbeddingsDigraphsRepresentatives(D1, D2);
-  D2 := DigraphCopyIfMutable(D2);
+  D2 := DigraphImmutableCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
   return Union(List(aut, x -> hom * x));

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -198,7 +198,7 @@ function(D)
   local order, n, deg, v;
   order := [];
   n := DigraphNrVertices(D);
-  D := DigraphImmutableCopyIfMutable(D);
+  D := DigraphMutableCopyIfMutable(D);
   while n > 0 do
     deg := ShallowCopy(OutDegrees(D)) + InDegrees(D);
     v := PositionMinimum(deg);
@@ -265,7 +265,7 @@ InstallMethod(HomomorphismsDigraphs, "for a digraph and a digraph",
 function(D1, D2)
   local hom, aut;
   hom := HomomorphismsDigraphsRepresentatives(D1, D2);
-  D2 := DigraphImmutableCopyIfMutable(D2);
+  D2 := DigraphMutableCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
   return Union(List(aut, x -> hom * x));
@@ -325,7 +325,7 @@ InstallMethod(MonomorphismsDigraphs, "for a digraph and a digraph",
 function(D1, D2)
   local hom, aut;
   hom := MonomorphismsDigraphsRepresentatives(D1, D2);
-  D2 := DigraphImmutableCopyIfMutable(D2);
+  D2 := DigraphMutableCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
   return Union(List(aut, x -> hom * x));
@@ -441,7 +441,7 @@ InstallMethod(EmbeddingsDigraphs, "for a digraph and a digraph",
 function(D1, D2)
   local hom, aut;
   hom := EmbeddingsDigraphsRepresentatives(D1, D2);
-  D2 := DigraphImmutableCopyIfMutable(D2);
+  D2 := DigraphMutableCopyIfMutable(D2);
   aut := List(AutomorphismGroup(DigraphRemoveAllMultipleEdges(D2)),
               AsTransformation);
   return Union(List(aut, x -> hom * x));

--- a/gap/grahom.gi
+++ b/gap/grahom.gi
@@ -143,8 +143,8 @@ function(D, order)
 end);
 
 InstallMethod(DigraphGreedyColouringNC,
-"for a dense digraph and a homogeneous list",
-[IsDenseDigraphRep, IsHomogeneousList],
+"for a digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, order)
   local n, colour, colouring, out, inn, empty, all, available, nr_coloured, v;
   n := DigraphNrVertices(D);
@@ -451,8 +451,9 @@ end);
 # IsDigraph{Homo/Epi/...}morphism
 ########################################################################
 
-InstallMethod(IsDigraphHomomorphism, "for a dense digraph, digraph, and perm",
-[IsDenseDigraphRep, IsDigraph, IsPerm],
+InstallMethod(IsDigraphHomomorphism,
+"for a digraph by out-neighbours, a digraph, and a perm",
+[IsDigraphByOutNeighboursRep, IsDigraph, IsPerm],
 function(src, ran, x)
   local i, j;
   if IsMultiDigraph(src) or IsMultiDigraph(ran) then
@@ -475,8 +476,8 @@ InstallMethod(IsDigraphEndomorphism, "for a digraph and a perm",
 [IsDigraph, IsPerm], IsDigraphAutomorphism);
 
 InstallMethod(IsDigraphHomomorphism,
-"for a dense digraph, digraph, and transformation",
-[IsDenseDigraphRep, IsDigraph, IsTransformation],
+"for a digraph by out-neighbours, digraph, and transformation",
+[IsDigraphByOutNeighboursRep, IsDigraph, IsTransformation],
 function(src, ran, x)
   local i, j;
   if IsMultiDigraph(src) or IsMultiDigraph(ran) then
@@ -525,8 +526,8 @@ InstallMethod(IsDigraphMonomorphism, "for digraph, digraph, and perm",
 [IsDigraph, IsDigraph, IsPerm], IsDigraphHomomorphism);
 
 InstallMethod(IsDigraphEmbedding,
-"for digraph, dense digraph, and transformation",
-[IsDigraph, IsDenseDigraphRep, IsTransformation],
+"for digraph, digraph by out-neighbours, and transformation",
+[IsDigraph, IsDigraphByOutNeighboursRep, IsTransformation],
 function(src, ran, x)
   local y, induced, i, j;
   if not IsDigraphMonomorphism(src, ran, x) then
@@ -547,8 +548,9 @@ function(src, ran, x)
   return true;
 end);
 
-InstallMethod(IsDigraphEmbedding, "for digraph, dense digraph, and perm",
-[IsDigraph, IsDenseDigraphRep, IsPerm],
+InstallMethod(IsDigraphEmbedding,
+"for a digraph, a digraph by out-neighbours, and a perm",
+[IsDigraph, IsDigraphByOutNeighboursRep, IsPerm],
 function(src, ran, x)
   local y, induced, i, j;
   if not IsDigraphHomomorphism(src, ran, x) then
@@ -568,8 +570,8 @@ function(src, ran, x)
   return true;
 end);
 
-InstallMethod(IsDigraphColouring, "for a dense digraph and a list",
-[IsDenseDigraphRep, IsHomogeneousList],
+InstallMethod(IsDigraphColouring, "for a digraph by out-neighbours and a list",
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, colours)
   local n, out, v, w;
   n := DigraphNrVertices(D);

--- a/gap/io.gi
+++ b/gap/io.gi
@@ -1445,7 +1445,8 @@ function(name, D, delimiter, offset)
   IO_Close(file);
 end);
 
-InstallMethod(Graph6String, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(Graph6String, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local list, adj, n, lenlist, tablen, blist, i, j, pos, block;
   if (IsMultiDigraph(D) or not IsSymmetricDigraph(D)
@@ -1497,7 +1498,8 @@ function(D)
   return List(list, i -> CharInt(i + 63));
 end);
 
-InstallMethod(Digraph6String, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(Digraph6String, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local list, adj, n, lenlist, tablen, blist, i, j, pos, block;
   # NOTE: this package originally used a version of digraph6 that reads down
@@ -1547,7 +1549,8 @@ function(D)
   return List(list, i -> CharInt(i + 63));
 end);
 
-InstallMethod(Sparse6String, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(Sparse6String, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local list, n, lenlist, adj, nredges, k, blist, v, nextbit, AddBinary, i, j,
         bitstopad, pos, block;
@@ -1653,7 +1656,8 @@ function(D)
   return List(list, i -> CharInt(i + 63));
 end);
 
-InstallMethod(DiSparse6String, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(DiSparse6String, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local list, n, lenlist, adj, source_i, range_i, source_d, range_d, len1,
   len2, sort_d, perm, sort_i, k, blist, v, nextbit, AddBinary, bitstopad,

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -37,6 +37,7 @@ DeclareOperation("DigraphClosure", [IsDigraph, IsPosInt]);
 DeclareGlobalFunction("DigraphDisjointUnion");
 DeclareGlobalFunction("DigraphJoin");
 DeclareGlobalFunction("DigraphEdgeUnion");
+DeclareGlobalFunction("DIGRAPHS_CombinationOperProcessArgs");
 
 # 4. Actions . . .
 DeclareOperation("OnDigraphs", [IsDigraph, IsPerm]);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -921,7 +921,7 @@ function(super, sub)
     return false;
   fi;
 
-  sym := MaximalSymmetricSubdigraph(DigraphCopyIfMutable(super));
+  sym := MaximalSymmetricSubdigraph(DigraphImmutableCopyIfMutable(super));
 
   if not IsSubdigraph(sym, sub) then
     return false;
@@ -940,7 +940,7 @@ end);
 InstallMethod(IsUndirectedSpanningTree, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(super, sub)
-  super := DigraphCopyIfMutable(super);
+  super := DigraphImmutableCopyIfMutable(super);
   return IsConnectedDigraph(MaximalSymmetricSubdigraph(super))
     and IsUndirectedSpanningForest(super, sub);
 end);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -921,7 +921,7 @@ function(super, sub)
     return false;
   fi;
 
-  sym := MaximalSymmetricSubdigraph(DigraphImmutableCopyIfMutable(super));
+  sym := MaximalSymmetricSubdigraph(DigraphMutableCopyIfMutable(super));
 
   if not IsSubdigraph(sym, sub) then
     return false;
@@ -940,7 +940,7 @@ end);
 InstallMethod(IsUndirectedSpanningTree, "for a digraph and a digraph",
 [IsDigraph, IsDigraph],
 function(super, sub)
-  super := DigraphImmutableCopyIfMutable(super);
+  super := DigraphMutableCopyIfMutable(super);
   return IsConnectedDigraph(MaximalSymmetricSubdigraph(super))
     and IsUndirectedSpanningForest(super, sub);
 end);

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -27,8 +27,9 @@
 # 1. Adding and removing vertices
 #############################################################################
 
-InstallMethod(DigraphAddVertex, "for a mutable dense digraph and an object",
-[IsMutableDigraph and IsDenseDigraphRep, IsObject],
+InstallMethod(DigraphAddVertex,
+"for a mutable digraph by out-neighbours and an object",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsObject],
 function(D, label)
   Add(D!.OutNeighbours, []);
   SetDigraphVertexLabel(D, DigraphNrVertices(D), label);
@@ -81,8 +82,8 @@ InstallMethod(DigraphAddVertices, "for an immutable digraph and an integer",
 {D, m} -> MakeImmutable(DigraphAddVertices(DigraphMutableCopy(D), m)));
 
 InstallMethod(DigraphRemoveVertex,
-"for a mutable dense digraph and positive integer",
-[IsMutableDigraph and IsDenseDigraphRep, IsPosInt],
+"for a mutable digraph by out-neighbours and positive integer",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, u)
   local pos, w, v;
   if u > DigraphNrVertices(D) then
@@ -150,8 +151,8 @@ InstallMethod(DigraphRemoveVertices, "for an immutable digraph and a list",
 #############################################################################
 
 InstallMethod(DigraphAddEdge,
-"for a mutable dense digraph, a positive integer, and a positive integer",
-[IsMutableDigraph and IsDenseDigraphRep, IsPosInt, IsPosInt],
+"for a mutable digraph by out-neighbours, a two positive integers",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, src, ran)
   if not src in DigraphVertices(D)then
     ErrorNoReturn("the 2nd argument <src> must be a vertex of the ",
@@ -168,7 +169,7 @@ function(D, src, ran)
 end);
 
 InstallMethod(DigraphAddEdge,
-"for an immutable digraph, a positive integer, and a positive integer",
+"for an immutable digraph and two positive integers",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, src, ran)
   return MakeImmutable(DigraphAddEdge(DigraphMutableCopy(D), src, ran));
@@ -202,8 +203,8 @@ InstallMethod(DigraphAddEdges, "for an immutable digraph and a list",
 {D, edges} -> MakeImmutable(DigraphAddEdges(DigraphMutableCopy(D), edges)));
 
 InstallMethod(DigraphRemoveEdge,
-"for a mutable dense digraph, a positive integer, and a positive integer",
-[IsMutableDigraph and IsDenseDigraphRep, IsPosInt, IsPosInt],
+"for a mutable digraph by out-neighbours and two positive integers",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, src, ran)
   local pos;
   if IsMultiDigraph(D) then
@@ -225,7 +226,7 @@ function(D, src, ran)
 end);
 
 InstallMethod(DigraphRemoveEdge,
-"for a immutable digraph, a positive integer, and a positive integer",
+"for a immutable digraph and two positive integers",
 [IsImmutableDigraph, IsPosInt, IsPosInt],
 function(D, src, ran)
   return MakeImmutable(DigraphRemoveEdge(DigraphMutableCopy(D), src, ran));
@@ -257,8 +258,8 @@ InstallMethod(DigraphRemoveEdges, "for an immutable digraph and a list",
 {D, edges} -> MakeImmutable(DigraphRemoveEdges(DigraphMutableCopy(D), edges)));
 
 InstallMethod(DigraphReverseEdge,
-"for a mutable dense digraph, positive integer, and positive integer",
-[IsMutableDigraph and IsDenseDigraphRep, IsPosInt, IsPosInt],
+"for a mutable digraph by out-neighbours and two positive integers",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, u, v)
   local pos;
   if IsMultiDigraph(D) then
@@ -316,8 +317,8 @@ InstallMethod(DigraphReverseEdges, "for an immutable digraph and a list",
 {D, E} -> MakeImmutable(DigraphReverseEdges(DigraphMutableCopy(D), E)));
 
 InstallMethod(DigraphClosure,
-"for a mutable dense digraph and a positive integer",
-[IsMutableDigraph and IsDenseDigraphRep, IsPosInt],
+"for a mutable digraph by out-neighbours and a positive integer",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, k)
   local list, mat, deg, n, stop, i, j;
 
@@ -352,7 +353,7 @@ function(D, k)
 end);
 
 InstallMethod(DigraphClosure,
-"for an immutable dense digraph and a positive integer",
+"for an immutable digraph by out-neighbours and a positive integer",
 [IsImmutableDigraph, IsPosInt],
 {D, k} -> MakeImmutable(DigraphClosure(DigraphMutableCopy(D), k)));
 
@@ -393,9 +394,10 @@ function(arg)
     arg := arg[1];
   fi;
 
-  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
-    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
-                  "list of dense digraphs,");
+  if not IsList(arg) or IsEmpty(arg)
+      or not ForAll(arg, IsDigraphByOutNeighboursRep) then
+    ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
+                  "single list of digraphs by out-neighbours,");
   fi;
 
   D := arg[1];
@@ -422,9 +424,10 @@ function(arg)
     arg := arg[1];
   fi;
 
-  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
-    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
-                  "list of dense digraphs,");
+  if not IsList(arg) or IsEmpty(arg)
+      or not ForAll(arg, IsDigraphByOutNeighboursRep) then
+    ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
+                  "single list of digraphs by out-neighbours,");
   fi;
 
   D      := arg[1];
@@ -462,9 +465,10 @@ function(arg)
     arg := arg[1];
   fi;
 
-  if not IsList(arg) or IsEmpty(arg) or not ForAll(arg, IsDenseDigraphRep) then
-    ErrorNoReturn("the arguments must be dense digraphs, or a single ",
-                  "list of dense digraphs,");
+  if not IsList(arg) or IsEmpty(arg)
+      or not ForAll(arg, IsDigraphByOutNeighboursRep) then
+    ErrorNoReturn("the arguments must be digraphs by out-neighbours, or a ",
+                  "single list of digraphs by out-neighbours,");
   fi;
 
   D := arg[1];
@@ -495,8 +499,8 @@ end);
 # 4. Actions
 ###############################################################################
 
-InstallMethod(OnDigraphs, "for a mutable dense digraph and a perm",
-[IsMutableDigraph and IsDenseDigraphRep, IsPerm],
+InstallMethod(OnDigraphs, "for a mutable digraph by out-neighbours and a perm",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsPerm],
 function(D, p)
   local out;
   if ForAll(DigraphVertices(D), i -> i ^ p = i) then
@@ -521,8 +525,9 @@ function(D, p)
   return MakeImmutable(OnDigraphs(DigraphMutableCopy(D), p));
 end);
 
-InstallMethod(OnDigraphs, "for a mutable dense digraph and a transformation",
-[IsMutableDigraph and IsDenseDigraphRep, IsTransformation],
+InstallMethod(OnDigraphs,
+"for a mutable digraph by out-neighbours and a transformation",
+[IsMutableDigraph and IsDigraphByOutNeighboursRep, IsTransformation],
 function(D, t)
   local old, new, v;
   if ForAll(DigraphVertices(D), i -> i ^ t = i) then
@@ -580,8 +585,8 @@ end);
 #############################################################################
 
 InstallMethod(InducedSubdigraph,
-"for a dense mutable digraph and a homogeneous list",
-[IsDenseDigraphRep and IsMutableDigraph, IsHomogeneousList],
+"for a mutable digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep and IsMutableDigraph, IsHomogeneousList],
 function(D, list)
   local M, N, old, old_edl, new_edl, lookup, next, vv, w, old_labels, v, i;
 
@@ -639,8 +644,8 @@ function(D, list)
 end);
 
 InstallMethod(QuotientDigraph,
-"for a dense mutable digraph and a homogeneous list",
-[IsDenseDigraphRep and IsMutableDigraph, IsHomogeneousList],
+"for a mutable digraph by out-neighbours and a homogeneous list",
+[IsDigraphByOutNeighboursRep and IsMutableDigraph, IsHomogeneousList],
 function(D, partition)
   local N, M, check, lookup, new, new_vl, old, old_vl, x, i, u, v;
 
@@ -704,7 +709,7 @@ end);
 # 6. In and out degrees, neighbours, and edges of vertices
 #############################################################################
 
-InstallMethod(InNeighboursOfVertex, "for a digraph and a vertex",
+InstallMethod(InNeighboursOfVertex, "for a digraph and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   if not v in DigraphVertices(D) then
@@ -715,13 +720,14 @@ function(D, v)
 end);
 
 InstallMethod(InNeighboursOfVertexNC,
-"for a digraph with in-neighbours and a vertex",
+"for a digraph with in-neighbours and a positive integer",
 [IsDigraph and HasInNeighbours, IsPosInt],
-2,  # to beat the next method for IsDenseDigraphRep
+2,  # to beat the next method for IsDigraphByOutNeighboursRep
 {D, v} -> InNeighbours(D)[v]);
 
-InstallMethod(InNeighboursOfVertexNC, "for a dense digraph and a vertex",
-[IsDenseDigraphRep, IsPosInt],
+InstallMethod(InNeighboursOfVertexNC,
+"for a digraph by out-neighbours and a positive integer",
+[IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, v)
   local inn, out, i, j;
 
@@ -737,8 +743,9 @@ function(D, v)
   return inn;
 end);
 
-InstallMethod(OutNeighboursOfVertex, "for a dense digraph and a vertex",
-[IsDenseDigraphRep, IsPosInt],
+InstallMethod(OutNeighboursOfVertex,
+"for a digraph by out-neighbours and a positive integer",
+[IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, v)
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
@@ -747,11 +754,12 @@ function(D, v)
   return OutNeighboursOfVertexNC(D, v);
 end);
 
-InstallMethod(OutNeighboursOfVertexNC, "for a dense digraph and a vertex",
-[IsDenseDigraphRep, IsPosInt],
+InstallMethod(OutNeighboursOfVertexNC,
+"for a digraph by out-neighbours and a positive integer",
+[IsDigraphByOutNeighboursRep, IsPosInt],
 {D, v} -> OutNeighbours(D)[v]);
 
-InstallMethod(InDegreeOfVertex, "for a digraph and a vertex",
+InstallMethod(InDegreeOfVertex, "for a digraph and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   if not v in DigraphVertices(D) then
@@ -761,18 +769,19 @@ function(D, v)
   return InDegreeOfVertexNC(D, v);
 end);
 
-InstallMethod(InDegreeOfVertexNC, "for a digraph with in-degrees and a vertex",
+InstallMethod(InDegreeOfVertexNC,
+"for a digraph with in-degrees and a positive integer",
 [IsDigraph and HasInDegrees, IsPosInt], 4,
 {D, v} -> InDegrees(D)[v]);
 
 InstallMethod(InDegreeOfVertexNC,
-"for a digraph with in-neighbours and a vertex",
+"for a digraph with in-neighbours and a positive integer",
 [IsDigraph and HasInNeighbours, IsPosInt],
-2,  # to beat the next method for IsDenseDigraphRep
+2,  # to beat the next method for IsDigraphByOutNeighboursRep
 {D, v} -> Length(InNeighbours(D)[v]));
 
-InstallMethod(InDegreeOfVertexNC, "for a digraph and a vertex",
-[IsDenseDigraphRep, IsPosInt],
+InstallMethod(InDegreeOfVertexNC, "for a digraph and a positive integer",
+[IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, v)
   local count, out, x, i;
   count := 0;
@@ -787,7 +796,7 @@ function(D, v)
   return count;
 end);
 
-InstallMethod(OutDegreeOfVertex, "for a digraph and a vertex",
+InstallMethod(OutDegreeOfVertex, "for a digraph and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   if not v in DigraphVertices(D) then
@@ -798,17 +807,19 @@ function(D, v)
 end);
 
 InstallMethod(OutDegreeOfVertexNC,
-"for a digraph with out-degrees and a vertex",
+"for a digraph with out-degrees and a positive integer",
 [IsDigraph and HasOutDegrees, IsPosInt],
-2,  # to beat the next method for IsDenseDigraphRep
+2,  # to beat the next method for IsDigraphByOutNeighboursRep
 {D, v} -> OutDegrees(D)[v]);
 
-InstallMethod(OutDegreeOfVertexNC, "for a dense digraph and a vertex",
-[IsDenseDigraphRep, IsPosInt],
+InstallMethod(OutDegreeOfVertexNC,
+"for a digraph by out-neighbours and a positive integer",
+[IsDigraphByOutNeighboursRep, IsPosInt],
 {D, v} -> Length(OutNeighbours(D)[v]));
 
-InstallMethod(DigraphOutEdges, "for a dense digraph and a vertex",
-[IsDenseDigraphRep, IsPosInt],
+InstallMethod(DigraphOutEdges,
+"for a digraph by out-neighbours and a positive integer",
+[IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, v)
   if not v in DigraphVertices(D) then
     ErrorNoReturn("the 2nd argument <v> is not a vertex of the ",
@@ -817,7 +828,7 @@ function(D, v)
   return List(OutNeighboursOfVertex(D, v), x -> [v, x]);
 end);
 
-InstallMethod(DigraphInEdges, "for a digraph and a vertex",
+InstallMethod(DigraphInEdges, "for a digraph and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   if not v in DigraphVertices(D) then
@@ -831,8 +842,8 @@ end);
 # 7. Copies of out/in-neighbours
 #############################################################################
 
-InstallMethod(OutNeighboursMutableCopy, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(OutNeighboursMutableCopy, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 D -> List(OutNeighbours(D), ShallowCopy));
 
 InstallMethod(InNeighboursMutableCopy, "for a digraph", [IsDigraph],
@@ -857,8 +868,8 @@ function(D, edge)
   return IsDigraphEdge(D, edge[1], edge[2]);
 end);
 
-InstallMethod(IsDigraphEdge, "for a dense digraph, int, int",
-[IsDenseDigraphRep, IsInt, IsInt],
+InstallMethod(IsDigraphEdge, "for a digraph by out-neighbours, int, int",
+[IsDigraphByOutNeighboursRep, IsInt, IsInt],
 function(D, u, v)
   local n;
 
@@ -874,8 +885,9 @@ function(D, u, v)
   return v in OutNeighboursOfVertex(D, u);
 end);
 
-InstallMethod(IsSubdigraph, "for a dense digraph and dense digraph",
-[IsDenseDigraphRep, IsDenseDigraphRep],
+InstallMethod(IsSubdigraph,
+"for two digraphs by out-neighbours",
+[IsDigraphByOutNeighboursRep, IsDigraphByOutNeighboursRep],
 function(super, sub)
   local n, x, y, i, j;
 
@@ -912,7 +924,7 @@ function(super, sub)
   return true;
 end);
 
-InstallMethod(IsUndirectedSpanningForest, "for a digraph and a digraph",
+InstallMethod(IsUndirectedSpanningForest, "for two digraphs",
 [IsDigraph, IsDigraph],
 function(super, sub)
   local sym, comps1, comps2;
@@ -989,7 +1001,7 @@ function(D, edges)
 end);
 
 InstallMethod(IsMaximalMatching, "for a digraph and a list",
-[IsDenseDigraphRep, IsHomogeneousList],
+[IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, edges)
   local seen, nbs, i, j;
 
@@ -1015,8 +1027,8 @@ end);
 #############################################################################
 
 InstallMethod(DigraphFloydWarshall,
-"for a dense digraph, function, object, and object",
-[IsDenseDigraphRep, IsFunction, IsObject, IsObject],
+"for a digraph by out-neighbours, function, object, and object",
+[IsDigraphByOutNeighboursRep, IsFunction, IsObject, IsObject],
 function(D, func, nopath, edge)
   local vertices, n, mat, out, i, j, k;
 
@@ -1049,7 +1061,8 @@ function(D, func, nopath, edge)
   return mat;
 end);
 
-InstallMethod(DigraphStronglyConnectedComponent, "for a digraph and a vertex",
+InstallMethod(DigraphStronglyConnectedComponent,
+"for a digraph and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   local scc;
@@ -1064,7 +1077,7 @@ function(D, v)
   return scc.comps[scc.id[v]];
 end);
 
-InstallMethod(DigraphConnectedComponent, "for a digraph and a vertex",
+InstallMethod(DigraphConnectedComponent, "for a digraph and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   local wcc;
@@ -1096,8 +1109,8 @@ function(D, u, v)
   return DigraphPath(D, u, v) <> fail;
 end);
 
-InstallMethod(DigraphPath, "for a dense digraph and two pos ints",
-[IsDenseDigraphRep, IsPosInt, IsPosInt],
+InstallMethod(DigraphPath, "for a digraph by out-neighbours and two pos ints",
+[IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, u, v)
   local verts;
 
@@ -1119,8 +1132,9 @@ function(D, u, v)
   return DIGRAPH_PATH(OutNeighbours(D), u, v);
 end);
 
-InstallMethod(DigraphShortestPath, "for a dense digraph and two pos ints",
-[IsDenseDigraphRep, IsPosInt, IsPosInt],
+InstallMethod(DigraphShortestPath,
+"for a digraph by out-neighbours and two pos ints",
+[IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, u, v)
   local current, next, parent, distance, falselist, verts, nbs, path, edge,
   n, a, b, i;
@@ -1174,7 +1188,7 @@ function(D, u, v)
               Add(path[2], edge[b]);
               b := parent[b];
             od;
-            Add(path[1], u);  # Adds the starting vertex to the list of vertices.
+            Add(path[1], u);  # Adds the starting vertex to the list of vertices
             return [Reversed(path[1]), Reversed(path[2])];
           fi;
         od;
@@ -1185,8 +1199,9 @@ function(D, u, v)
     return fail;
 end);
 
-InstallMethod(IteratorOfPaths, "for a dense digraph and two pos ints",
-[IsDenseDigraphRep, IsPosInt, IsPosInt],
+InstallMethod(IteratorOfPaths,
+"for a digraph by out-neighbours and two pos ints",
+[IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, u, v)
   if not (u in DigraphVertices(D) and v in DigraphVertices(D)) then
     ErrorNoReturn("the 2nd and 3rd arguments <u> and <v> must be ",
@@ -1325,7 +1340,7 @@ function(D, u, v)
 end);
 
 InstallMethod(DigraphLongestDistanceFromVertex, "for a digraph and a pos int",
-[IsDenseDigraphRep, IsPosInt],
+[IsDigraphByOutNeighboursRep, IsPosInt],
 function(D, v)
   local dist;
 
@@ -1340,7 +1355,7 @@ function(D, v)
   return dist;
 end);
 
-InstallMethod(DigraphLayers, "for a digraph, and a vertex",
+InstallMethod(DigraphLayers, "for a digraph, and a positive integer",
 [IsDigraph, IsPosInt],
 function(D, v)
   local layers, gens, sch, trace, rep, word, orbs, layers_with_orbnums,
@@ -1427,7 +1442,7 @@ function(D, vertex, distances)
 end);
 
 InstallMethod(DigraphShortestDistance,
-"for a digraph, a vertex, and a vertex",
+"for a digraph, a vertex, and a positive integer",
 [IsDigraph, IsPosInt, IsPosInt],
 function(D, u, v)
   local dist;
@@ -1495,8 +1510,8 @@ end);
 #############################################################################
 
 InstallMethod(PartialOrderDigraphJoinOfVertices,
-"for a dense digraph and two positive integers",
-[IsDenseDigraphRep, IsPosInt, IsPosInt],
+"for a digraph by out-neighbours and two positive integers",
+[IsDigraphByOutNeighboursRep, IsPosInt, IsPosInt],
 function(D, i, j)
   local x, nbs, intr;
 

--- a/gap/orbits.gi
+++ b/gap/orbits.gi
@@ -68,8 +68,8 @@ function(G, domain)
   return rec(orbits := orbs, schreier := sch, lookup := lookup);
 end);
 
-InstallMethod(RepresentativeOutNeighbours, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(RepresentativeOutNeighbours, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local reps, out, nbs, i;
 

--- a/gap/planar.gi
+++ b/gap/planar.gi
@@ -37,7 +37,7 @@ function(D)
   elif HasIsPlanarDigraph(D) and not IsPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return PLANAR_EMBEDDING(D);
 end);
 
@@ -48,7 +48,7 @@ function(D)
   elif HasIsOuterPlanarDigraph(D) and not IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return OUTER_PLANAR_EMBEDDING(D);
 end);
 
@@ -57,7 +57,7 @@ function(D)
   if IsPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return KURATOWSKI_PLANAR_SUBGRAPH(D);
 end);
 
@@ -66,7 +66,7 @@ function(D)
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return KURATOWSKI_OUTER_PLANAR_SUBGRAPH(D);
 end);
 
@@ -75,7 +75,7 @@ function(D)
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return SUBGRAPH_HOMEOMORPHIC_TO_K23(D);
 end);
 
@@ -84,7 +84,7 @@ function(D)
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return SUBGRAPH_HOMEOMORPHIC_TO_K4(D);
 end);
 
@@ -93,7 +93,7 @@ function(D)
   if IsPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
   return SUBGRAPH_HOMEOMORPHIC_TO_K33(D);
 end);
 
@@ -104,7 +104,7 @@ end);
 InstallMethod(IsPlanarDigraph, "for a digraph", [IsDigraph],
 function(D)
   local C, v, e;
-  C := DigraphCopyIfMutable(D);
+  C := DigraphImmutableCopyIfMutable(D);
   C := MaximalAntiSymmetricSubdigraph(C);
   v := DigraphNrVertices(D);
   e := DigraphNrEdges(C);
@@ -131,6 +131,6 @@ function(D)
     # Outer planar graphs are 3-colourable
     return false;
   fi;
-  C := DigraphCopyIfMutable(D);
+  C := DigraphImmutableCopyIfMutable(D);
   return IS_OUTER_PLANAR(MaximalAntiSymmetricSubdigraph(C));
 end);

--- a/gap/planar.gi
+++ b/gap/planar.gi
@@ -37,7 +37,7 @@ function(D)
   elif HasIsPlanarDigraph(D) and not IsPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return PLANAR_EMBEDDING(D);
 end);
 
@@ -48,7 +48,7 @@ function(D)
   elif HasIsOuterPlanarDigraph(D) and not IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return OUTER_PLANAR_EMBEDDING(D);
 end);
 
@@ -57,7 +57,7 @@ function(D)
   if IsPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return KURATOWSKI_PLANAR_SUBGRAPH(D);
 end);
 
@@ -66,7 +66,7 @@ function(D)
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return KURATOWSKI_OUTER_PLANAR_SUBGRAPH(D);
 end);
 
@@ -75,7 +75,7 @@ function(D)
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return SUBGRAPH_HOMEOMORPHIC_TO_K23(D);
 end);
 
@@ -84,7 +84,7 @@ function(D)
   if IsOuterPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return SUBGRAPH_HOMEOMORPHIC_TO_K4(D);
 end);
 
@@ -93,7 +93,7 @@ function(D)
   if IsPlanarDigraph(D) then
     return fail;
   fi;
-  D := MaximalAntiSymmetricSubdigraph(DigraphImmutableCopyIfMutable(D));
+  D := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   return SUBGRAPH_HOMEOMORPHIC_TO_K33(D);
 end);
 
@@ -104,8 +104,7 @@ end);
 InstallMethod(IsPlanarDigraph, "for a digraph", [IsDigraph],
 function(D)
   local C, v, e;
-  C := DigraphImmutableCopyIfMutable(D);
-  C := MaximalAntiSymmetricSubdigraph(C);
+  C := MaximalAntiSymmetricSubdigraph(DigraphMutableCopyIfMutable(D));
   v := DigraphNrVertices(D);
   e := DigraphNrEdges(C);
   if v < 5 or e < 9 then
@@ -131,6 +130,6 @@ function(D)
     # Outer planar graphs are 3-colourable
     return false;
   fi;
-  C := DigraphImmutableCopyIfMutable(D);
+  C := DigraphMutableCopyIfMutable(D);
   return IS_OUTER_PLANAR(MaximalAntiSymmetricSubdigraph(C));
 end);

--- a/gap/prop.gd
+++ b/gap/prop.gd
@@ -13,6 +13,7 @@ DeclareProperty("IsMultiDigraph", IsDigraph);
 
 DeclareProperty("IsAcyclicDigraph", IsDigraph);
 DeclareProperty("IsBipartiteDigraph", IsDigraph);
+DeclareProperty("IsMultipartiteDigraph", IsDigraph);
 DeclareProperty("IsBiconnectedDigraph", IsDigraph);
 DeclareProperty("IsChainDigraph", IsDigraph);
 DeclareProperty("IsCompleteDigraph", IsDigraph);
@@ -59,11 +60,22 @@ InstallTrueMethod(IsAcyclicDigraph, IsEmptyDigraph);
 InstallTrueMethod(IsRegularDigraph, IsInRegularDigraph and IsOutRegularDigraph);
 InstallTrueMethod(IsStronglyConnectedDigraph,
                   IsConnectedDigraph and IsSymmetricDigraph);
+InstallTrueMethod(IsStronglyConnectedDigraph, IsEulerianDigraph);
+InstallTrueMethod(IsStronglyConnectedDigraph, IsHamiltonianDigraph);
 InstallTrueMethod(IsStronglyConnectedDigraph, IsUndirectedTree);
+InstallTrueMethod(IsConnectedDigraph, IsStronglyConnectedDigraph);
 InstallTrueMethod(IsUndirectedForest, IsUndirectedTree);
+InstallTrueMethod(IsBipartiteDigraph, IsCompleteBipartiteDigraph);
+InstallTrueMethod(IsConnectedDigraph, IsBiconnectedDigraph);
+InstallTrueMethod(IsRegularDigraph, IsVertexTransitive);
+InstallTrueMethod(IsOutRegularDigraph, IsRegularDigraph);
+InstallTrueMethod(IsInRegularDigraph, IsRegularDigraph);
 
 DeclareSynonymAttr("IsPartialOrderDigraph",
                    IsReflexiveDigraph and IsAntisymmetricDigraph
+                   and IsTransitiveDigraph);
+DeclareSynonymAttr("IsEquivalenceDigraph",
+                   IsReflexiveDigraph and IsSymmetricDigraph
                    and IsTransitiveDigraph);
 DeclareSynonymAttr("IsLatticeDigraph",
                     IsMeetSemilatticeDigraph and IsJoinSemilatticeDigraph);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -73,7 +73,7 @@ function(D)
     return false;
   fi;
   topo := Reversed(DigraphTopologicalSort(D));
-  D := OnDigraphs(DigraphCopyIfMutable(D), PermList(topo) ^ -1);
+  D := OnDigraphs(DigraphImmutableCopyIfMutable(D), PermList(topo) ^ -1);
   list := InNeighboursMutableCopy(D);
   Apply(list, Set);
   return DIGRAPHS_IsMeetJoinSemilatticeDigraph(list);
@@ -133,7 +133,7 @@ D -> DigraphNrVertices(D) = 0);
 
 InstallImmediateMethod(IsAcyclicDigraph, "for a strongly connected digraph",
 IsStronglyConnectedDigraph, 0,
-D -> DigraphNrVertices(D) <= 2);
+D -> DigraphNrVertices(D) <= 1 and IsEmptyDigraph(D));
 
 InstallMethod(IsAcyclicDigraph, "for a dense digraph",
 [IsDenseDigraphRep],
@@ -400,7 +400,7 @@ function(D)
     return false;
   fi;
 
-  D := DigraphCopyIfMutable(D);
+  D := DigraphImmutableCopyIfMutable(D);
 
   if IsMultiDigraph(D) then
     D := DigraphRemoveAllMultipleEdges(D);

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -9,7 +9,8 @@
 ##
 
 # "multi" means it has at least one multiple edges
-InstallMethod(IsMultiDigraph, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(IsMultiDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 IS_MULTI_DIGRAPH);
 
 InstallMethod(IsChainDigraph, "for a digraph", [IsDigraph],
@@ -51,8 +52,8 @@ function(nbs)
   return true;
 end);
 
-InstallMethod(IsJoinSemilatticeDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(IsJoinSemilatticeDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local topo;
   if not IsPartialOrderDigraph(D) then
@@ -66,7 +67,7 @@ function(D)
 end);
 
 InstallMethod(IsMeetSemilatticeDigraph, "for a digraph",
-[IsDenseDigraphRep],
+[IsDigraphByOutNeighboursRep],
 function(D)
   local topo, list;
   if not IsPartialOrderDigraph(D) then
@@ -79,8 +80,8 @@ function(D)
   return DIGRAPHS_IsMeetJoinSemilatticeDigraph(list);
 end);
 
-InstallMethod(IsStronglyConnectedDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(IsStronglyConnectedDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 D -> IS_STRONGLY_CONNECTED_DIGRAPH(OutNeighbours(D)));
 
 InstallMethod(IsCompleteDigraph, "for a digraph",
@@ -135,8 +136,8 @@ InstallImmediateMethod(IsAcyclicDigraph, "for a strongly connected digraph",
 IsStronglyConnectedDigraph, 0,
 D -> DigraphNrVertices(D) <= 1 and IsEmptyDigraph(D));
 
-InstallMethod(IsAcyclicDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(IsAcyclicDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local n;
   n := DigraphNrVertices(D);
@@ -159,8 +160,8 @@ end);
 # Complexity O(number of edges)
 # this could probably be improved further ! JDM
 
-InstallMethod(IsSymmetricDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(IsSymmetricDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local out, inn, new, i;
 
@@ -178,8 +179,8 @@ end);
 
 # Functional: for every vertex v there is exactly one edge with source v
 
-InstallMethod(IsFunctionalDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(IsFunctionalDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 D -> ForAll(OutNeighbours(D), x -> Length(x) = 1));
 
 InstallMethod(IsTournament, "for a digraph", [IsDigraph],
@@ -248,11 +249,12 @@ D -> ForAny(DigraphVertices(D), x -> IsDigraphEdge(D, x, x)));
 InstallMethod(IsAperiodicDigraph, "for a digraph", [IsDigraph],
 D -> DigraphPeriod(D) = 1);
 
-InstallMethod(IsAntisymmetricDigraph, "for a dense digraph",
-[IsDenseDigraphRep],
+InstallMethod(IsAntisymmetricDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 D -> IS_ANTISYMMETRIC_DIGRAPH(OutNeighbours(D)));
 
-InstallMethod(IsTransitiveDigraph, "for a dense digraph", [IsDenseDigraphRep],
+InstallMethod(IsTransitiveDigraph, "for a digraph by out-neighbours",
+[IsDigraphByOutNeighboursRep],
 function(D)
   local n, m, sorted, verts, out, trans, reflex, v, u;
 

--- a/gap/prop.gi
+++ b/gap/prop.gi
@@ -73,7 +73,7 @@ function(D)
     return false;
   fi;
   topo := Reversed(DigraphTopologicalSort(D));
-  D := OnDigraphs(DigraphImmutableCopyIfMutable(D), PermList(topo) ^ -1);
+  D := OnDigraphs(DigraphMutableCopyIfMutable(D), PermList(topo) ^ -1);
   list := InNeighboursMutableCopy(D);
   Apply(list, Set);
   return DIGRAPHS_IsMeetJoinSemilatticeDigraph(list);
@@ -400,7 +400,7 @@ function(D)
     return false;
   fi;
 
-  D := DigraphImmutableCopyIfMutable(D);
+  D := DigraphMutableCopyIfMutable(D);
 
   if IsMultiDigraph(D) then
     D := DigraphRemoveAllMultipleEdges(D);

--- a/tst/extreme/attr.tst
+++ b/tst/extreme/attr.tst
@@ -19,19 +19,19 @@ gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                     "/digraphs-lib/extreme.d6.gz"), 1);
 <immutable digraph with 5000 vertices, 4211332 edges>
 gap> ReducedDigraph(gr);
-<immutable digraph with 5000 vertices, 4211332 edges>
+<immutable connected digraph with 5000 vertices, 4211332 edges>
 
 #  DigraphSymmetricClosure 1
 # For a digraph with lots of edges: digraphs-lib/extreme.d6.gz
 gap> DigraphSymmetricClosure(gr);
-<immutable digraph with 5000 vertices, 7713076 edges>
+<immutable symmetric digraph with 5000 vertices, 7713076 edges>
 gap> gr := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                     "/data/symmetric-closure.ds6.gz"),
 >                       DigraphFromDiSparse6String,
 >                       1);
 <immutable digraph with 46656 vertices, 120245 edges>
 gap> DigraphSymmetricClosure(gr);
-<immutable digraph with 46656 vertices, 197930 edges>
+<immutable symmetric digraph with 46656 vertices, 197930 edges>
 
 #  DigraphAllSimpleCircuits
 gap> gr := DigraphFromDigraph6String(
@@ -43,7 +43,7 @@ gap> Length(circs);
 
 #  HamiltonianPath and IsHamiltonianDigraph
 gap> g := CompleteDigraph(20);
-<immutable digraph with 20 vertices, 380 edges>
+<immutable complete digraph with 20 vertices>
 gap> HamiltonianPath(g);
 [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 ]
 gap> IsDigraphMonomorphism(CycleDigraph(20), 
@@ -53,7 +53,7 @@ true
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CompleteMultipartiteDigraph([1, 9, 1, 1, 2, 1, 1, 1]);
-<immutable digraph with 17 vertices, 198 edges>
+<immutable multipartite symmetric digraph with 17 vertices, 198 edges>
 gap> HamiltonianPath(g);
 fail
 gap> IsHamiltonianDigraph(g);

--- a/tst/extreme/grahom.tst
+++ b/tst/extreme/grahom.tst
@@ -149,34 +149,10 @@ false
 gap> gr := CompleteDigraph(25);
 <immutable digraph with 25 vertices, 600 edges>
 gap> gens := GeneratorsOfEndomorphismMonoid(gr);
-[ Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-     18, 19, 20, 21, 22, 23, 25, 24 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-     18, 19, 20, 21, 22, 24, 23 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-     18, 19, 20, 21, 23, 22 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-     18, 19, 20, 22, 21 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-      11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 20 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-     18, 20, 19 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-      13, 14, 15, 16, 17, 19, 18 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18,
-     17 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-      15, 17, 16 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-     13, 14, 16, 15 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-      12, 13, 15, 14 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-     12, 14, 13 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13,
-      12 ] ), Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 11 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 10 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 8, 10, 9 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 7, 9, 8 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 6, 8, 7 ] ), 
-  Transformation( [ 1, 2, 3, 4, 5, 7, 6 ] ), 
-  Transformation( [ 1, 2, 3, 4, 6, 5 ] ), Transformation( [ 1, 2, 3, 5, 4 ] ),
-  Transformation( [ 1, 2, 4, 3 ] ), Transformation( [ 1, 3, 2 ] ), 
-  Transformation( [ 2, 1 ] ), Transformation( [ 7, 2, 3, 4, 5, 6, 1, 8, 9, 10,
-     11, 12, 13, 14, 15, 16, 17, 24, 19, 20, 21, 22, 23, 18 ] ) ]
+[ Transformation( [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+      18, 19, 20, 21, 22, 23, 24, 25, 1 ] ), Transformation( [ 2, 1 ] ), 
+  Transformation( [ 7, 2, 3, 4, 5, 6, 1, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+     24, 19, 20, 21, 22, 23, 18 ] ) ]
 gap> ForAll(gens, x -> IsDigraphAutomorphism(gr, x)); 
 true
 gap> GeneratorsOfEndomorphismMonoid(gr) = gens;

--- a/tst/extreme/grahom.tst
+++ b/tst/extreme/grahom.tst
@@ -147,7 +147,7 @@ false
 
 # CompleteDigraph (with no loops) has no singular endomorphisms
 gap> gr := CompleteDigraph(25);
-<immutable digraph with 25 vertices, 600 edges>
+<immutable complete digraph with 25 vertices>
 gap> gens := GeneratorsOfEndomorphismMonoid(gr);
 [ Transformation( [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
       18, 19, 20, 21, 22, 23, 24, 25, 1 ] ), Transformation( [ 2, 1 ] ), 
@@ -196,7 +196,7 @@ gap> gens := GeneratorsOfEndomorphismMonoid(gr);
 
 # EmptyDigraph(n) has endomorphism monoid T_n
 gap> gr := EmptyDigraph(5);
-<immutable digraph with 5 vertices, 0 edges>
+<immutable empty digraph with 5 vertices>
 gap> gens := GeneratorsOfEndomorphismMonoid(gr);;
 gap> Size(Semigroup(gens)) = 5 ^ 5;
 true
@@ -206,7 +206,7 @@ true
 
 # ChainDigraph (with no loops) has no singular endomorphisms
 gap> gr := ChainDigraph(20);
-<immutable digraph with 20 vertices, 19 edges>
+<immutable chain digraph with 20 vertices>
 gap> gens := GeneratorsOfEndomorphismMonoid(gr);
 [ IdentityTransformation ]
 
@@ -214,7 +214,7 @@ gap> gens := GeneratorsOfEndomorphismMonoid(gr);
 # is equal to, or one more than, the image of the previous point
 gap> n := 12;;
 gap> D := DigraphAddAllLoops(ChainDigraph(n));
-<immutable digraph with 12 vertices, 23 edges>
+<immutable reflexive digraph with 12 vertices, 23 edges>
 gap> S := GeneratorsOfEndomorphismMonoid(D);;
 gap> if IsBound(SmallSemigroupGeneratingSet) then 
 > S := SmallSemigroupGeneratingSet(S);;
@@ -229,7 +229,7 @@ true
 # transformations
 gap> n := 6;;
 gap> D := DigraphReflexiveTransitiveClosure(ChainDigraph(n));
-<immutable digraph with 6 vertices, 21 edges>
+<immutable preorder digraph with 6 vertices, 21 edges>
 gap> S := GeneratorsOfEndomorphismMonoid(D);;
 gap> if IsBound(SmallSemigroupGeneratingSet) then 
 > S := SmallSemigroupGeneratingSet(S);;
@@ -243,7 +243,7 @@ gap> Size(S);
 
 # CycleDigraph (with no loops) has no singular endomorphisms
 gap> gr := CycleDigraph(20);
-<immutable digraph with 20 vertices, 20 edges>
+<immutable cycle digraph with 20 vertices>
 gap> gens := [];;
 gap> gens := Concatenation(gens, GeneratorsOfEndomorphismMonoid(gr));
 [ Transformation( [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
@@ -311,9 +311,9 @@ gap> GeneratorsOfEndomorphismMonoid(gr);;
 #  HomomorphismDigraphsFinder 1
 # Small example: CompleteDigraph(2) to CompleteDigraph(3)
 gap> gr1 := CompleteDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable complete digraph with 2 vertices>
 gap> gr2 := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> func := function(user_param, t)
 >      user_param := user_param ^ t;
 > end;;

--- a/tst/extreme/isomorph.tst
+++ b/tst/extreme/isomorph.tst
@@ -17,7 +17,7 @@ gap> DIGRAPHS_StartTest();
 # All graphs of 5 vertices, compare with GRAPE
 gap> graph5 := ReadDigraphs(Concatenation(DIGRAPHS_Dir(),
 >                                         "/data/graph5.g6.gz"));
-[ <immutable digraph with 5 vertices, 0 edges>, 
+[ <immutable empty digraph with 5 vertices>, 
   <immutable digraph with 5 vertices, 2 edges>, 
   <immutable digraph with 5 vertices, 4 edges>, 
   <immutable digraph with 5 vertices, 6 edges>, 
@@ -132,7 +132,7 @@ gap> gr := Digraph([[6, 7], [6, 9], [1, 3, 4, 5, 8, 9],
 gap> AutomorphismGroup(gr);
 Group(())
 gap> gr := CycleDigraph(1000);
-<immutable digraph with 1000 vertices, 1000 edges>
+<immutable cycle digraph with 1000 vertices>
 gap> AutomorphismGroup(gr);
 <permutation group of size 1000 with 1 generators>
 gap> Size(last);
@@ -374,9 +374,9 @@ true
 
 #  IsomorphismDigraphs: for digraphs, 1
 gap> gr1 := CompleteBipartiteDigraph(100, 50);
-<immutable digraph with 150 vertices, 10000 edges>
+<immutable complete bipartite digraph with bicomponent sizes 100 and 50>
 gap> gr2 := CompleteBipartiteDigraph(50, 100);
-<immutable digraph with 150 vertices, 10000 edges>
+<immutable complete bipartite digraph with bicomponent sizes 50 and 100>
 gap> p := IsomorphismDigraphs(gr1, gr2);
 (1,51,101)(2,52,102)(3,53,103)(4,54,104)(5,55,105)(6,56,106)(7,57,107)(8,58,
 108)(9,59,109)(10,60,110)(11,61,111)(12,62,112)(13,63,113)(14,64,114)(15,65,

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -87,17 +87,17 @@ Error, the argument <D> must be a digraph with no multiple edges,
 gap> DigraphDual(DigraphMutableCopy(gr));
 Error, the argument <D> must be a digraph with no multiple edges,
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphDual(gr);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphDual(gr);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> gr := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> DigraphDual(gr);
 <immutable digraph with 2 vertices, 4 edges>
 gap> gr := Digraph(rec(DigraphNrVertices := 2, DigraphSource := [], DigraphRange := []));
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> DigraphDual(gr);
 <immutable digraph with 2 vertices, 4 edges>
 gap> gr := Digraph([[2, 2], []]);
@@ -113,7 +113,7 @@ gap> DigraphDual(gr);
 <immutable digraph with 6 vertices, 27 edges>
 gap> r := rec(DigraphNrVertices := 4, DigraphSource := [], DigraphRange := []);;
 gap> gr := Digraph(r);
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> DigraphDual(gr);
 <immutable digraph with 4 vertices, 16 edges>
 gap> gr := Digraph(r);;
@@ -219,11 +219,11 @@ gap> multiple := Digraph(r);;
 gap> DigraphTopologicalSort(multiple);
 [ 2, 1 ]
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphTopologicalSort(gr);
 [  ]
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphTopologicalSort(gr);
 [ 1 ]
 gap> gr := Digraph([[1]]);
@@ -284,7 +284,7 @@ gap> scc := DigraphStronglyConnectedComponents(gr);
 rec( comps := [ [ 1, 3, 2, 4, 9, 8, 5, 6, 7, 10, 11 ] ], 
   id := [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ] )
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphStronglyConnectedComponents(gr);
 rec( comps := [  ], id := [  ] )
 gap> r := rec(DigraphNrVertices := 9,
@@ -304,7 +304,7 @@ gap> Length(scc.comps);
 gap> Length(scc.comps) = DigraphNrVertices(circuit);
 true
 gap> gr := CycleDigraph(10);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable cycle digraph with 10 vertices>
 gap> gr2 := DigraphRemoveEdge(gr, 10, 1);
 <immutable digraph with 10 vertices, 9 edges>
 gap> IsStronglyConnectedDigraph(gr);
@@ -344,11 +344,11 @@ gap> gr := Digraph([[1, 2], [1], [2], [5], []]);
 gap> wcc := DigraphConnectedComponents(gr);
 rec( comps := [ [ 1, 2, 3 ], [ 4, 5 ] ], id := [ 1, 1, 1, 2, 2 ] )
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphConnectedComponents(gr);
 rec( comps := [  ], id := [  ] )
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphConnectedComponents(gr);
 rec( comps := [ [ 1 ] ], id := [ 1 ] )
 gap> gr := Digraph([[1], [2], [3], [4]]);
@@ -479,7 +479,7 @@ gap> OutNeighbours(gr);
 #  OutDegree and OutDegreeSequence and InDegrees and InDegreeSequence
 gap> r := rec(DigraphNrVertices := 0, DigraphSource := [], DigraphRange := []);;
 gap> gr1 := Digraph(r);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> OutDegrees(gr1);
 [  ]
 gap> OutDegreeSequence(gr1);
@@ -489,7 +489,7 @@ gap> InDegrees(gr1);
 gap> InDegreeSequence(gr1);
 [  ]
 gap> gr2 := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> OutDegrees(gr2);
 [  ]
 gap> OutDegreeSequence(gr2);
@@ -499,7 +499,7 @@ gap> InDegrees(gr2);
 gap> InDegreeSequence(gr2);
 [  ]
 gap> gr3 := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> InNeighbours(gr3);
 [  ]
 gap> OutDegrees(gr3);
@@ -617,11 +617,11 @@ gap> DigraphSources(gr);
 
 #  DigraphPeriod
 gap> gr := EmptyDigraph(100);
-<immutable digraph with 100 vertices, 0 edges>
+<immutable empty digraph with 100 vertices>
 gap> DigraphPeriod(gr);
 0
 gap> gr := CompleteDigraph(100);
-<immutable digraph with 100 vertices, 9900 edges>
+<immutable complete digraph with 100 vertices>
 gap> DigraphPeriod(gr);
 1
 gap> gr := Digraph([[2, 2], [3], [4], [1]]);
@@ -722,7 +722,7 @@ gap> gr1 := Digraph([[2], [1]]);
 gap> IsSymmetricDigraph(gr1);
 true
 gap> gr2 := DigraphSymmetricClosure(gr1);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> IsIdenticalObj(gr1, gr2);
 true
 gap> gr1 = gr2;
@@ -742,7 +742,7 @@ gap> gr1 := Digraph(
 gap> IsSymmetricDigraph(gr1);
 false
 gap> gr2 := DigraphSymmetricClosure(gr1);
-<immutable digraph with 12 vertices, 38 edges>
+<immutable symmetric digraph with 12 vertices, 38 edges>
 gap> HasIsSymmetricDigraph(gr2);
 true
 gap> IsSymmetricDigraph(gr2);
@@ -754,7 +754,7 @@ gap> gr3 := Digraph(
 gap> gr2 = gr3;
 true
 gap> gr := DigraphSymmetricClosure(ChainDigraph(10000));
-<immutable digraph with 10000 vertices, 19998 edges>
+<immutable symmetric digraph with 10000 vertices, 19998 edges>
 gap> IsSymmetricDigraph(gr);
 true
 gap> gr := DigraphCopy(gr);
@@ -780,9 +780,9 @@ false
 gap> DigraphTopologicalSort(gr);
 fail
 gap> gr1 := DigraphTransitiveClosure(gr);
-<immutable digraph with 4 vertices, 16 edges>
+<immutable transitive digraph with 4 vertices, 16 edges>
 gap> gr2 := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 4 vertices, 16 edges>
+<immutable preorder digraph with 4 vertices, 16 edges>
 gap> gr1 = gr2;
 true
 gap> gr1 = DigraphReflexiveTransitiveClosure(DigraphMutableCopy(gr));
@@ -793,21 +793,21 @@ gap> gr := Digraph(adj);
 gap> IsAcyclicDigraph(gr);
 true
 gap> gr1 := DigraphTransitiveClosure(gr);
-<immutable digraph with 7 vertices, 18 edges>
+<immutable transitive digraph with 7 vertices, 18 edges>
 gap> gr2 := DigraphReflexiveTransitiveClosure(DigraphImmutableCopy(gr));
-<immutable digraph with 7 vertices, 25 edges>
+<immutable preorder digraph with 7 vertices, 25 edges>
 gap> gr := Digraph([[2], [3], [4], [3]]);
 <immutable digraph with 4 vertices, 4 edges>
 gap> gr1 := DigraphTransitiveClosure(gr);
-<immutable digraph with 4 vertices, 9 edges>
+<immutable transitive digraph with 4 vertices, 9 edges>
 gap> gr2 := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 4 vertices, 11 edges>
+<immutable preorder digraph with 4 vertices, 11 edges>
 gap> gr := Digraph([[2], [3], [4, 5], [], [5]]);
 <immutable digraph with 5 vertices, 5 edges>
 gap> gr1 := DigraphTransitiveClosure(gr);
-<immutable digraph with 5 vertices, 10 edges>
+<immutable transitive digraph with 5 vertices, 10 edges>
 gap> gr2 := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 5 vertices, 14 edges>
+<immutable preorder digraph with 5 vertices, 14 edges>
 gap> gr := Digraph(
 > [[1, 4, 5, 6, 7, 8], [5, 7, 8, 9, 10, 13], [2, 4, 6, 10],
 >  [7, 9, 10, 11], [7, 9, 10, 12, 13, 15], [7, 8, 10, 13], [10, 11],
@@ -815,7 +815,7 @@ gap> gr := Digraph(
 >  [7, 13, 14], [10, 11], [7, 10, 11], [7, 13, 16], [7, 10, 11]]);
 <immutable digraph with 16 vertices, 60 edges>
 gap> trans1 := DigraphTransitiveClosure(gr);
-<immutable digraph with 16 vertices, 98 edges>
+<immutable transitive digraph with 16 vertices, 98 edges>
 gap> trans2 := DigraphByAdjacencyMatrix(DIGRAPH_TRANS_CLOSURE(gr));
 <immutable digraph with 16 vertices, 98 edges>
 gap> trans1 = trans2;
@@ -829,7 +829,7 @@ true
 gap> IS_TRANSITIVE_DIGRAPH(trans);
 true
 gap> reflextrans1 := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 16 vertices, 112 edges>
+<immutable preorder digraph with 16 vertices, 112 edges>
 gap> reflextrans2 :=
 > DigraphByAdjacencyMatrix(DIGRAPH_REFLEX_TRANS_CLOSURE(gr));
 <immutable digraph with 16 vertices, 112 edges>
@@ -858,9 +858,9 @@ gap> rd := ReducedDigraph(gr);
 gap> DigraphVertexLabels(rd);
 [ 1, 2, 4, 6, 7 ]
 gap> gr := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> rd := ReducedDigraph(gr);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> rd = gr;
 true
 gap> DigraphVertexLabels(gr) = DigraphVertexLabels(rd);
@@ -952,7 +952,7 @@ gap> gr := Digraph([[2], [1, 3], [4], [3]]);;
 gap> AsTransformation(gr);
 fail
 gap> gr := AsDigraph(Transformation([1, 1, 1]), 5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable functional digraph with 5 vertices>
 gap> DigraphEdges(gr);
 [ [ 1, 1 ], [ 2, 1 ], [ 3, 1 ], [ 4, 4 ], [ 5, 5 ] ]
 gap> AsTransformation(gr);
@@ -1171,7 +1171,7 @@ gap> gr := Digraph([[2], []]);
 gap> DigraphOddGirth(gr);
 infinity
 gap> gr := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> DigraphOddGirth(gr);
 infinity
 gap> gr := DigraphDisjointUnion(CycleDigraph(2), CycleDigraph(3));;
@@ -1181,7 +1181,7 @@ gap> for i in [1 .. 50] do
 gap> DigraphOddGirth(gr);
 3
 gap> G := Digraph(IsMutableDigraph, [[]]);
-<mutable digraph with 1 vertex, 0 edges>
+<mutable empty digraph with 1 vertex>
 gap> for i in [2 .. 200] do
 >   DigraphAddVertex(G, i);
 >   DigraphAddEdges(G, [[1, i], [i, 1]]);
@@ -1196,13 +1196,13 @@ gap> DigraphOddGirth(D);
 
 # DigraphMycielskian
 gap> D1 := DigraphSymmetricClosure(CycleDigraph(2));
-<immutable digraph with 2 vertices, 2 edges>
+<immutable cycle digraph with 2 vertices>
 gap> D2 := DigraphSymmetricClosure(CycleDigraph(5));
-<immutable digraph with 5 vertices, 10 edges>
+<immutable symmetric digraph with 5 vertices, 10 edges>
 gap> IsIsomorphicDigraph(DigraphMycielskian(D1), D2);
 true
 gap> D := DigraphSymmetricClosure(CayleyDigraph(DihedralGroup(8)));
-<immutable digraph with 8 vertices, 32 edges>
+<immutable symmetric digraph with 8 vertices, 32 edges>
 gap> ChromaticNumber(D);
 4
 gap> D := DigraphMycielskian(D);
@@ -1216,13 +1216,13 @@ gap> D2 := Digraph([[], [3, 4], [2, 5], [2, 6], [3, 6], [4, 5, 7], [6]]);
 gap> IsIsomorphicDigraph(DigraphMycielskian(D1), D2);
 true
 gap> D := DigraphSymmetricClosure(CycleDigraph(5));
-<immutable digraph with 5 vertices, 10 edges>
+<immutable symmetric digraph with 5 vertices, 10 edges>
 gap> D := DigraphMutableCopy(D);
 <mutable digraph with 5 vertices, 10 edges>
 gap> DigraphMycielskian(D);
 <mutable digraph with 11 vertices, 40 edges>
 gap> D := DigraphSymmetricClosure(Digraph([[1, 2], [1]]));
-<immutable digraph with 2 vertices, 3 edges>
+<immutable symmetric digraph with 2 vertices, 3 edges>
 gap> D := DigraphMutableCopy(D);
 <mutable digraph with 2 vertices, 3 edges>
 gap> DigraphMycielskian(D);
@@ -1262,7 +1262,7 @@ gap> DigraphDegeneracy(gr);
 gap> DigraphDegeneracyOrdering(gr);
 [ 5, 4, 3, 2, 1 ]
 gap> gr := DigraphSymmetricClosure(ChainDigraph(4));
-<immutable digraph with 4 vertices, 6 edges>
+<immutable symmetric digraph with 4 vertices, 6 edges>
 gap> DigraphDegeneracy(gr);
 1
 gap> DigraphDegeneracyOrdering(gr);
@@ -1273,7 +1273,7 @@ gap> DigraphDegeneracy(gr);
 1
 gap> gr := DigraphSymmetricClosure(Digraph(
 > [[2, 5], [3, 5], [4], [5, 6], [], []]));
-<immutable digraph with 6 vertices, 14 edges>
+<immutable symmetric digraph with 6 vertices, 14 edges>
 gap> DigraphDegeneracy(gr);
 2
 gap> DigraphDegeneracyOrdering(gr);
@@ -1315,17 +1315,17 @@ gap> gr := Digraph([[2, 3], [1, 3], [4], [4]]);
 gap> IsSymmetricDigraph(gr);
 false
 gap> gr2 := MaximalSymmetricSubdigraph(gr);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable symmetric digraph with 4 vertices, 3 edges>
 gap> OutNeighbours(gr2);
 [ [ 2 ], [ 1 ], [  ], [ 4 ] ]
 gap> gr2 := MaximalSymmetricSubdigraphWithoutLoops(gr);
-<immutable digraph with 4 vertices, 2 edges>
+<immutable symmetric digraph with 4 vertices, 2 edges>
 gap> OutNeighbours(gr2);
 [ [ 2 ], [ 1 ], [  ], [  ] ]
 gap> gr := Digraph([[2, 2], [1, 1]]);
 <immutable multidigraph with 2 vertices, 4 edges>
 gap> gr2 := MaximalSymmetricSubdigraphWithoutLoops(gr);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> OutNeighbours(gr2);
 [ [ 2 ], [ 1 ] ]
 gap> gr := Digraph([[1, 2, 2], [1, 1]]);
@@ -1333,7 +1333,7 @@ gap> gr := Digraph([[1, 2, 2], [1, 1]]);
 gap> IsSymmetricDigraph(gr);
 true
 gap> gr3 := MaximalSymmetricSubdigraphWithoutLoops(gr);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> gr2 = gr3;
 true
 gap> gr := Digraph([[2, 3], [1], [1, 3]]);
@@ -1341,13 +1341,13 @@ gap> gr := Digraph([[2, 3], [1], [1, 3]]);
 gap> IsSymmetricDigraph(gr);
 true
 gap> gr := MaximalSymmetricSubdigraphWithoutLoops(gr);
-<immutable digraph with 3 vertices, 4 edges>
+<immutable symmetric digraph with 3 vertices, 4 edges>
 gap> OutNeighbours(gr);
 [ [ 2, 3 ], [ 1 ], [ 1 ] ]
 
 #  RepresentativeOutNeighbours
 gap> gr := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> RepresentativeOutNeighbours(gr);
 [ [ 2 ] ]
 gap> DigraphOrbitReps(gr);
@@ -1473,7 +1473,7 @@ gap> gr := Digraph([[2, 4, 7, 3], [3, 5, 8, 1], [1, 6, 9, 2],
 gap> ChromaticNumber(gr);
 3
 gap> gr := DigraphSymmetricClosure(ChainDigraph(5));
-<immutable digraph with 5 vertices, 8 edges>
+<immutable symmetric digraph with 5 vertices, 8 edges>
 gap> DigraphGreedyColoring(gr);;
 gap> ChromaticNumber(gr);
 2
@@ -1482,15 +1482,15 @@ gap> gr := DigraphFromGraph6String("KmKk~K??G@_@");
 gap> ChromaticNumber(gr);
 4
 gap> gr := CycleDigraph(7);
-<immutable digraph with 7 vertices, 7 edges>
+<immutable cycle digraph with 7 vertices>
 gap> ChromaticNumber(gr);
 3
 gap> gr := CycleDigraph(71);
-<immutable digraph with 71 vertices, 71 edges>
+<immutable cycle digraph with 71 vertices>
 gap> ChromaticNumber(gr);
 3
 gap> gr := CycleDigraph(1001);
-<immutable digraph with 1001 vertices, 1001 edges>
+<immutable cycle digraph with 1001 vertices>
 gap> ChromaticNumber(gr);
 3
 gap> a := DigraphRemoveEdges(CompleteDigraph(50), [[1, 2], [2, 1]]);;
@@ -1544,7 +1544,7 @@ gap> NrSpanningTrees(Digraph([[2, 3, 4], [1, 5], [1, 5], [1, 5], [2, 3, 4]]));
 
 #  UndirectedSpanningTree and UndirectedSpanningForest
 gap> gr := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> tree := UndirectedSpanningTree(gr);
 fail
 gap> forest := UndirectedSpanningForest(gr);
@@ -1552,11 +1552,11 @@ fail
 gap> UndirectedSpanningForest(EmptyDigraph(IsMutableDigraph, 0));
 fail
 gap> gr := EmptyDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> tree := UndirectedSpanningTree(gr);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> forest := UndirectedSpanningForest(gr);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsUndirectedSpanningTree(gr, gr);
 true
 gap> IsUndirectedSpanningTree(gr, forest);
@@ -1564,11 +1564,11 @@ true
 gap> gr = forest;
 true
 gap> gr := EmptyDigraph(2);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> tree := UndirectedSpanningTree(gr);
 fail
 gap> forest := UndirectedSpanningForest(gr);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsUndirectedTree(forest);
 false
 gap> IsUndirectedSpanningForest(gr, forest);
@@ -1592,7 +1592,7 @@ true
 gap> D := DigraphFromDigraph6String("&I~~~~^Znn~|~~x^|v{");
 <immutable digraph with 10 vertices, 89 edges>
 gap> tree := UndirectedSpanningTree(D);
-<immutable digraph with 10 vertices, 18 edges>
+<immutable symmetric digraph with 10 vertices, 18 edges>
 gap> IsUndirectedSpanningTree(D, tree);
 true
 gap> tree := UndirectedSpanningTree(DigraphMutableCopy(D));
@@ -1692,15 +1692,15 @@ true
 
 #  HamiltonianPath
 gap> g := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> HamiltonianPath(g);
 [  ]
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> HamiltonianPath(g);
 [ 1 ]
 gap> g := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> HamiltonianPath(g);
 fail
 gap> g := Digraph([[1]]);
@@ -1775,7 +1775,7 @@ gap> IsDigraphMonomorphism(CycleDigraph(10),
 >                          Transformation(HamiltonianPath(g)));
 true
 gap> g := CompleteMultipartiteDigraph([1, 30]);
-<immutable digraph with 31 vertices, 60 edges>
+<immutable complete bipartite digraph with bicomponent sizes 1 and 30>
 gap> HamiltonianPath(g);
 fail
 gap> g := Digraph([[2, 5, 6], [3, 1, 7], [4, 2, 8], [5, 3, 9], [1, 4, 10],
@@ -1784,15 +1784,15 @@ gap> g := Digraph([[2, 5, 6], [3, 1, 7], [4, 2, 8], [5, 3, 9], [1, 4, 10],
 gap> HamiltonianPath(g);
 fail
 gap> g := CompleteMultipartiteDigraph([16, 15]);
-<immutable digraph with 31 vertices, 480 edges>
+<immutable complete bipartite digraph with bicomponent sizes 16 and 15>
 gap> HamiltonianPath(g);
 fail
 gap> g := CompleteMultipartiteDigraph([1, 15, 1, 1, 1, 1, 1, 1]);
-<immutable digraph with 22 vertices, 252 edges>
+<immutable multipartite symmetric digraph with 22 vertices, 252 edges>
 gap> HamiltonianPath(g);
 fail
 gap> g := CycleDigraph(100);
-<immutable digraph with 100 vertices, 100 edges>
+<immutable cycle digraph with 100 vertices>
 gap> HamiltonianPath(g);
 [ 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 
   96, 97, 98, 99, 100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 
@@ -1801,7 +1801,7 @@ gap> HamiltonianPath(g);
   55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 
   74, 75, 76 ]
 gap> g := CycleDigraph(513);
-<immutable digraph with 513 vertices, 513 edges>
+<immutable cycle digraph with 513 vertices>
 gap> g := DigraphAddEdges(g, [[6, 8], [8, 7], [7, 9]]);
 <immutable digraph with 513 vertices, 516 edges>
 gap> g := DigraphRemoveEdge(g, [6, 7]);
@@ -1858,7 +1858,7 @@ gap> DigraphCore(D);
 gap> DigraphHomomorphism(D, InducedSubdigraph(D, DigraphCore(D)));
 Transformation( [ 1, 3, 2, 3 ] )
 gap> D := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> DigraphCore(D);
 [ 1 .. 10 ]
 gap> D := Digraph([[2], [3], [4], [5], [6], [2]]);
@@ -1870,15 +1870,15 @@ gap> D := Digraph([[2], [1], [4, 5], [5], [4]]);
 gap> DigraphCore(D);
 [ 3, 4, 5 ]
 gap> D := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphCore(D);
 [  ]
 gap> D := EmptyDigraph(1000);
-<immutable digraph with 1000 vertices, 0 edges>
+<immutable empty digraph with 1000 vertices>
 gap> DigraphCore(D);
 [ 1 ]
 gap> D := EmptyDigraph(IsMutableDigraph, 0);
-<mutable digraph with 0 vertices, 0 edges>
+<mutable empty digraph with 0 vertices>
 gap> for i in [2 .. 15] do
 > DigraphDisjointUnion(D, CycleDigraph(i));
 > od;
@@ -1937,7 +1937,7 @@ gap> DigraphCore(D);
 
 # MaximalAntiSymmetricSubdigraph
 gap> MaximalAntiSymmetricSubdigraph(Digraph([[2, 2], [1]]));
-<immutable digraph with 2 vertices, 1 edge>
+<immutable antisymmetric digraph with 2 vertices, 1 edge>
 gap> MaximalAntiSymmetricSubdigraph(Digraph(IsMutableDigraph, [[2, 2], [1]]));
 <mutable digraph with 2 vertices, 1 edge>
 gap> D := Digraph(IsMutableDigraph, [[1]]);
@@ -1945,33 +1945,33 @@ gap> D := Digraph(IsMutableDigraph, [[1]]);
 gap> MaximalAntiSymmetricSubdigraph(D) = D;
 true
 gap> MaximalAntiSymmetricSubdigraph(NullDigraph(0));
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsAntisymmetricDigraph(DigraphCopy(last));
 true
 gap> MaximalAntiSymmetricSubdigraph(NullDigraph(1));
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsAntisymmetricDigraph(DigraphCopy(last));
 true
 gap> MaximalAntiSymmetricSubdigraph(CompleteDigraph(1));
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsAntisymmetricDigraph(DigraphCopy(last));
 true
 gap> MaximalAntiSymmetricSubdigraph(CompleteBipartiteDigraph(2, 30000));
-<immutable digraph with 30002 vertices, 60000 edges>
+<immutable antisymmetric digraph with 30002 vertices, 60000 edges>
 gap> IsAntisymmetricDigraph(DigraphCopy(last));
 true
 gap> MaximalAntiSymmetricSubdigraph(Digraph([[1, 1, 2, 2], []]));
-<immutable digraph with 2 vertices, 2 edges>
+<immutable antisymmetric digraph with 2 vertices, 2 edges>
 gap> OutNeighbours(last);
 [ [ 1, 2 ], [  ] ]
 gap> MaximalAntiSymmetricSubdigraph(CompleteDigraph(10));
-<immutable digraph with 10 vertices, 45 edges>
+<immutable antisymmetric digraph with 10 vertices, 45 edges>
 gap> D := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> MaximalAntiSymmetricSubdigraph(D);
-<immutable digraph with 10 vertices, 45 edges>
+<immutable antisymmetric digraph with 10 vertices, 45 edges>
 gap> MaximalAntiSymmetricSubdigraph(D);
-<immutable digraph with 10 vertices, 45 edges>
+<immutable antisymmetric digraph with 10 vertices, 45 edges>
 
 # CharacteristicPolynomial
 gap> gr := Digraph([
@@ -1984,7 +1984,7 @@ gap> CharacteristicPolynomial(gr);
 x_1^10-3*x_1^9-7*x_1^8-x_1^7+14*x_1^6+x_1^5-26*x_1^4+51*x_1^3-10*x_1^2+18*x_1-\
 30
 gap> gr := CompleteDigraph(5);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> CharacteristicPolynomial(gr);
 x_1^5-10*x_1^3-20*x_1^2-15*x_1-4
 
@@ -2012,7 +2012,7 @@ Error, the argument <D> must be a digraph with no multiple edges,
 
 # AsGraph
 gap> D := NullDigraph(IsMutableDigraph, 3);
-<mutable digraph with 3 vertices, 0 edges>
+<mutable empty digraph with 3 vertices>
 gap> AsGraph(D);
 rec( adjacencies := [ [  ], [  ], [  ] ], group := Group(()), isGraph := true,
   names := [ 1 .. 3 ], order := 3, representatives := [ 1, 2, 3 ], 
@@ -2020,19 +2020,19 @@ rec( adjacencies := [ [  ], [  ], [  ] ], group := Group(()), isGraph := true,
 
 # DigraphSource
 gap> D := NullDigraph(IsMutableDigraph, 3);
-<mutable digraph with 3 vertices, 0 edges>
+<mutable empty digraph with 3 vertices>
 gap> DigraphSource(D);
 [  ]
 gap> DigraphRange(D);
 [  ]
 gap> DigraphSymmetricClosure(NullDigraph(IsMutableDigraph, 1));
-<mutable digraph with 1 vertex, 0 edges>
+<mutable empty digraph with 1 vertex>
 gap> D := Digraph([[2], []]);
 <immutable digraph with 2 vertices, 1 edge>
 gap> DigraphSymmetricClosure(D);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> DigraphSymmetricClosure(D);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> D := Digraph(IsMutableDigraph, [[2, 2], []]);
 <mutable multidigraph with 2 vertices, 2 edges>
 gap> DigraphTransitiveClosure(D);
@@ -2046,25 +2046,25 @@ Error, the argument <D> must be a digraph with no multiple edges,
 gap> D := Digraph([[2], []]);
 <immutable digraph with 2 vertices, 1 edge>
 gap> DigraphTransitiveClosure(D);
-<immutable digraph with 2 vertices, 1 edge>
+<immutable transitive digraph with 2 vertices, 1 edge>
 gap> DigraphTransitiveClosure(D);
-<immutable digraph with 2 vertices, 1 edge>
+<immutable transitive digraph with 2 vertices, 1 edge>
 gap> DigraphReflexiveTransitiveClosure(D);
-<immutable digraph with 2 vertices, 3 edges>
+<immutable preorder digraph with 2 vertices, 3 edges>
 gap> DigraphReflexiveTransitiveClosure(D);
-<immutable digraph with 2 vertices, 3 edges>
+<immutable preorder digraph with 2 vertices, 3 edges>
 gap> D := DigraphMutableCopy(DigraphSymmetricClosure(D));
 <mutable digraph with 2 vertices, 2 edges>
 gap> MaximalSymmetricSubdigraphWithoutLoops(D);
 <mutable digraph with 2 vertices, 2 edges>
 gap> MaximalSymmetricSubdigraphWithoutLoops(MakeImmutable(D));
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> MaximalSymmetricSubdigraphWithoutLoops(D);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable symmetric digraph with 2 vertices, 2 edges>
 gap> D := CycleDigraph(IsMutableDigraph, 10);
 <mutable digraph with 10 vertices, 10 edges>
 gap> UndirectedSpanningForest(D);
-<mutable digraph with 10 vertices, 0 edges>
+<mutable empty digraph with 10 vertices>
 
 #  Digraph(Reflexive)TransitiveReduction
 
@@ -2084,9 +2084,9 @@ Error, not yet implemented for non-topologically sortable digraphs,
 
 # Working examples
 gap> gr1 := ChainDigraph(6);
-<immutable digraph with 6 vertices, 5 edges>
+<immutable chain digraph with 6 vertices>
 gap> gr2 := DigraphReflexiveTransitiveClosure(gr1);
-<immutable digraph with 6 vertices, 21 edges>
+<immutable preorder digraph with 6 vertices, 21 edges>
 gap> DigraphTransitiveReduction(gr2) = gr1;  # trans reduction contains loops
 false
 gap> DigraphReflexiveTransitiveReduction(gr2) = gr1;  # ref trans reduct doesnt
@@ -2096,7 +2096,7 @@ gap> gr3 := DigraphAddEdge(gr1, [3, 3]);
 gap> DigraphHasLoops(gr3);
 true
 gap> gr4 := DigraphTransitiveClosure(gr3);
-<immutable digraph with 6 vertices, 16 edges>
+<immutable transitive digraph with 6 vertices, 16 edges>
 gap> gr2 = gr4;
 false
 gap> DigraphReflexiveTransitiveReduction(gr4) = gr1;

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -1868,7 +1868,7 @@ gap> DigraphCore(D);
 gap> D := Digraph([[2], [1], [4, 5], [5], [4]]);
 <immutable digraph with 5 vertices, 6 edges>
 gap> DigraphCore(D);
-[ 3 .. 5 ]
+[ 3, 4, 5 ]
 gap> D := EmptyDigraph(0);
 <immutable digraph with 0 vertices, 0 edges>
 gap> DigraphCore(D);
@@ -1926,7 +1926,7 @@ gap> DigraphCore(D);
 gap> D := DigraphFromDigraph6String("&IO?_@?A?CG??O?_G??");
 <immutable digraph with 10 vertices, 9 edges>
 gap> DigraphCore(D);
-[ 7 .. 9 ]
+[ 7, 8, 9 ]
 gap> D := CycleDigraph(IsMutableDigraph, 2);
 <mutable digraph with 2 vertices, 2 edges>
 gap> for i in [1 .. 9] do

--- a/tst/standard/cliques.tst
+++ b/tst/standard/cliques.tst
@@ -226,9 +226,9 @@ Error, at least 1 argument is required,
 gap> DigraphClique();
 Error, at least 1 argument is required,
 gap> DigraphMaximalClique(1);
-Error, the 1st argument <D> must be a dense digraph,
+Error, the 1st argument <D> must be a digraph by out-neighbours,
 gap> DigraphClique(1);
-Error, the 1st argument <D> must be a dense digraph,
+Error, the 1st argument <D> must be a digraph by out-neighbours,
 gap> DigraphMaximalClique(gr);
 [ 5, 4, 3, 2, 1 ]
 gap> DigraphClique(gr);

--- a/tst/standard/constructors.tst
+++ b/tst/standard/constructors.tst
@@ -181,7 +181,7 @@ gap> gr3 := LineUndirectedDigraph(gr);
 gap> gr2 = gr3;
 true
 gap> gr := CycleDigraph(8);
-<immutable digraph with 8 vertices, 8 edges>
+<immutable cycle digraph with 8 vertices>
 gap> gr2 := LineDigraph(gr);
 <immutable digraph with 8 vertices, 8 edges>
 gap> DigraphGroup(gr);
@@ -191,7 +191,7 @@ gap> gr3 := LineDigraph(gr);
 gap> gr2 = gr3;
 true
 gap> gr := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> LineUndirectedDigraph(gr);
 Error, the argument <D> must be a symmetric digraph,
 

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1084,7 +1084,7 @@ gap> G := DihedralGroup(8);
 <pc group of size 8 with 3 generators>
 gap> digraph := Digraph(AsSet(G), ReturnTrue);
 <immutable digraph with 8 vertices, 64 edges>
-gap> IsDenseDigraphRep(digraph);
+gap> IsDigraphByOutNeighboursRep(digraph);
 true
 gap> digraph := Digraph("abcd", function(i, j) return i < j; end);
 <immutable digraph with 4 vertices, 6 edges>
@@ -1097,7 +1097,7 @@ gap> digraph := Digraph(["hello", "world", 13, true, (1, 4, 3)],
 <immutable digraph with 5 vertices, 5 edges>
 gap> HasDigraphAdjacencyFunction(digraph);
 true
-gap> IsDenseDigraphRep(digraph);
+gap> IsDigraphByOutNeighboursRep(digraph);
 true
 
 #  Digraphs with known automorphisms

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -107,7 +107,7 @@ gap> Digraph(2, [1], [2, 2]);
 Error, the record components 'DigraphSource' and 'DigraphRange' must have equa\
 l length,
 gap> Digraph(5, [], []);
-<immutable digraph with 5 vertices, 0 edges>
+<immutable empty digraph with 5 vertices>
 gap> Digraph(2, "ab", [0, 1]);
 Error, the record component 'DigraphSource' is invalid,
 gap> Digraph(2, [0, 1], "ab");
@@ -239,14 +239,14 @@ Binary Relation on 5 points
 gap> IsEquivalenceRelation(b);
 true
 gap> gr2 := AsDigraph(b);
-<immutable digraph with 5 vertices, 9 edges>
+<immutable equivalence digraph with 5 vertices, 9 edges>
 gap> gr := Digraph([[1, 2], [3], []]);
 <immutable digraph with 3 vertices, 3 edges>
 gap> b := AsBinaryRelation(gr);;
 gap> IsAntisymmetricBinaryRelation(b);
 true
 gap> gr := AsDigraph(b);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable antisymmetric digraph with 3 vertices, 3 edges>
 gap> HasIsAntisymmetricDigraph(gr);
 true
 
@@ -277,9 +277,9 @@ gap> gr := DigraphByEdges([[1, 2]], 1);
 Error, the 1st argument <edges> must not contain values greater than 
 1, the 2nd argument <n>,
 gap> gr := DigraphByEdges([], 3);
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> gr := DigraphByEdges([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> gr = EmptyDigraph(0);
 true
 
@@ -349,7 +349,7 @@ false
 gap> AdjacencyMatrix(gr2) = mat;
 true
 gap> DigraphByAdjacencyMatrix([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 
 #  DigraphByAdjacencyMatrix (by a boolean matrix)
 gap> mat := List([1 .. 5], x -> BlistList([1 .. 5], []));;
@@ -418,27 +418,27 @@ gap> gr2 := DigraphByInNeighbours(IsImmutableDigraph, inn);
 gap> f := Transformation([]);
 IdentityTransformation
 gap> gr := AsDigraph(f);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> gr = Digraph([]);
 true
 gap> AsDigraph(f, 10);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable functional digraph with 10 vertices>
 gap> g := Transformation([2, 6, 7, 2, 6, 1, 1, 5]);
 Transformation( [ 2, 6, 7, 2, 6, 1, 1, 5 ] )
 gap> AsDigraph(g);
-<immutable digraph with 8 vertices, 8 edges>
+<immutable functional digraph with 8 vertices>
 gap> AsDigraph(g, -1);
 Error, the 2nd argument <n> should be a non-negative integer,
 gap> AsDigraph(g, 10);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable functional digraph with 10 vertices>
 gap> AsDigraph(g, 6);
 fail
 gap> AsDigraph(g, 7);
-<immutable digraph with 7 vertices, 7 edges>
+<immutable functional digraph with 7 vertices>
 gap> h := Transformation([2, 4, 1, 3, 5]);
 Transformation( [ 2, 4, 1, 3 ] )
 gap> AsDigraph(h);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable functional digraph with 4 vertices>
 gap> AsDigraph(h, 2);
 fail
 
@@ -458,7 +458,7 @@ gap> RandomDigraph("a");
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RandomDigraph' on 1 arguments
 gap> RandomDigraph(4, 0);
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> RandomDigraph(10, 1.01);
 Error, the 2nd argument <p> must be between 0 and 1,
 gap> RandomDigraph(10, -0.01);
@@ -481,7 +481,7 @@ gap> RandomDigraph(IsImmutableDigraph, "a");
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RandomDigraph' on 2 arguments
 gap> RandomDigraph(IsImmutableDigraph, 4, 0);
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> RandomDigraph(IsImmutableDigraph, 10, 1.01);
 Error, the 2nd argument <p> must be between 0 and 1,
 gap> RandomDigraph(IsImmutableDigraph, 10, -0.01);
@@ -504,7 +504,7 @@ gap> RandomDigraph(IsMutableDigraph, "a");
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `RandomDigraph' on 2 arguments
 gap> RandomDigraph(IsMutableDigraph, 4, 0);
-<mutable digraph with 4 vertices, 0 edges>
+<mutable empty digraph with 4 vertices>
 gap> RandomDigraph(IsMutableDigraph, 10, 1.01);
 Error, the 2nd argument <p> must be between 0 and 1,
 gap> RandomDigraph(IsMutableDigraph, 10, -0.01);
@@ -531,9 +531,9 @@ Error, no 1st choice method found for `RandomMultiDigraph' on 2 arguments
 
 #  RandomTournament
 gap> RandomTournament(25);
-<immutable digraph with 25 vertices, 300 edges>
+<immutable tournament with 25 vertices>
 gap> RandomTournament(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> RandomTournament(-1);
 Error, the argument <n> must be a non-negative integer,
 gap> RandomTournament(IsMutableDigraph, 10);
@@ -658,9 +658,9 @@ gap> gr2 := Digraph([[1], [2]]);
 gap> gr1 = gr2;
 false
 gap> gr1 := Digraph([[], [], []]);
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> gr2 := Digraph(rec(DigraphNrVertices := 3, DigraphSource := [], DigraphRange := []));
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> gr1 = gr2;
 true
 gap> gr1 := Digraph([[1], []]);
@@ -1009,7 +1009,7 @@ true
 
 # Tests for DigraphCopy originally located in digraph.tst
 gap> gr1 := CompleteDigraph(6);
-<immutable digraph with 6 vertices, 30 edges>
+<immutable complete digraph with 6 vertices>
 gap> SetDigraphVertexLabels(gr1, Elements(SymmetricGroup(3)));
 gap> DigraphVertexLabels(gr1);
 [ (), (2,3), (1,2), (1,2,3), (1,3,2), (1,3) ]
@@ -1026,7 +1026,7 @@ gap> HasAdjacencyMatrix(gr2);
 false
 gap> gr1 := EmptyDigraph(0);;
 gap> gr2 := DigraphCopy(gr1);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> String(gr2);
 "Digraph( IsImmutableDigraph, [ ] )"
 gap> PrintString(gr2);
@@ -1039,11 +1039,11 @@ gap> gr := Digraph([[6, 1, 2, 3], [6], [2, 2, 3], [1, 1], [6, 5],
 gap> gr = DigraphCopy(gr);
 true
 gap> gr := CompleteDigraph(100);
-<immutable digraph with 100 vertices, 9900 edges>
+<immutable complete digraph with 100 vertices>
 gap> gr = DigraphCopy(gr);
 true
 gap> gr := CycleDigraph(10000);
-<immutable digraph with 10000 vertices, 10000 edges>
+<immutable cycle digraph with 10000 vertices>
 gap> gr = DigraphCopy(gr);
 true
 gap> SetDigraphVertexLabel(gr, 1, "w");
@@ -1126,25 +1126,25 @@ true
 
 #  DigraphAddAllLoops
 gap> gr := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> OutNeighbours(gr)[1];
 [ 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
 gap> gr2 := DigraphAddAllLoops(gr);
-<immutable digraph with 10 vertices, 100 edges>
+<immutable reflexive digraph with 10 vertices, 100 edges>
 gap> OutNeighbours(gr2)[1];
 [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 1 ]
 gap> gr3 := DigraphAddAllLoops(gr);
-<immutable digraph with 10 vertices, 100 edges>
+<immutable reflexive digraph with 10 vertices, 100 edges>
 gap> OutNeighbours(gr3)[1];
 [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 1 ]
 gap> gr := EmptyDigraph(100);
-<immutable digraph with 100 vertices, 0 edges>
+<immutable empty digraph with 100 vertices>
 gap> DigraphAddAllLoops(gr);
-<immutable digraph with 100 vertices, 100 edges>
+<immutable reflexive digraph with 100 vertices, 100 edges>
 gap> gr := Digraph([[1, 2, 3], [2, 2, 2, 2], [5, 1], [1, 2, 3, 4], [5]]);
 <immutable multidigraph with 5 vertices, 14 edges>
 gap> gr2 := DigraphAddAllLoops(gr);
-<immutable multidigraph with 5 vertices, 15 edges>
+<immutable reflexive multidigraph with 5 vertices, 15 edges>
 gap> OutNeighbours(gr2);
 [ [ 1, 2, 3 ], [ 2, 2, 2, 2 ], [ 5, 1, 3 ], [ 1, 2, 3, 4 ], [ 5 ] ]
 
@@ -1205,7 +1205,7 @@ gap> D := DigraphNC(IsMutableDigraph, OutNeighbours(MakeImmutable(D)));
 <mutable digraph with 2 vertices, 2 edges>
 gap> D := DigraphNC(rec(xxx := 1, DigraphRange := [], DigraphSource := [],
 >  DigraphNrVertices := 1000));
-<immutable digraph with 1000 vertices, 0 edges>
+<immutable empty digraph with 1000 vertices>
 gap> IsBound(D!.xxx);
 false
 gap> list := [[1, 2], []];
@@ -1217,15 +1217,15 @@ gap> PrintString(D);
 gap> EvalString(String(D)) = D;
 true
 gap> DigraphByAdjacencyMatrix(IsMutableDigraph, []);
-<mutable digraph with 0 vertices, 0 edges>
+<mutable empty digraph with 0 vertices>
 gap> DigraphByAdjacencyMatrix(IsMutableDigraph, [[true]]);
 <mutable digraph with 1 vertex, 1 edge>
 gap> DigraphByAdjacencyMatrix([[true]]);
 <immutable digraph with 1 vertex, 1 edge>
 gap> DigraphByEdges(IsMutableDigraph, []);
-<mutable digraph with 0 vertices, 0 edges>
+<mutable empty digraph with 0 vertices>
 gap> DigraphByEdges(IsMutableDigraph, [], 10);
-<mutable digraph with 10 vertices, 0 edges>
+<mutable empty digraph with 10 vertices>
 gap> D := AsDigraph(IsMutableDigraph, Transformation([1, 1, 2]));
 <mutable digraph with 3 vertices, 3 edges>
 gap> IsFunctionalDigraph(D);
@@ -1233,7 +1233,7 @@ true
 
 #  AsBinaryRelation
 gap> gr := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> AsBinaryRelation(gr);
 Error, the argument <D> must be a digraph with at least 1 vertex,
 gap> gr := Digraph([[1, 1]]);
@@ -1296,9 +1296,19 @@ gap> HasIsAntisymmetricBinaryRelation(rel3);
 true
 
 # AsSemigroup, AsMonoid (for IsPartialPermX and a digraph)
-gap> di := Digraph([[1], [1, 2], [1, 2, 3], [1, 2, 3, 4]]);;
+gap> di := Digraph(IsMutableDigraph, [[1], [1, 2], [1, 2, 3], [1, 2, 3, 4]]);
+<mutable digraph with 4 vertices, 10 edges>
 gap> S := AsSemigroup(IsPartialPermSemigroup, di);;
 gap> IsInverseSemigroup(S) and ForAll(Elements(S), IsIdempotent);
+true
+gap> di;
+<mutable digraph with 4 vertices, 10 edges>
+gap> di := DigraphMutableCopy(DigraphFromDigraph6String("&H_E?gF_~GH~n~?G"));
+<mutable digraph with 9 vertices, 36 edges>
+gap> S := AsSemigroup(IsPartialPermSemigroup, di);;
+gap> IsInverseSemigroup(S) and ForAll(Elements(S), IsIdempotent);
+true
+gap> di = DigraphFromDigraph6String("&H_E?gF_~GH~n~?G");
 true
 gap> di := Digraph([[1], [1, 2], [1, 3], [1, 2, 3, 4]]);;
 gap> S := AsSemigroup(IsPartialPermSemigroup, di);;
@@ -1359,8 +1369,10 @@ gap> G1 := SymmetricGroup(4);;
 gap> G2 := SymmetricGroup(2);;
 gap> G3 := SymmetricGroup(3);;
 gap> G4 := SymmetricGroup(4);;
-gap> gr := Digraph([[1, 3], [2, 3], [3]]);;
-gap> gr2 := Digraph([[1, 3], [2, 3], [3], [1, 2, 3, 4]]);;
+gap> gr := Digraph(IsMutableDigraph, [[1, 3], [2, 3], [3]]);
+<mutable digraph with 3 vertices, 5 edges>
+gap> gr2 := Digraph([[1, 3], [2, 3], [3], [1, 2, 3, 4]]);
+<immutable digraph with 4 vertices, 9 edges>
 gap> sgn := function(x)
 > if SignPerm(x) = 1 then
 > return ();
@@ -1371,6 +1383,8 @@ gap> hom13 := GroupHomomorphismByFunction(G1, G3, sgn);;
 gap> hom23 := GroupHomomorphismByFunction(G2, G3, sgn);;
 gap> T := AsSemigroup(IsPartialPermSemigroup, gr, [G1, G2, G3], [[1, 3, hom13],
 > [2, 3, hom23]]);;
+gap> gr;
+<mutable digraph with 3 vertices, 5 edges>
 gap> Size(T);
 32
 gap> D := GreensDClasses(T);;
@@ -1511,21 +1525,114 @@ the reflexive transitive reduction of the second argument,
 
 # MakeImmutable
 gap> D := NullDigraph(IsMutableDigraph, 10);
-<mutable digraph with 10 vertices, 0 edges>
+<mutable empty digraph with 10 vertices>
 gap> MakeImmutable(D);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
 
 # 
 gap> D := NullDigraph(10);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
 gap> D := Graph(D);
 rec( adjacencies := [ [  ] ], group := Sym( [ 1 .. 10 ] ), isGraph := true, 
   names := [ 1 .. 10 ], order := 10, representatives := [ 1 ], 
   schreierVector := [ -1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ] )
 gap> DigraphCons(IsImmutableDigraph, D);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
 gap> Digraph(IsImmutableDigraph, D);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
+
+# ViewString
+gap> CycleDigraph(3);
+<immutable cycle digraph with 3 vertices>
+gap> ChainDigraph(3);
+<immutable chain digraph with 3 vertices>
+gap> CompleteDigraph(3);
+<immutable complete digraph with 3 vertices>
+gap> CompleteBipartiteDigraph(3, 2);
+<immutable complete bipartite digraph with bicomponent sizes 3 and 2>
+gap> D := Digraph([[1, 2], [2]]);;
+gap> IsLatticeDigraph(D);;
+gap> D;
+<immutable lattice digraph with 2 vertices, 3 edges>
+gap> D := Digraph([[1, 2], [2]]);;
+gap> IsMeetSemilatticeDigraph(D);;
+gap> D;
+<immutable meet semilattice digraph with 2 vertices, 3 edges>
+gap> D := Digraph([[1, 2], [2]]);;
+gap> IsJoinSemilatticeDigraph(D);;
+gap> D;
+<immutable join semilattice digraph with 2 vertices, 3 edges>
+gap> D := Digraph([[2], [3], [1]]);;
+gap> IsStronglyConnectedDigraph(D);;
+gap> D;
+<immutable strongly connected digraph with 3 vertices, 3 edges>
+gap> D := Digraph([[2, 3], [4], [4], []]);;
+gap> IsBiconnectedDigraph(D);;
+gap> D;
+<immutable biconnected digraph with 4 vertices, 4 edges>
+gap> D := Digraph([[2], [3], []]);;
+gap> IsConnectedDigraph(D);;
+gap> D;
+<immutable connected digraph with 3 vertices, 2 edges>
+gap> CompleteMultipartiteDigraph([3, 4, 5]);
+<immutable multipartite symmetric digraph with 12 vertices, 94 edges>
+gap> D := Digraph([[2], [3], []]);;
+gap> IsBipartiteDigraph(D);;
+gap> D;
+<immutable bipartite digraph with bicomponent sizes 2 and 1>
+gap> D := Digraph([[2], [3], [1]]);;
+gap> IsVertexTransitive(D);;
+gap> D;
+<immutable vertex-transitive digraph with 3 vertices, 3 edges>
+gap> IsEdgeTransitive(D);;
+gap> D;
+<immutable edge- and vertex-transitive digraph with 3 vertices, 3 edges>
+gap> D := Digraph([[2], [3], [1]]);;
+gap> IsEdgeTransitive(D);;
+gap> D;
+<immutable edge-transitive digraph with 3 vertices, 3 edges>
+gap> D := Digraph([[2, 3], [1, 3], [1, 2]]);;
+gap> IsOutRegularDigraph(D);;
+gap> D;
+<immutable out-regular digraph with 3 vertices, 6 edges>
+gap> IsInRegularDigraph(D);;
+gap> D;
+<immutable regular digraph with 3 vertices, 6 edges>
+gap> D := Digraph([[2, 3], [1, 3], [1, 2]]);;
+gap> IsInRegularDigraph(D);;
+gap> D;
+<immutable in-regular digraph with 3 vertices, 6 edges>
+gap> D := Digraph([[2], [3], []]);;
+gap> IsAcyclicDigraph(D);;
+gap> D;
+<immutable acyclic digraph with 3 vertices, 2 edges>
+gap> D := Digraph([[1, 2], [2]]);;
+gap> IsPartialOrderDigraph(D);;
+gap> D;
+<immutable partial order digraph with 2 vertices, 3 edges>
+gap> D := Digraph([[1, 2], [2]]);;
+gap> IsPreorderDigraph(D);;
+gap> D;
+<immutable preorder digraph with 2 vertices, 3 edges>
+gap> D := Digraph([[2], [1]]);;
+gap> IsSymmetricDigraph(D);;
+gap> D;
+<immutable symmetric digraph with 2 vertices, 2 edges>
+gap> D := Digraph([[1, 2], [2]]);;
+gap> IsTransitiveDigraph(D);;
+gap> D;
+<immutable transitive digraph with 2 vertices, 3 edges>
+gap> D := Digraph([[2], [1]]);;
+gap> IsEulerianDigraph(D);;
+gap> D;
+<immutable Eulerian digraph with 2 vertices, 2 edges>
+gap> IsHamiltonianDigraph(D);;
+gap> D;
+<immutable Eulerian and Hamiltonian digraph with 2 vertices, 2 edges>
+gap> D := Digraph([[2], [1]]);;
+gap> IsHamiltonianDigraph(D);;
+gap> D;
+<immutable Hamiltonian digraph with 2 vertices, 2 edges>
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(G);

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -15,9 +15,9 @@ gap> DIGRAPHS_StartTest();
 
 #  Display and PrintString and String
 gap> Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> Digraph([[1]]);
 <immutable digraph with 1 vertex, 1 edge>
 gap> Digraph([[2], []]);

--- a/tst/standard/examples.tst
+++ b/tst/standard/examples.tst
@@ -23,41 +23,41 @@ gap> PetersenGraph(IsMutableDigraph);
 
 # GeneralisedPetersenGraph
 gap> D := GeneralisedPetersenGraph(8, 3);
-<immutable digraph with 16 vertices, 48 edges>
+<immutable symmetric digraph with 16 vertices, 48 edges>
 gap> IsBipartiteDigraph(D);
 true
 gap> D := GeneralisedPetersenGraph(15, 7);
-<immutable digraph with 30 vertices, 90 edges>
+<immutable symmetric digraph with 30 vertices, 90 edges>
 gap> IsBipartiteDigraph(D);
 false
 gap> D := GeneralisedPetersenGraph(10, 2);
-<immutable digraph with 20 vertices, 60 edges>
+<immutable symmetric digraph with 20 vertices, 60 edges>
 gap> IsVertexTransitive(D);
 true
 gap> D := GeneralisedPetersenGraph(11, 2);
-<immutable digraph with 22 vertices, 66 edges>
+<immutable symmetric digraph with 22 vertices, 66 edges>
 gap> IsVertexTransitive(D);
 false
 gap> D := GeneralisedPetersenGraph(5, 2);
-<immutable digraph with 10 vertices, 30 edges>
+<immutable symmetric digraph with 10 vertices, 30 edges>
 gap> IsIsomorphicDigraph(D, PetersenGraph());
 true
 gap> G8_3 := DigraphFromGraph6String("OCQa`Q?OH?a@A@@?_OGB@");
 <immutable digraph with 16 vertices, 48 edges>
 gap> D := GeneralisedPetersenGraph(8, 3);
-<immutable digraph with 16 vertices, 48 edges>
+<immutable symmetric digraph with 16 vertices, 48 edges>
 gap> IsIsomorphicDigraph(D, G8_3);
 true
 
 #  CompleteDigraph
 gap> gr := CompleteDigraph(5);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> AutomorphismGroup(gr) = SymmetricGroup(5);
 true
 gap> CompleteDigraph(1) = EmptyDigraph(1);
 true
 gap> CompleteDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> CompleteDigraph(-1);
 Error, the argument <n> must be a non-negative integer,
 gap> CompleteDigraph(IsMutableDigraph, 10);
@@ -65,11 +65,11 @@ gap> CompleteDigraph(IsMutableDigraph, 10);
 
 #  EmptyDigraph
 gap> gr := EmptyDigraph(5);
-<immutable digraph with 5 vertices, 0 edges>
+<immutable empty digraph with 5 vertices>
 gap> AutomorphismGroup(gr) = SymmetricGroup(5);
 true
 gap> EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> EmptyDigraph(-1);
 Error, the argument <n> must be a non-negative integer,
 gap> EmptyDigraph(IsMutableDigraph, -1);
@@ -89,7 +89,7 @@ true
 gap> DigraphEdges(gr);
 [ [ 1, 2 ], [ 2, 3 ], [ 3, 4 ], [ 4, 5 ], [ 5, 6 ], [ 6, 1 ] ]
 gap> gr := CycleDigraph(1000);
-<immutable digraph with 1000 vertices, 1000 edges>
+<immutable cycle digraph with 1000 vertices>
 gap> gr := CycleDigraph(IsMutableDigraph, 6);
 <mutable digraph with 6 vertices, 6 edges>
 
@@ -98,13 +98,13 @@ gap> gr := ChainDigraph(0);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `ChainDigraph' on 1 arguments
 gap> gr := ChainDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsEmptyDigraph(gr);
 true
 gap> gr = EmptyDigraph(1);
 true
 gap> gr := ChainDigraph(2);
-<immutable digraph with 2 vertices, 1 edge>
+<immutable chain digraph with 2 vertices>
 gap> AutomorphismGroup(gr) = Group(());
 true
 gap> HasIsTransitiveDigraph(gr);
@@ -112,17 +112,19 @@ true
 gap> IsTransitiveDigraph(gr);
 true
 gap> gr := ChainDigraph(10);
-<immutable digraph with 10 vertices, 9 edges>
+<immutable chain digraph with 10 vertices>
 gap> OutNeighbours(gr);
 [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 6 ], [ 7 ], [ 8 ], [ 9 ], [ 10 ], [  ] ]
 gap> AutomorphismGroup(gr) = Group(());
 true
 gap> grrt := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 10 vertices, 55 edges>
+<immutable preorder digraph with 10 vertices, 55 edges>
 gap> IsPartialOrderBinaryRelation(AsBinaryRelation(grrt));
 true
 gap> IsAntisymmetricDigraph(grrt);
 true
+gap> grrt;
+<immutable partial order digraph with 10 vertices, 55 edges>
 gap> ChainDigraph(IsMutableDigraph, 10);
 <mutable digraph with 10 vertices, 9 edges>
 
@@ -136,7 +138,7 @@ Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `CompleteBipartiteDigraph' on 2 argument\
 s
 gap> gr := CompleteBipartiteDigraph(4, 3);
-<immutable digraph with 7 vertices, 24 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 3>
 gap> AutomorphismGroup(gr) = Group((1, 2, 3, 4), (1, 2), (5, 6, 7), (5, 6));
 true
 gap> DigraphEdges(gr);
@@ -145,20 +147,20 @@ gap> DigraphEdges(gr);
   [ 5, 3 ], [ 5, 4 ], [ 6, 1 ], [ 6, 2 ], [ 6, 3 ], [ 6, 4 ], [ 7, 1 ], 
   [ 7, 2 ], [ 7, 3 ], [ 7, 4 ] ]
 gap> gr := CompleteBipartiteDigraph(4, 4);
-<immutable digraph with 8 vertices, 32 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 4>
 gap> AutomorphismGroup(gr) = Group((1, 2, 3, 4), (1, 2), (5, 6, 7, 8), (5, 6),
 >                                  (1, 5)(2, 6)(3, 7)(4, 8));
 true
 
 #  CompleteMultipartiteDigraph
 gap> CompleteMultipartiteDigraph([5, 4, 2]);
-<immutable digraph with 11 vertices, 76 edges>
+<immutable multipartite symmetric digraph with 11 vertices, 76 edges>
 gap> CompleteMultipartiteDigraph([5, 4, 2, 10, 1000]);
-<immutable digraph with 1021 vertices, 42296 edges>
+<immutable multipartite symmetric digraph with 1021 vertices, 42296 edges>
 gap> CompleteMultipartiteDigraph([5]);
-<immutable digraph with 5 vertices, 0 edges>
+<immutable empty digraph with 5 vertices>
 gap> CompleteMultipartiteDigraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> CompleteMultipartiteDigraph([5, 4, 2, 10, -5]);
 Error, the argument <list> must be a list of positive integers,
 gap> CompleteMultipartiteDigraph([5, 0, 2]);
@@ -199,19 +201,19 @@ gap> DigraphEdges(CompleteMultipartiteDigraph([7, 8, 2]));
 
 #  JohnsonDigraph
 gap> JohnsonDigraph(0, 4);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> JohnsonDigraph(0, 0);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> JohnsonDigraph(3, 0);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> JohnsonDigraph(1, 0);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> gr := JohnsonDigraph(3, 1);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable symmetric digraph with 3 vertices, 6 edges>
 gap> OutNeighbours(gr);
 [ [ 2, 3 ], [ 1, 3 ], [ 1, 2 ] ]
 gap> gr := JohnsonDigraph(4, 2);
-<immutable digraph with 6 vertices, 24 edges>
+<immutable symmetric digraph with 6 vertices, 24 edges>
 gap> OutNeighbours(gr);
 [ [ 2, 3, 4, 5 ], [ 1, 3, 4, 6 ], [ 1, 2, 5, 6 ], [ 1, 2, 5, 6 ], 
   [ 1, 3, 4, 6 ], [ 2, 3, 4, 5 ] ]

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -151,7 +151,7 @@ gap> HomomorphismDigraphsFinder(gr1, gr1, fail, [], 1, 2, 0, [1, 2],
 > [], [1, fail], [2, 1]);
 Error, the 2nd argument <partition> must be a homogeneous list,
 gap> gr := ChainDigraph(2);
-<immutable digraph with 2 vertices, 1 edge>
+<immutable chain digraph with 2 vertices>
 gap> GeneratorsOfEndomorphismMonoid();
 Error, at least 1 argument expected, found 0,
 gap> GeneratorsOfEndomorphismMonoid(Group(()));
@@ -159,14 +159,14 @@ Error, the 1st argument must be a digraph,
 gap> GeneratorsOfEndomorphismMonoid(gr);
 [ IdentityTransformation ]
 gap> gr := DigraphTransitiveClosure(CompleteDigraph(2));
-<immutable digraph with 2 vertices, 4 edges>
+<immutable transitive digraph with 2 vertices, 4 edges>
 gap> DigraphHasLoops(gr);
 true
 gap> GeneratorsOfEndomorphismMonoid(gr);
 [ Transformation( [ 2, 1 ] ), IdentityTransformation, 
   Transformation( [ 1, 1 ] ) ]
 gap> gr := EmptyDigraph(2);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> GeneratorsOfEndomorphismMonoid(gr, Group(()), Group((1, 2)));
 Error, the 2nd argument must be a homogenous list,
 gap> gr := EmptyDigraph(2);;
@@ -230,7 +230,7 @@ gap> gr := Digraph([[2, 2], []]);
 gap> DigraphColouring(gr, 1);
 fail
 gap> gr := EmptyDigraph(3);
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> DigraphColouring(gr, 4);
 fail
 gap> DigraphColouring(gr, 3);
@@ -240,7 +240,7 @@ Transformation( [ 1, 1, 2 ] )
 gap> DigraphColouring(gr, 1);
 Transformation( [ 1, 1, 1 ] )
 gap> gr := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> DigraphColouring(gr, 1);
 fail
 gap> DigraphColouring(gr, 2);
@@ -248,7 +248,7 @@ fail
 gap> DigraphColouring(gr, 3);
 IdentityTransformation
 gap> gr := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphColouring(gr, 1);
 fail
 gap> DigraphColouring(gr, 2);
@@ -256,7 +256,7 @@ fail
 gap> DigraphColouring(gr, 3);
 fail
 gap> gr := EmptyDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphColouring(gr, 1);
 IdentityTransformation
 gap> DigraphColouring(gr, 2);
@@ -804,7 +804,7 @@ gap> Length(last);
 gap> gr := Digraph([[2, 3], [], [], [5], [], []]);
 <immutable digraph with 6 vertices, 3 edges>
 gap> gr := DigraphSymmetricClosure(gr);
-<immutable digraph with 6 vertices, 6 edges>
+<immutable symmetric digraph with 6 vertices, 6 edges>
 gap> HomomorphismDigraphsFinder(gr, gr, fail, [], infinity, fail, 0,
 > [1 .. 6], [], fail, fail);
 [ IdentityTransformation, Transformation( [ 1, 2, 3, 4, 5, 1 ] ), 
@@ -1068,7 +1068,7 @@ gap> IsDigraphHomomorphism(gr, gr, ());
 Error, the 1st and 2nd arguments <src> and <ran> must be digraphs with no mult\
 iple edges,
 gap> gr := DigraphTransitiveClosure(CompleteDigraph(2));
-<immutable digraph with 2 vertices, 4 edges>
+<immutable transitive digraph with 2 vertices, 4 edges>
 gap> ForAll(GeneratorsOfEndomorphismMonoid(gr),
 >           x -> IsDigraphEndomorphism(gr, x));
 true
@@ -1213,7 +1213,7 @@ false
 
 # IsDigraphColouring
 gap> D := JohnsonDigraph(5, 3);
-<immutable digraph with 10 vertices, 60 edges>
+<immutable symmetric digraph with 10 vertices, 60 edges>
 gap> IsDigraphColouring(D, [1, 2, 3, 3, 2, 1, 4, 5, 6, 7]);
 true
 gap> IsDigraphColouring(D, [1, 2, 3, 3, 2, 1, 2, 5, 6, 7]);

--- a/tst/standard/grape.tst
+++ b/tst/standard/grape.tst
@@ -40,11 +40,11 @@ Error, the 1st argument <G> must be a finite group,
 
 #  DigraphAddEdgeOrbit
 gap> digraph := NullDigraph(4);
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> HasDigraphGroup(digraph);
 true
 gap> digraph := DigraphCopy(digraph);
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> HasDigraphGroup(digraph);
 false
 gap> SetDigraphGroup(digraph, Group((1, 3), (1, 2)(3, 4)));
@@ -59,7 +59,7 @@ true
 
 #  DigraphRemoveEdgeOrbit
 gap> digraph := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> HasDigraphGroup(digraph);
 true
 gap> digraph := DigraphCopy(digraph);
@@ -136,7 +136,7 @@ true
 gap> HasDigraphGroup(DigraphCopy(digraph));
 false
 gap> digraph := EdgeOrbitsDigraph(Group(()), [3, 2]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> OutNeighbours(digraph);
 [  ]
 gap> HasDigraphGroup(digraph);
@@ -173,7 +173,7 @@ gap> gr3 := DigraphRemoveEdgeOrbit(gr1, [1, 3]);
 gap> gr3 := DigraphRemoveEdgeOrbit(gr3, [1, 2]);
 <immutable digraph with 8 vertices, 8 edges>
 gap> gr3 := DigraphRemoveEdgeOrbit(gr3, [1, 4]);
-<immutable digraph with 8 vertices, 0 edges>
+<immutable empty digraph with 8 vertices>
 gap> DigraphAddEdgeOrbit(gr1, [0, 3]);
 Error, the 2nd argument <edge> must be a list of 2 positive integers,
 gap> DigraphAddEdgeOrbit(gr1, [1, 2, 3]);

--- a/tst/standard/io.tst
+++ b/tst/standard/io.tst
@@ -15,11 +15,11 @@ gap> DIGRAPHS_StartTest();
 
 #  DigraphFromGraph6String and Graph6String
 gap> DigraphFromGraph6String("?");
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphFromGraph6String("E?A?");
 <immutable digraph with 6 vertices, 2 edges>
 gap> DigraphFromGraph6String("@");
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> gr := Digraph(300, [1, 2], [2, 1]);
 <immutable digraph with 300 vertices, 2 edges>
 gap> str := Graph6String(gr);;
@@ -80,7 +80,7 @@ Error, cannot open the file given as the 1st argument <name>,
 
 #  DigraphFromSparse6String and Sparse6String
 gap> DigraphFromSparse6String(":@");
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphFromSparse6String(Concatenation(":[___dCfEcdFjCIideLhIfJ",
 >                                           "kLgkQge`RSbPTaOTbMNaS`QY"));
 <immutable digraph with 28 vertices, 84 edges>
@@ -190,7 +190,7 @@ IO_OK
 gap> ReadDigraphs(filename);
 [ <immutable digraph with 5 vertices, 7 edges>, 
   <immutable digraph with 105 vertices, 100 edges>, 
-  <immutable digraph with 0 vertices, 0 edges>, 
+  <immutable empty digraph with 0 vertices>, 
   <immutable digraph with 10 vertices, 47 edges> ]
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.txt");;
 gap> WriteDigraphs(filename,
@@ -212,7 +212,7 @@ IO_OK
 gap> ReadDigraphs(filename);
 [ <immutable digraph with 5 vertices, 7 edges>, 
   <immutable digraph with 105 vertices, 100 edges>, 
-  <immutable digraph with 0 vertices, 0 edges>, 
+  <immutable empty digraph with 0 vertices>, 
   <immutable digraph with 10 vertices, 47 edges> ]
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.txt");;
 gap> WriteDigraphs(filename, gr, "w");
@@ -225,7 +225,7 @@ gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/test.txt");;
 gap> ReadDigraphs(filename);
 [ <immutable digraph with 5 vertices, 7 edges>, 
   <immutable digraph with 100 vertices, 100 edges>, 
-  <immutable digraph with 0 vertices, 0 edges>, 
+  <immutable empty digraph with 0 vertices>, 
   <immutable digraph with 10 vertices, 47 edges> ]
 gap> gr := [CompleteDigraph(30)];;
 gap> DigraphGroup(gr[1]) = SymmetricGroup(30);
@@ -278,7 +278,7 @@ gap> WriteDigraphs(f, List([1 .. 5], CompleteDigraph));
 IO_OK
 gap> f := DigraphFile(filename, "r");;
 gap> ReadDigraphs(f);
-[ <immutable digraph with 1 vertex, 0 edges>, 
+[ <immutable empty digraph with 1 vertex>, 
   <immutable digraph with 2 vertices, 2 edges>, 
   <immutable digraph with 3 vertices, 6 edges>, 
   <immutable digraph with 4 vertices, 12 edges>, 
@@ -291,7 +291,7 @@ gap> WriteDigraphs(f, JohnsonDigraph(6, 3));
 IO_OK
 gap> f := DigraphFile(filename, "r");;
 gap> ReadDigraphs(f);
-[ <immutable digraph with 1 vertex, 0 edges>, 
+[ <immutable empty digraph with 1 vertex>, 
   <immutable digraph with 2 vertices, 2 edges>, 
   <immutable digraph with 3 vertices, 6 edges>, 
   <immutable digraph with 4 vertices, 12 edges>, 
@@ -305,13 +305,13 @@ gap> ReadDigraphs(f);
 gap> it := IteratorFromDigraphFile(newfilename);
 <iterator>
 gap> NextIterator(it);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> NextIterator(it);
 <immutable digraph with 2 vertices, 2 edges>
 gap> it := IteratorFromDigraphFile(newfilename, DigraphFromGraph6String);
 <iterator>
 gap> NextIterator(it);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsDoneIterator(it);
 false
 gap> NextIterator(it);
@@ -333,7 +333,7 @@ true
 gap> it := ShallowCopy(it);
 <iterator>
 gap> NextIterator(it);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IteratorFromDigraphFile(1, 2, 3);
 Error, there must be 1 or 2 arguments,
 gap> IteratorFromDigraphFile(1, 2);
@@ -394,7 +394,7 @@ gap> gr := TournamentLineDecoder("101001");
 gap> OutNeighbours(gr);
 [ [ 2, 4 ], [  ], [ 1, 2, 4 ], [ 2 ] ]
 gap> gr := TournamentLineDecoder("");
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 
 #  AdjacencyMatrixUpperTriangleLineDecoder
 gap> gr := AdjacencyMatrixUpperTriangleLineDecoder("100101");
@@ -406,7 +406,7 @@ gap> gr := AdjacencyMatrixUpperTriangleLineDecoder("11y111x111");
 gap> OutNeighbours(gr);
 [ [ 2, 3, 5 ], [ 3, 4 ], [ 4, 5 ], [ 5 ], [  ] ]
 gap> gr := AdjacencyMatrixUpperTriangleLineDecoder("");
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 
 #  TCodeDecoder
 gap> gr := TCodeDecoder("3 2 0 2 2 1");
@@ -451,20 +451,20 @@ Error, the 2nd argument <s> is not a valid disparse6 string,
 gap> DigraphFromDiSparse6String(".~~");
 Error, the 2nd argument <s> is not a valid disparse6 string,
 gap> DigraphFromDiSparse6String(".~~??@???o??N");
-<immutable digraph with 262144 vertices, 0 edges>
+<immutable empty digraph with 262144 vertices>
 gap> DigraphFromDiSparse6String(".~??");
 Error, the 2nd argument <s> is not a valid disparse6 string,
 gap> DiSparse6String(CompleteDigraph(1));
 ".@~"
 gap> DigraphFromDiSparse6String(".@~");
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> gr := Digraph([[], [], [1, 2]]);;
 gap> DiSparse6String(gr);
 ".BoN"
 
 #  Plain text encoding  
 gap> gr := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> str := PlainTextString(gr);
 "0 1  0 2  1 0  1 2  2 0  2 1"
 gap> gr2 := DigraphFromPlainTextString(str);
@@ -622,7 +622,7 @@ Error, the 2nd argument <digraphs> must be a digraph or list of digraphs,
 gap> Sparse6String(EmptyDigraph(2 ^ 20));
 ":~~??C???"
 gap> DigraphFromSparse6String(":~~??C???");
-<immutable digraph with 1048576 vertices, 0 edges>
+<immutable empty digraph with 1048576 vertices>
 
 #  WriteDIMACSFile
 # Error testing
@@ -643,7 +643,7 @@ gap> WriteDIMACSDigraph(filename, gr);
 Error, cannot open the file given as the 1st argument <name>,
 gap> filename := "tmp.gz";;
 gap> D := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> SetDigraphVertexLabels(D, ["a", "b", "c"]);
 gap> WriteDIMACSDigraph(filename, CompleteDigraph(3));
 IO_OK
@@ -652,7 +652,7 @@ gap> Exec("rm -f tmp.gz");
 # Handling loops
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/loops.dimacs");;
 gap> gr := EmptyDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphHasLoops(gr);
 false
 gap> HasDigraphHasLoops(gr);
@@ -871,7 +871,7 @@ Error, the argument <filename> must be a string,
 gap> filename := Concatenation(DIGRAPHS_Dir(), "/tst/out/good.dimacs");;
 gap> file := IO_File(filename, "r");;
 gap> gr := CompleteDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable complete digraph with 2 vertices>
 gap> DigraphGroup(gr);
 Sym( [ 1 .. 2 ] )
 gap> IO_Pickle(file, gr);

--- a/tst/standard/isomorph.tst
+++ b/tst/standard/isomorph.tst
@@ -18,7 +18,7 @@ gap> DIGRAPHS_StartTest();
 # Complete digraph on n vertices should have automorphism group S_n
 gap> n := 5;;
 gap> gr := CompleteDigraph(n);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> AutomorphismGroup(gr) = SymmetricGroup(n);
 true
 gap> not DIGRAPHS_NautyAvailable or
@@ -28,7 +28,7 @@ true
 # Empty digraph on n vertices should have automorphism group S_n
 gap> n := 10;;
 gap> gr := EmptyDigraph(n);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
 gap> AutomorphismGroup(gr) = SymmetricGroup(n);
 true
 gap> not DIGRAPHS_NautyAvailable or
@@ -38,7 +38,7 @@ true
 # Chain digraph on n vertices should have trivial automorphism group
 gap> n := 5;;
 gap> gr := ChainDigraph(n);
-<immutable digraph with 5 vertices, 4 edges>
+<immutable chain digraph with 5 vertices>
 gap> IsTrivial(AutomorphismGroup(gr));
 true
 gap> not DIGRAPHS_NautyAvailable or IsTrivial(NautyAutomorphismGroup(gr));
@@ -53,7 +53,7 @@ true
 # Cycle digraph on n vertices should have cyclic automorphism group C_n
 gap> n := 5;;
 gap> gr := CycleDigraph(n);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> IsCyclic(AutomorphismGroup(gr));
 true
 gap> Size(AutomorphismGroup(gr)) = n;
@@ -66,7 +66,7 @@ true
 # shoud have automorphism group S_m x S_n
 gap> m := 5;; n := 4;;
 gap> gr := CompleteBipartiteDigraph(m, n);
-<immutable digraph with 9 vertices, 40 edges>
+<immutable complete bipartite digraph with bicomponent sizes 5 and 4>
 gap> G := AutomorphismGroup(gr);;
 gap> G = DirectProduct(SymmetricGroup(m), SymmetricGroup(n));
 true
@@ -237,7 +237,7 @@ true
 gap> gr1 := Digraph([[2, 2], [1]]);
 <immutable multidigraph with 2 vertices, 3 edges>
 gap> gr2 := CompleteDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable complete digraph with 2 vertices>
 gap> IsIsomorphicDigraph(gr1, gr2, [1, 1], [1, 1]);
 false
 gap> IsIsomorphicDigraph(gr2, gr1, [1, 1], [1, 1]);
@@ -274,7 +274,7 @@ er m <= 2,
 gap> IsIsomorphicDigraph(gr2, gr2, [1, 2], [2, 1]);
 true
 gap> gr1 := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> gr2 := DigraphDisjointUnion(CycleDigraph(2), CycleDigraph(2));
 <immutable digraph with 4 vertices, 4 edges>
 gap> IsIsomorphicDigraph(gr1, gr2, [1, 1, 1, 1], [1, 1, 1, 1]);
@@ -297,9 +297,9 @@ false
 # IsomorphismDigraphs: for digraphs without multiple edges
 # Non-isomorphic graphs
 gap> gr1 := EmptyDigraph(3);
-<immutable digraph with 3 vertices, 0 edges>
+<immutable empty digraph with 3 vertices>
 gap> gr2 := ChainDigraph(3);
-<immutable digraph with 3 vertices, 2 edges>
+<immutable chain digraph with 3 vertices>
 gap> IsomorphismDigraphs(gr1, gr2);
 fail
 gap> IsomorphismDigraphs(gr2, gr1);
@@ -399,7 +399,7 @@ true
 gap> gr1 := Digraph([[2, 2], [1]]);
 <immutable multidigraph with 2 vertices, 3 edges>
 gap> gr2 := CompleteDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable complete digraph with 2 vertices>
 gap> IsomorphismDigraphs(gr1, gr2, [1, 1], [1, 1]);
 fail
 gap> IsomorphismDigraphs(gr2, gr1, [1, 1], [1, 1]);
@@ -432,7 +432,7 @@ gap> IsomorphismDigraphs(gr2, gr2, [1, 1], [[1, 2]]);
 gap> IsomorphismDigraphs(gr2, gr2, [1, 2], [2, 1]);
 (1,2)
 gap> gr1 := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> gr2 := DigraphDisjointUnion(CycleDigraph(2), CycleDigraph(2));
 <immutable digraph with 4 vertices, 4 edges>
 gap> IsomorphismDigraphs(gr1, gr2, [1, 1, 1, 1], [1, 1, 1, 1]);
@@ -540,7 +540,7 @@ true
 
 #  AutomorphismGroup: for a digraph with colored vertices
 gap> gr := CompleteBipartiteDigraph(4, 4);
-<immutable digraph with 8 vertices, 32 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 4>
 gap> AutomorphismGroup(gr) = Group([
 > (7, 8), (6, 7), (5, 6), (3, 4), (2, 3), (1, 2), (1, 5)(2, 6)(3, 7)(4, 8)]);
 true
@@ -551,7 +551,7 @@ Group(())
 
 #  AutomorphismGroup: for a digraph with incorrect colors
 gap> gr := CompleteBipartiteDigraph(4, 4);
-<immutable digraph with 8 vertices, 32 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 4>
 gap> AutomorphismGroup(gr, [[1 .. 4], [5 .. 9]]);
 Error, the 2nd argument <partition> does not define a colouring of the vertice\
 s [1 .. 8], since the entry in position 2 contains 
@@ -587,7 +587,7 @@ fail
 
 #  CanonicalLabelling: for a digraph with colored vertices
 gap> gr := CompleteBipartiteDigraph(4, 4);
-<immutable digraph with 8 vertices, 32 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 4>
 gap> BlissCanonicalLabelling(gr);
 (1,8)(2,7)(3,6)(4,5)
 gap> not DIGRAPHS_NautyAvailable
@@ -606,7 +606,7 @@ true
 
 #  CanonicalLabelling: for a digraph with incorrect colors
 gap> gr := CompleteBipartiteDigraph(4, 4);
-<immutable digraph with 8 vertices, 32 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 4>
 gap> BlissCanonicalLabelling(gr, [[1 .. 4], [5 .. 9]]);
 Error, the 2nd argument <partition> does not define a colouring of the vertice\
 s [1 .. 8], since the entry in position 2 contains 

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -291,25 +291,24 @@ gap> gr := CompleteDigraph(2);
 gap> DigraphEdges(gr);
 [ [ 1, 2 ], [ 2, 1 ] ]
 gap> qr := QuotientDigraph(gr, [[1, 2]]);
-<immutable multidigraph with 1 vertex, 2 edges>
+<immutable digraph with 1 vertex, 1 edge>
 gap> DigraphEdges(qr);
-[ [ 1, 1 ], [ 1, 1 ] ]
+[ [ 1, 1 ] ]
 gap> QuotientDigraph(EmptyDigraph(0), []);
 <immutable digraph with 0 vertices, 0 edges>
 gap> QuotientDigraph(EmptyDigraph(0), [[1]]);
-Error, the 2nd argument <partition> is not a valid partition of the vertices o\
-f 1st argument <D>.The only valid partition of a null digraph is the empty lis\
-t,
+Error, the 2nd argument <partition> should be an empty list, which is the only\
+ valid partition of the vertices of 1st argument <D> because it has no vertice\
+s,
 gap> gr := Digraph([[1, 2, 3, 2], [1, 3, 2], [1, 2]]);
 <immutable multidigraph with 3 vertices, 9 edges>
 gap> DigraphEdges(gr);
 [ [ 1, 1 ], [ 1, 2 ], [ 1, 3 ], [ 1, 2 ], [ 2, 1 ], [ 2, 3 ], [ 2, 2 ], 
   [ 3, 1 ], [ 3, 2 ] ]
 gap> qr := QuotientDigraph(gr, [[1, 3], [2]]);
-<immutable multidigraph with 2 vertices, 9 edges>
+<immutable digraph with 2 vertices, 4 edges>
 gap> DigraphEdges(qr);
-[ [ 1, 1 ], [ 1, 2 ], [ 1, 1 ], [ 1, 2 ], [ 1, 1 ], [ 1, 2 ], [ 2, 1 ], 
-  [ 2, 1 ], [ 2, 2 ] ]
+[ [ 1, 1 ], [ 1, 2 ], [ 2, 1 ], [ 2, 2 ] ]
 gap> QuotientDigraph(gr, [3]);
 Error, the 2nd argument <partition> is not a valid partition of the vertices [\
 1 .. 3] of the 1st argument <D>,
@@ -340,9 +339,9 @@ gap> gr := Digraph(rec(
 > DigraphRange := [6, 7, 1, 6, 5, 1, 4, 8, 1, 3, 4, 6, 7, 7, 1, 4, 5, 6, 7, 5, 6]));
 <immutable digraph with 8 vertices, 21 edges>
 gap> qr := QuotientDigraph(gr, [[1], [2, 3, 5, 7], [4, 6, 8]]);
-<immutable multidigraph with 3 vertices, 21 edges>
+<immutable digraph with 3 vertices, 8 edges>
 gap> OutNeighbours(qr);
-[ [ 3, 2 ], [ 1, 3, 2, 1, 2, 3, 3, 2, 1, 3, 2, 3, 2 ], [ 1, 3, 3, 2, 2, 3 ] ]
+[ [ 2, 3 ], [ 1, 2, 3 ], [ 1, 2, 3 ] ]
 
 #  DigraphInEdges and DigraphOutEdges: for a vertex
 gap> gr := Digraph([[2, 2, 2, 2, 2], [1, 1, 1, 1], [1], [3, 2]]);
@@ -695,13 +694,17 @@ gap> gr2 := DigraphRemoveVertices(gr, []);
 gap> gr = gr2;
 true
 gap> gr2 := DigraphRemoveVertices(gr, [0]);
-Error, the 2nd argument <list> must be a list consisting of positive integers,
+Error, the 2nd argument <list> must be a duplicate-free list of positive integ\
+ers,
 gap> gr2 := DigraphRemoveVertices(gr, [1, "a"]);
-Error, the 2nd argument <list> must be a list consisting of positive integers,
+Error, the 2nd argument <list> must be a duplicate-free list of positive integ\
+ers,
 gap> gr2 := DigraphRemoveVertices(gr, [1, 1]);
-Error, the 2nd argument <list> must be a duplicate-free list,
+Error, the 2nd argument <list> must be a duplicate-free list of positive integ\
+ers,
 gap> gr2 := DigraphRemoveVertices(gr, [1, 0]);
-Error, the 2nd argument <list> must be a list consisting of positive integers,
+Error, the 2nd argument <list> must be a duplicate-free list of positive integ\
+ers,
 gap> gr2 := DigraphRemoveVertices(gr, [1, 5]);
 <immutable digraph with 3 vertices, 6 edges>
 gap> gr2 := DigraphRemoveVertices(gr, [1, 3]);
@@ -1849,18 +1852,16 @@ gap> D;
 gap> D := DigraphMutableCopy(CompleteDigraph(10));
 <mutable digraph with 10 vertices, 90 edges>
 gap> DD := QuotientDigraph(D, [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10]]);
-<mutable multidigraph with 4 vertices, 90 edges>
+<mutable digraph with 4 vertices, 15 edges>
 gap> InNeighboursOfVertexNC(DD, 1);
-[ 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 
-  4, 4 ]
+[ 1, 2, 3, 4 ]
 gap> MakeImmutable(DD);
-<immutable multidigraph with 4 vertices, 90 edges>
+<immutable digraph with 4 vertices, 15 edges>
 gap> InNeighbours(DD);;
 gap> InNeighboursOfVertexNC(DD, 1);
-[ 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 
-  4, 4 ]
+[ 1, 2, 3, 4 ]
 gap> InDegreeOfVertexNC(DD, 1);
-27
+4
 gap> DigraphShortestPath(DD, 1, 5);
 Error, the 2nd and 3rd arguments <u> and <v> must be vertices of the 1st argum\
 ent <D>,

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -864,14 +864,14 @@ gap> gr2 := CompleteDigraph(100);
 gap> DigraphDisjointUnion(gr) = gr;
 true
 gap> DigraphDisjointUnion([[]]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphDisjointUnion([gr], [gr]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphDisjointUnion(gr, Group(()));
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphDisjointUnion(gr, gr);
 <immutable digraph with 2000 vertices, 2000 edges>
 gap> DigraphDisjointUnion([gr2, gr2]);
@@ -914,14 +914,14 @@ gap> gr2 := DigraphFromDiSparse6String(".H`OS?aEMC?bneOY`l_?QCJ");
 gap> DigraphEdgeUnion(gr1) = gr1;
 true
 gap> DigraphEdgeUnion([[]]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphEdgeUnion([gr1], [gr1]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphEdgeUnion(gr1, Group(()));
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> m1 := DigraphEdgeUnion(gr1, gr2);
 <immutable multidigraph with 10 vertices, 29 edges>
 gap> m2 := DigraphEdgeUnion(gr2, gr1);
@@ -961,14 +961,14 @@ gap> gr2 := EmptyDigraph(10);
 gap> DigraphJoin(gr) = gr;
 true
 gap> DigraphJoin([[]]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphJoin([gr], [gr]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphJoin([gr, Group(())]);
-Error, the arguments must be dense digraphs, or a single list of dense digraph\
-s,
+Error, the arguments must be digraphs by out-neighbours, or a single list of d\
+igraphs by out-neighbours,
 gap> DigraphJoin(gr, gr2);
 <immutable digraph with 30 vertices, 780 edges>
 gap> DigraphJoin(gr, EmptyDigraph(0));

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -40,7 +40,7 @@ gap> DigraphRemoveEdges(gr, [[2, 1]]);
 gap> last = gr;
 true
 gap> DigraphRemoveEdges(gr, [[1, 2]]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> gr := DigraphFromDigraph6String("&DtGsw_");
 <immutable digraph with 5 vertices, 12 edges>
 gap> Set(DigraphEdges(gr)) = Set(
@@ -151,7 +151,7 @@ gap> OutNeighbours(gr);
 
 #  OnMultiDigraphs: for a pair of permutations
 gap> gr1 := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> DigraphEdges(gr1);
 [ [ 1, 2 ], [ 1, 3 ], [ 2, 1 ], [ 2, 3 ], [ 3, 1 ], [ 3, 2 ] ]
 gap> gr2 := OnMultiDigraphs(gr1, (1, 3), (3, 6));;
@@ -233,11 +233,11 @@ gap> InducedSubdigraph(gr, [1 .. 9]);
 Error, the 2nd argument <list> must be a duplicate-free subset of the vertices\
  of the digraph <D> that is the 1st argument,
 gap> InducedSubdigraph(gr, []);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> InducedSubdigraph(gr, [2 .. 6]);
 <immutable multidigraph with 5 vertices, 7 edges>
 gap> InducedSubdigraph(gr, [8]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> i1 := InducedSubdigraph(gr, [1, 4, 3]);
 <immutable multidigraph with 3 vertices, 6 edges>
 gap> OutNeighbours(i1);
@@ -259,7 +259,7 @@ gap> InducedSubdigraph(gr, [2 .. 9]);
 Error, the 2nd argument <list> must be a duplicate-free subset of the vertices\
  of the digraph <D> that is the 1st argument,
 gap> InducedSubdigraph(gr, []);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> i1 := InducedSubdigraph(gr, [1, 3, 5, 7]);
 <immutable digraph with 4 vertices, 8 edges>
 gap> OutNeighbours(i1);
@@ -273,9 +273,9 @@ true
 gap> InducedSubdigraph(gr, [2 .. 8]);
 <immutable multidigraph with 7 vertices, 15 edges>
 gap> InducedSubdigraph(gr, [8]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> InducedSubdigraph(gr, [7, 8]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> gr := Digraph([[2, 4], [4, 5], [2, 5, 5], [5, 5], [3]]);
 <immutable multidigraph with 5 vertices, 10 edges>
 gap> gri := InducedSubdigraph(gr, [4, 2, 5]);
@@ -287,7 +287,7 @@ gap> OutNeighbours(gri);
 
 #  QuotientDigraph
 gap> gr := CompleteDigraph(2);
-<immutable digraph with 2 vertices, 2 edges>
+<immutable complete digraph with 2 vertices>
 gap> DigraphEdges(gr);
 [ [ 1, 2 ], [ 2, 1 ] ]
 gap> qr := QuotientDigraph(gr, [[1, 2]]);
@@ -295,7 +295,7 @@ gap> qr := QuotientDigraph(gr, [[1, 2]]);
 gap> DigraphEdges(qr);
 [ [ 1, 1 ] ]
 gap> QuotientDigraph(EmptyDigraph(0), []);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> QuotientDigraph(EmptyDigraph(0), [[1]]);
 Error, the 2nd argument <partition> should be an empty list, which is the only\
  valid partition of the vertices of 1st argument <D> because it has no vertice\
@@ -388,7 +388,7 @@ Error, the 2nd argument <v> is not a vertex of the 1st argument <D>,
 
 # CycleDigraph with source/range
 gap> gr := CycleDigraph(1000);
-<immutable digraph with 1000 vertices, 1000 edges>
+<immutable cycle digraph with 1000 vertices>
 gap> IsDigraphEdge(gr, [1]);
 false
 gap> IsDigraphEdge(gr, ["a", 2]);
@@ -436,7 +436,7 @@ false
 
 # A bigger digraph with OutNeighbours
 gap> gr := CompleteDigraph(500);
-<immutable digraph with 500 vertices, 249500 edges>
+<immutable complete digraph with 500 vertices>
 gap> IsDigraphEdge(gr, [200, 199]);
 true
 gap> IsDigraphEdge(gr, [499, 499]);
@@ -444,11 +444,11 @@ false
 gap> IsDigraphEdge(gr, [249, 251]);
 true
 gap> gr := EmptyDigraph(1000000);
-<immutable digraph with 1000000 vertices, 0 edges>
+<immutable empty digraph with 1000000 vertices>
 gap> IsDigraphEdge(gr, [9999, 9999]);
 false
 gap> gr := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> mat := AdjacencyMatrix(gr);;
 gap> IsDigraphEdge(gr, [5, 5]);
 false
@@ -565,7 +565,7 @@ gap> DigraphAddEdge(gr, [1, 11]);
 Error, the 2nd argument <ran> must be a vertex of the digraph <D> that is the \
 1st argument,
 gap> gr := EmptyDigraph(2);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> DigraphAddEdge(gr, [1, 2]);
 <immutable digraph with 2 vertices, 1 edge>
 gap> DigraphEdges(last);
@@ -632,11 +632,11 @@ true
 
 #  DigraphAddVertex
 gap> gr := CompleteDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphVertices(gr);
 [ 1 ]
 gap> gr2 := DigraphAddVertex(gr);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> DigraphVertices(gr2);
 [ 1, 2 ]
 gap> DigraphEdges(gr) = DigraphEdges(gr2);
@@ -688,7 +688,7 @@ gap> DigraphVertexLabels(D);
 
 #  DigraphRemoveVertices
 gap> gr := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> gr2 := DigraphRemoveVertices(gr, []);
 <immutable digraph with 4 vertices, 12 edges>
 gap> gr = gr2;
@@ -714,7 +714,7 @@ true
 gap> DigraphVertexLabels(gr2);
 [ 2, 4 ]
 gap> gr3 := DigraphRemoveVertices(gr, [1 .. 4]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> gr := Digraph(rec(DigraphNrVertices := 4,
 > DigraphSource := [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4],
 > DigraphRange := [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]));
@@ -723,7 +723,7 @@ gap> IsCompleteDigraph(gr);
 false
 gap> SetDigraphVertexLabels(gr, [(), (1, 2), (1, 2, 3), (1, 2, 3, 4)]);
 gap> gr2 := DigraphRemoveVertices(gr, [1 .. 4]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> gr3 := DigraphRemoveVertices(gr, [2, 3]);
 <immutable digraph with 2 vertices, 4 edges>
 gap> DigraphVertexLabels(gr3);
@@ -749,7 +749,7 @@ gap> DigraphReverseEdges(gr, [2]);
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `DigraphReverseEdge' on 2 arguments
 gap> gr := CompleteDigraph(100);
-<immutable digraph with 100 vertices, 9900 edges>
+<immutable complete digraph with 100 vertices>
 gap> DigraphReverseEdges(gr, "a");
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `DigraphReverseEdge' on 2 arguments
@@ -775,7 +775,7 @@ Error, no 1st choice method found for `DigraphReverseEdge' on 2 arguments
 gap> gr = DigraphReverseEdges(gr, []);
 true
 gap> gr := CycleDigraph(100);
-<immutable digraph with 100 vertices, 100 edges>
+<immutable cycle digraph with 100 vertices>
 gap> edges := ShallowCopy(DigraphEdges(gr));;
 gap>  gr = DigraphReverseEdges(gr, edges);
 false
@@ -858,9 +858,9 @@ true
 
 #  DigraphDisjointUnion
 gap> gr := CycleDigraph(1000);
-<immutable digraph with 1000 vertices, 1000 edges>
+<immutable cycle digraph with 1000 vertices>
 gap> gr2 := CompleteDigraph(100);
-<immutable digraph with 100 vertices, 9900 edges>
+<immutable complete digraph with 100 vertices>
 gap> DigraphDisjointUnion(gr) = gr;
 true
 gap> DigraphDisjointUnion([[]]);
@@ -955,9 +955,9 @@ gap> OutNeighbours(gr);
 
 #  DigraphJoin
 gap> gr := CompleteDigraph(20);
-<immutable digraph with 20 vertices, 380 edges>
+<immutable complete digraph with 20 vertices>
 gap> gr2 := EmptyDigraph(10);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
 gap> DigraphJoin(gr) = gr;
 true
 gap> DigraphJoin([[]]);
@@ -976,7 +976,7 @@ gap> DigraphJoin(gr, EmptyDigraph(0));
 gap> DigraphJoin(EmptyDigraph(0), CycleDigraph(1000));
 <immutable digraph with 1000 vertices, 1000 edges>
 gap> DigraphJoin(EmptyDigraph(0), EmptyDigraph(0));
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphJoin(EmptyDigraph(5), EmptyDigraph(5));
 <immutable digraph with 10 vertices, 50 edges>
 gap> gr1 := Digraph([[2, 2, 3], [3], [2]]);
@@ -1125,7 +1125,7 @@ gap> DigraphConnectedComponents(gr1);;
 gap> IsReachable(gr1, 100, 1);
 false
 gap> gr1 := CycleDigraph(100);
-<immutable digraph with 100 vertices, 100 edges>
+<immutable cycle digraph with 100 vertices>
 gap> IsReachable(gr1, 1, 50);
 true
 gap> IsReachable(gr1, 1, 1);
@@ -1178,7 +1178,7 @@ true
 
 #  DigraphPath
 gap> gr := ChainDigraph(10);
-<immutable digraph with 10 vertices, 9 edges>
+<immutable chain digraph with 10 vertices>
 gap> DigraphPath(gr, 1, 2);
 [ [ 1, 2 ], [ 1 ] ]
 gap> DigraphPath(gr, 1, 1);
@@ -1303,7 +1303,7 @@ Error, the 2nd argument <v> must be a vertex of the 1st argument <D>,
 
 #  DigraphLayers
 gap> gr := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> DigraphLayers(gr, 1);
 [ [ 1 ], [ 2, 3, 4 ] ]
 gap> DigraphLayers(gr, 2);
@@ -1356,7 +1356,7 @@ gap> DigraphShortestDistance(gr, [2], DigraphLayers(gr, 2)[3]);
 gap> DigraphShortestDistance(gr, [2, 3], [3, 4]);
 0
 gap> gr := CompleteDigraph(64);
-<immutable digraph with 64 vertices, 4032 edges>
+<immutable complete digraph with 64 vertices>
 gap> DigraphShortestDistance(gr, [1 .. 10], [20 .. 23]);
 1
 gap> DigraphShortestDistance(gr, [1, 13], [20 .. 23]);
@@ -1364,7 +1364,7 @@ gap> DigraphShortestDistance(gr, [1, 13], [20 .. 23]);
 gap> DigraphShortestDistance(gr, [1, 13], [38, 41]);
 1
 gap> gr := ChainDigraph(72);
-<immutable digraph with 72 vertices, 71 edges>
+<immutable chain digraph with 72 vertices>
 gap> DigraphShortestDistance(gr, [1 .. 10], [20 .. 23]);
 10
 gap> DigraphShortestDistance(gr, [1, 13], [20 .. 23]);
@@ -1418,11 +1418,11 @@ Error, the 2nd argument <list> must be a list of length 2,
 
 #  DigraphDistancesSet
 gap> gr := ChainDigraph(10);
-<immutable digraph with 10 vertices, 9 edges>
+<immutable chain digraph with 10 vertices>
 gap> DigraphDistanceSet(gr, 5, 2);
 [ 7 ]
 gap> gr := DigraphSymmetricClosure(ChainDigraph(10));
-<immutable digraph with 10 vertices, 18 edges>
+<immutable symmetric digraph with 10 vertices, 18 edges>
 gap> DigraphDistanceSet(gr, 5, 2);
 [ 3, 7 ]
 gap> gr := ChainDigraph(10);;
@@ -1490,9 +1490,9 @@ false
 
 #  IsUndirectedSpanningForest
 gap> gr1 := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> gr2 := EmptyDigraph(9);
-<immutable digraph with 9 vertices, 0 edges>
+<immutable empty digraph with 9 vertices>
 gap> IsUndirectedSpanningForest(gr1, gr2);
 false
 gap> gr2 := DigraphAddEdge(EmptyDigraph(10), [1, 2]);
@@ -1534,7 +1534,7 @@ true
 
 #  PartialOrderDigraphMeetOfVertices
 gap> gr := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> PartialOrderDigraphJoinOfVertices(gr, 1, 4);
 Error, the 1st argument <D> must satisfy IsPartialOrderDigraph,
 
@@ -1660,7 +1660,7 @@ true
 gap> IsPerfectMatching(gr, edges);
 false
 gap> gr := CompleteDigraph(500);
-<immutable digraph with 500 vertices, 249500 edges>
+<immutable complete digraph with 500 vertices>
 gap> edges := [];;
 gap> for i in [0 .. 249] do
 >   Append(edges, [[2 * i + 1, 2 * i + 2]]);
@@ -1752,7 +1752,7 @@ true
 gap> D := Digraph([[1], [3, 4], [5, 6], [4, 2, 3], [4, 5], [1]]);
 <immutable digraph with 6 vertices, 11 edges>
 gap> DigraphAddAllLoops(D);
-<immutable digraph with 6 vertices, 14 edges>
+<immutable reflexive digraph with 6 vertices, 14 edges>
 gap> IsIdenticalObj(last, D);
 false
 gap> D := Digraph([[1], [3, 4], [5, 6], [4, 2, 3], [4, 5], [1]]);
@@ -1796,7 +1796,7 @@ gap> DigraphJoin(D, CycleDigraph(3), CycleDigraph(3),
 > CycleDigraph(3));
 <mutable digraph with 12 vertices, 120 edges>
 gap> D := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> DigraphJoin(D, D, D);
 <immutable digraph with 9 vertices, 63 edges>
 gap> DigraphJoin(D, CycleDigraph(3), CycleDigraph(3),
@@ -1808,7 +1808,7 @@ gap> DigraphEdgeUnion(D, CycleDigraph(3), CycleDigraph(3),
 > CycleDigraph(3));
 <mutable multidigraph with 3 vertices, 12 edges>
 gap> DD := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> DD := DigraphEdgeUnion(D, CycleDigraph(3), CycleDigraph(3),
 > CycleDigraph(3));
 <mutable multidigraph with 3 vertices, 21 edges>
@@ -1840,7 +1840,7 @@ gap> D := MakeImmutable(D);
 gap> D := DigraphReverseEdge(D, 1, 2);
 <immutable multidigraph with 3 vertices, 7 edges>
 gap> D := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> DigraphReverseEdge(D, [1, 2]);
 <immutable digraph with 3 vertices, 3 edges>
 gap> D := DigraphMutableCopy(CompleteDigraph(10));
@@ -1868,15 +1868,15 @@ ent <D>,
 gap> IsTransitiveDigraph(DD);
 false
 gap> DD := DigraphTransitiveClosure(DigraphRemoveAllMultipleEdges(DD));
-<immutable digraph with 4 vertices, 16 edges>
+<immutable transitive digraph with 4 vertices, 16 edges>
 gap> IsTransitiveDigraph(DD);
 true
 gap> DigraphShortestPath(DD, 1, 2);
 [ [ 1, 2 ], [ 2 ] ]
 gap> D := ChainDigraph(4);
-<immutable digraph with 4 vertices, 3 edges>
+<immutable chain digraph with 4 vertices>
 gap> D := DigraphTransitiveClosure(D);
-<immutable digraph with 4 vertices, 6 edges>
+<immutable transitive digraph with 4 vertices, 6 edges>
 gap> DigraphShortestPath(D, 2, 1);
 fail
 gap> D := DigraphDisjointUnion(CycleDigraph(3), CycleDigraph(3));

--- a/tst/standard/orbits.tst
+++ b/tst/standard/orbits.tst
@@ -15,14 +15,14 @@ gap> DIGRAPHS_StartTest();
 
 #  DigraphStabilizer, error
 gap> gr := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphStabilizer(gr, 1);
 Error, the 2nd argument <v> must not exceed 
 0, the number of vertices of the digraph in the 1st argument <D>,
 
 #  DigraphStabilizer,
 gap> gr := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> DigraphStabilizer(gr, 1);
 Group([ (2,3) ])
 gap> DigraphStabilizer(gr, 2);
@@ -46,17 +46,17 @@ Group([ (2,3) ])
 
 #  DigraphOrbits
 gap> gr := CycleDigraph(10);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable cycle digraph with 10 vertices>
 gap> DigraphOrbits(gr);
 [ [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] ]
 
 #  RepresentativeOutNeighbours
 gap> gr := ChainDigraph(3);
-<immutable digraph with 3 vertices, 2 edges>
+<immutable chain digraph with 3 vertices>
 gap> RepresentativeOutNeighbours(gr);
 [ [ 2 ], [ 3 ], [  ] ]
 gap> gr := CycleDigraph(12);
-<immutable digraph with 12 vertices, 12 edges>
+<immutable cycle digraph with 12 vertices>
 gap> RepresentativeOutNeighbours(gr);
 [ [ 2 ] ]
 

--- a/tst/standard/planar.tst
+++ b/tst/standard/planar.tst
@@ -15,15 +15,15 @@ gap> DIGRAPHS_StartTest();
 
 # IsPlanarDigraph
 gap> D := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsPlanarDigraph(D);
 true
 gap> D := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> IsPlanarDigraph(D);
 true
 gap> D := CompleteDigraph(5);
-<immutable digraph with 5 vertices, 20 edges>
+<immutable complete digraph with 5 vertices>
 gap> IsPlanarDigraph(D);
 false
 gap> D := Digraph([[2, 4, 7, 9, 10], [1, 3, 4, 6, 9, 10], [6, 10], 
@@ -35,7 +35,7 @@ gap> ChromaticNumber(D);
 gap> IsPlanarDigraph(D);
 false
 gap> D := CompleteBipartiteDigraph(3, 3);
-<immutable digraph with 6 vertices, 18 edges>
+<immutable complete bipartite digraph with bicomponent sizes 3 and 3>
 gap> D := DigraphDisjointUnion(D, D);
 <immutable digraph with 12 vertices, 36 edges>
 gap> IsPlanarDigraph(D);
@@ -53,15 +53,15 @@ false
 gap> IsOuterPlanarDigraph(D);
 false
 gap> D := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsOuterPlanarDigraph(D);
 true
 gap> D := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> IsOuterPlanarDigraph(D);
 false
 gap> D := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> ChromaticNumber(D);
 4
 gap> IsOuterPlanarDigraph(D);
@@ -90,7 +90,7 @@ false
 gap> PlanarEmbedding(D);
 fail
 gap> D := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> PlanarEmbedding(D);
 [  ]
 gap> D := List(["D??", "D?_", "D?o", "D?w", "D?{", "DCO", "DCW", "DCc", "DCo",
@@ -142,11 +142,11 @@ false
 gap> OuterPlanarEmbedding(D);
 fail
 gap> D := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> OuterPlanarEmbedding(D);
 [  ]
 gap> D := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> OuterPlanarEmbedding(D);
 [ [ 2, 3 ], [ 3 ], [  ] ]
 
@@ -195,7 +195,7 @@ gap> KuratowskiPlanarSubdigraph(D);
 [ [ 2, 9, 7 ], [ 3 ], [ 6 ], [ 5, 9 ], [ 6 ], [  ], [ 4 ], [ 7, 9, 3 ], [  ], 
   [  ] ]
 gap> D := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> KuratowskiPlanarSubdigraph(D);
 fail
 
@@ -215,11 +215,11 @@ false
 gap> KuratowskiOuterPlanarSubdigraph(D);
 [ [  ], [  ], [  ], [ 8, 9 ], [  ], [  ], [ 9, 4 ], [ 7, 9 ], [  ], [  ] ]
 gap> D := NullDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> KuratowskiOuterPlanarSubdigraph(D);
 fail
 gap> D := CompleteDigraph(3);
-<immutable digraph with 3 vertices, 6 edges>
+<immutable complete digraph with 3 vertices>
 gap> KuratowskiOuterPlanarSubdigraph(D);
 fail
 

--- a/tst/standard/prop.tst
+++ b/tst/standard/prop.tst
@@ -42,11 +42,11 @@ true
 
 #  IsMultiDigraph
 gap> gr1 := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsMultiDigraph(gr1);
 false
 gap> gr2 := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsMultiDigraph(gr2);
 false
 gap> source := [1 .. 10000];;
@@ -65,6 +65,10 @@ gap> IsMultiDigraph(gr4);
 true
 
 #  IsAcyclicDigraph
+gap> D := Digraph([[2], [1]]);;
+gap> IsStronglyConnectedDigraph(D);;
+gap> IsAcyclicDigraph(D);
+false
 gap> loop := Digraph([[1]]);
 <immutable digraph with 1 vertex, 1 edge>
 gap> IsMultiDigraph(loop);
@@ -176,7 +180,7 @@ false
 gap> IsFunctionalDigraph(loop);
 true
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsFunctionalDigraph(gr);
 true
 gap> r := rec(DigraphVertices := [1 .. 10],
@@ -284,7 +288,7 @@ gap> gr4 := DigraphNC([[], [3], [1]]);;
 gap> IsEmptyDigraph(gr4);
 false
 gap> gr5 := DigraphByAdjacencyMatrix([[0, 0], [0, 0]]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsEmptyDigraph(gr5);
 true
 gap> gr6 := DigraphByEdges([[3, 5], [1, 1], [2, 3], [5, 4]]);
@@ -316,7 +320,7 @@ gap> gr := Digraph([[1], []]);
 gap> IsTournament(gr);
 false
 gap> gr := EmptyDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> HasIsTournament(gr);
 false
 gap> IsTournament(gr);
@@ -332,7 +336,7 @@ false
 
 #  IsStronglyConnectedDigraph
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsStronglyConnectedDigraph(gr);
 true
 gap> adj := [[3, 4, 5, 7, 10], [4, 5, 10], [1, 2, 4, 7], [2, 9],
@@ -410,11 +414,11 @@ gap> gr := Digraph(r);
 gap> IsReflexiveDigraph(gr);
 true
 gap> gr := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsReflexiveDigraph(gr);
 true
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> HasIsAcyclicDigraph(gr);
 false
 gap> IsReflexiveDigraph(gr);
@@ -449,7 +453,7 @@ true
 
 #  IsCompleteDigraph
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsCompleteDigraph(gr);
 true
 gap> gr := Digraph([[2, 2], []]);
@@ -471,11 +475,11 @@ true
 
 #  IsConnectedDigraph
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsConnectedDigraph(gr);
 true
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsConnectedDigraph(gr);
 true
 gap> gr := Digraph([[1]]);
@@ -509,11 +513,11 @@ true
 
 #  DigraphHasLoops
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphHasLoops(gr);
 false
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphHasLoops(gr);
 false
 gap> gr := Digraph([[1]]);
@@ -535,11 +539,11 @@ gap> gr := Digraph([[6, 7], [6, 9], [1, 2, 4, 5, 8, 9],
 gap> DigraphHasLoops(gr);
 false
 gap> gr := Digraph(rec(DigraphNrVertices := 0, DigraphSource := [], DigraphRange := []));
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> DigraphHasLoops(gr);
 false
 gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [], DigraphRange := []));
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphHasLoops(gr);
 false
 gap> gr := Digraph(rec(DigraphNrVertices := 1, DigraphSource := [1], DigraphRange := [1]));
@@ -696,19 +700,19 @@ gap> gr := Digraph([[2, 4], [], [1], [1], [4]]);
 gap> IsBipartiteDigraph(gr);
 true
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsBipartiteDigraph(gr);
 false
 gap> gr := CycleDigraph(89);
-<immutable digraph with 89 vertices, 89 edges>
+<immutable cycle digraph with 89 vertices>
 gap> IsBipartiteDigraph(gr);
 false
 gap> gr := CycleDigraph(314);
-<immutable digraph with 314 vertices, 314 edges>
+<immutable cycle digraph with 314 vertices>
 gap> IsBipartiteDigraph(gr);
 true
 gap> gr := CompleteDigraph(4);
-<immutable digraph with 4 vertices, 12 edges>
+<immutable complete digraph with 4 vertices>
 gap> IsBipartiteDigraph(gr);
 false
 gap> gr := Digraph([[2, 4], [], [1], [1], [4], [7], []]);
@@ -792,7 +796,7 @@ gap> gr := Digraph([[2], [1, 3], [2, 4], [3, 5, 6], [4, 6], [4, 5]]);
 gap> IsDistanceRegularDigraph(gr);
 false
 gap> gr := CompleteBipartiteDigraph(3, 4);
-<immutable digraph with 7 vertices, 24 edges>
+<immutable complete bipartite digraph with bicomponent sizes 3 and 4>
 gap> IsDistanceRegularDigraph(gr);
 false
 gap> gr := Digraph([[], [3], [2]]);
@@ -802,7 +806,7 @@ false
 
 #  IsCompleteBipartiteDigraph
 gap> gr := CompleteBipartiteDigraph(4, 5);
-<immutable digraph with 9 vertices, 40 edges>
+<immutable complete bipartite digraph with bicomponent sizes 4 and 5>
 gap> IsCompleteBipartiteDigraph(gr);
 true
 gap> gr := Digraph([[2, 2], []]);
@@ -810,11 +814,11 @@ gap> gr := Digraph([[2, 2], []]);
 gap> IsCompleteBipartiteDigraph(gr);
 false
 gap> gr := CycleDigraph(3);
-<immutable digraph with 3 vertices, 3 edges>
+<immutable cycle digraph with 3 vertices>
 gap> IsCompleteBipartiteDigraph(gr);
 false
 gap> gr := CycleDigraph(4);
-<immutable digraph with 4 vertices, 4 edges>
+<immutable cycle digraph with 4 vertices>
 gap> IsCompleteBipartiteDigraph(gr);
 false
 gap> gr := Digraph([[2], [1]]);
@@ -824,15 +828,15 @@ true
 
 #  IsDirectedTree
 gap> g := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsDirectedTree(g);
 false
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsDirectedTree(g);
 true
 gap> g := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsDirectedTree(g);
 false
 gap> g := Digraph([[1]]);
@@ -886,15 +890,15 @@ false
 
 #  IsUndirectedTree
 gap> g := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsUndirectedTree(g);
 false
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsUndirectedTree(g);
 true
 gap> g := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsUndirectedTree(g);
 false
 gap> g := Digraph([[1]]);
@@ -948,15 +952,15 @@ false
 
 #  IsUndirectedForest
 gap> gr := ChainDigraph(10);
-<immutable digraph with 10 vertices, 9 edges>
+<immutable chain digraph with 10 vertices>
 gap> IsUndirectedForest(gr);
 false
 gap> gr := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsUndirectedForest(gr);
 false
 gap> gr := EmptyDigraph(1);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsUndirectedForest(gr);
 true
 gap> gr := Digraph([[1, 1]]);
@@ -968,7 +972,7 @@ gap> gr := Digraph([[1]]);
 gap> IsUndirectedForest(gr);
 false
 gap> gr := DigraphSymmetricClosure(ChainDigraph(4));
-<immutable digraph with 4 vertices, 6 edges>
+<immutable symmetric digraph with 4 vertices, 6 edges>
 gap> HasIsUndirectedTree(gr) or HasIsUndirectedForest(gr);
 false
 gap> IsUndirectedTree(gr);
@@ -994,15 +998,15 @@ true
 
 #  IsEulerianDigraph
 gap> g := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsEulerianDigraph(g);
 true
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsEulerianDigraph(g);
 true
 gap> g := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsEulerianDigraph(g);
 false
 gap> g := Digraph([[1]]);
@@ -1062,11 +1066,11 @@ gap> g := Digraph([[2, 3], [3], [1]]);
 gap> IsEulerianDigraph(g);
 false
 gap> g := EmptyDigraph(IsMutableDigraph, 10);
-<mutable digraph with 10 vertices, 0 edges>
+<mutable empty digraph with 10 vertices>
 gap> IsEulerianDigraph(g);
 false
 gap> g;
-<mutable digraph with 10 vertices, 0 edges>
+<mutable empty digraph with 10 vertices>
 
 # IsJoinSemilatticeDigraph, IsMeetSemilatticeDigraph, and IsLatticeDigraph
 gap> gr := Digraph([[1, 2], [2]]);
@@ -1078,7 +1082,7 @@ true
 gap> IsLatticeDigraph(gr);
 true
 gap> gr := CycleDigraph(5);
-<immutable digraph with 5 vertices, 5 edges>
+<immutable cycle digraph with 5 vertices>
 gap> IsMeetSemilatticeDigraph(gr);
 false
 gap> IsJoinSemilatticeDigraph(gr);
@@ -1104,7 +1108,7 @@ false
 
 # IsPartialOrderDigraph
 gap> gr := NullDigraph(5);
-<immutable digraph with 5 vertices, 0 edges>
+<immutable empty digraph with 5 vertices>
 gap> IsPartialOrderDigraph(gr);
 false
 gap> gr := Digraph([[1], [2], [3]]);
@@ -1137,7 +1141,7 @@ gap> gr := DigraphFromDiSparse6String(Concatenation(
 > "BkQqZIkmrJLkytZUl]uJXmkyjrNI}Rv"));
 <immutable digraph with 266 vertices, 919 edges>
 gap> gr := DigraphReflexiveTransitiveClosure(gr);
-<immutable digraph with 266 vertices, 10772 edges>
+<immutable preorder digraph with 266 vertices, 10772 edges>
 gap> IsPartialOrderDigraph(gr);
 true
 gap> IsMeetSemilatticeDigraph(gr);
@@ -1161,11 +1165,11 @@ true
 
 #  IsBiconnectedDigraph
 gap> gr := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsBiconnectedDigraph(gr);
 true
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsBiconnectedDigraph(gr);
 true
 gap> gr := Digraph([[1]]);
@@ -1200,15 +1204,15 @@ false
 
 #  IsHamiltonianDigraph
 gap> g := Digraph([]);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := Digraph([[], []]);
-<immutable digraph with 2 vertices, 0 edges>
+<immutable empty digraph with 2 vertices>
 gap> IsHamiltonianDigraph(g);
 false
 gap> g := Digraph([[1]]);
@@ -1279,43 +1283,43 @@ gap> g := Digraph([[2, 4, 6, 10], [1, 3, 4, 5, 6, 7, 9, 10], [1, 5, 7, 8],
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CompleteMultipartiteDigraph([1, 30]);
-<immutable digraph with 31 vertices, 60 edges>
+<immutable complete bipartite digraph with bicomponent sizes 1 and 30>
 gap> IsHamiltonianDigraph(g);
 false
 gap> g := CompleteMultipartiteDigraph([16, 15]);
-<immutable digraph with 31 vertices, 480 edges>
+<immutable complete bipartite digraph with bicomponent sizes 16 and 15>
 gap> IsHamiltonianDigraph(g);
 false
 gap> g := CompleteMultipartiteDigraph([1, 1, 2, 3, 5, 8, 13, 21]);
-<immutable digraph with 54 vertices, 2202 edges>
+<immutable multipartite symmetric digraph with 54 vertices, 2202 edges>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CompleteMultipartiteDigraph([1, 1, 2, 3, 5, 8, 13, 21, 34]);
-<immutable digraph with 88 vertices, 5874 edges>
+<immutable multipartite symmetric digraph with 88 vertices, 5874 edges>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CompleteBipartiteDigraph(50, 50);
-<immutable digraph with 100 vertices, 5000 edges>
+<immutable complete bipartite digraph with bicomponent sizes 50 and 50>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CompleteMultipartiteDigraph([1, 15, 1, 1, 1, 1, 1, 1]);
-<immutable digraph with 22 vertices, 252 edges>
+<immutable multipartite symmetric digraph with 22 vertices, 252 edges>
 gap> IsHamiltonianDigraph(g);
 false
 gap> g := CompleteDigraph(50);
-<immutable digraph with 50 vertices, 2450 edges>
+<immutable complete digraph with 50 vertices>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CycleDigraph(1000000);
-<immutable digraph with 1000000 vertices, 1000000 edges>
+<immutable cycle digraph with 1000000 vertices>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CompleteDigraph(100);
-<immutable digraph with 100 vertices, 9900 edges>
+<immutable complete digraph with 100 vertices>
 gap> IsHamiltonianDigraph(g);
 true
 gap> g := CycleDigraph(513);
-<immutable digraph with 513 vertices, 513 edges>
+<immutable cycle digraph with 513 vertices>
 gap> g := DigraphAddEdges(g, [[6, 8], [8, 7], [7, 9]]);
 <immutable digraph with 513 vertices, 516 edges>
 gap> g := DigraphRemoveEdge(g, [6, 7]);
@@ -1335,15 +1339,15 @@ true
 
 # IsDigraphCore
 gap> D := CompleteDigraph(10);
-<immutable digraph with 10 vertices, 90 edges>
+<immutable complete digraph with 10 vertices>
 gap> IsDigraphCore(D);
 true
 gap> D := JohnsonDigraph(8, 3);
-<immutable digraph with 56 vertices, 840 edges>
+<immutable symmetric digraph with 56 vertices, 840 edges>
 gap> IsDigraphCore(D);
 true
 gap> D := CompleteBipartiteDigraph(500, 500);
-<immutable digraph with 1000 vertices, 500000 edges>
+<immutable complete bipartite digraph with bicomponent sizes 500 and 500>
 gap> IsDigraphCore(D);
 false
 gap> D := PetersenGraph();
@@ -1357,11 +1361,11 @@ false
 gap> D;
 <mutable digraph with 40 vertices, 80 edges>
 gap> D := EmptyDigraph(100000);
-<immutable digraph with 100000 vertices, 0 edges>
+<immutable empty digraph with 100000 vertices>
 gap> IsDigraphCore(D);
 false
 gap> D := EmptyDigraph(0);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 gap> IsDigraphCore(D);
 true
 
@@ -1390,7 +1394,7 @@ false
 
 # Code coverage
 gap> D := DigraphCopy(NullDigraph(4));
-<immutable digraph with 4 vertices, 0 edges>
+<immutable empty digraph with 4 vertices>
 gap> HasIsEmptyDigraph(D);
 false
 gap> HasDigraphNrEdges(D);

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -56,7 +56,7 @@ gap> IsMultiDigraph(gr);
 false
 gap> IsAcyclicDigraph(gr);
 false
-gap> r := rec(DigraphVertices := [1 .. 10000], 
+gap> r := rec(DigraphNrVertices := 10000,
 >             DigraphSource := [],
 >             DigraphRange := []);;
 gap> for i in [1 .. 9999] do
@@ -88,7 +88,7 @@ gap> OutNeighbours(gr);;
 gap> d := Digraph(rec(DigraphVertices := [1 .. 5], 
 >                     DigraphRange := [], 
 >                     DigraphSource := []));
-<immutable digraph with 5 vertices, 0 edges>
+<immutable empty digraph with 5 vertices>
 gap> IsMultiDigraph(d);
 false
 
@@ -272,7 +272,7 @@ gap> DigraphNrEdges(gr2);
 #  Fix seg fault cause by wrong handling of no edges in
 # FuncDIGRAPH_SOURCE_RANGE
 gap> gr := Digraph([[]]);
-<immutable digraph with 1 vertex, 0 edges>
+<immutable empty digraph with 1 vertex>
 gap> DigraphSource(gr);
 [  ]
 gap> DigraphRange(gr);
@@ -290,7 +290,7 @@ gap> OutNeighbours(OnDigraphs(d, Transformation([2, 3, 1])));
 gap> f := Transformation([7, 10, 10, 1, 7, 9, 10, 4, 2, 3]);
 Transformation( [ 7, 10, 10, 1, 7, 9, 10, 4, 2, 3 ] )
 gap> AsDigraph(f);
-<immutable digraph with 10 vertices, 10 edges>
+<immutable functional digraph with 10 vertices>
 gap> AsDigraph(f, 4);
 fail
 
@@ -316,7 +316,7 @@ ceeding the length of the argument,
 #  Symmetric closure of a digraph with no vertices
 gap> gr := EmptyDigraph(0);;
 gap> DigraphSymmetricClosure(gr);
-<immutable digraph with 0 vertices, 0 edges>
+<immutable empty digraph with 0 vertices>
 
 # Issue 114: Bug in NautyTracesInterface for graphs with 0 vertices
 gap> not DIGRAPHS_NautyAvailable or 
@@ -343,9 +343,9 @@ true
 
 # MakeImmutable
 gap> D := NullDigraph(IsMutableDigraph, 10);
-<mutable digraph with 10 vertices, 0 edges>
+<mutable empty digraph with 10 vertices>
 gap> MakeImmutable(D);
-<immutable digraph with 10 vertices, 0 edges>
+<immutable empty digraph with 10 vertices>
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);


### PR DESCRIPTION
The major changes are that `QuotientDigraph` always returns things without multiple edges, and `ViewString` now shows much more pre-computed data for immutable digraphs.

After this, the 'only' thing left to do for 1.0 is the documentation. Big job, but I'll be confident (and hopefully the rest of you too) that the code/functionality we're documenting is pretty much correct.