### PR TITLE
Tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 To get the latest version of the package, download the archive file
 `digraphs-x.x.x.tar.gz` from the
-[Digraphs](https://gap-packages.github.io/Digraphs) webpage, and inside
+[Digraphs][] webpage, and inside
 the `pkg` subdirectory of your GAP installation unpack `digraphs-x.x.x.tar.gz`
 using, for example:
 
@@ -25,20 +25,20 @@ For questions, remarks, suggestions, and issues please use the
 
 ## Installation
 
-It is assumed that you have a working copy of [GAP](http://www.gap-system.org)
+It is assumed that you have a working copy of [GAP][]
 with version number 4.9.0 or higher.  The most up-to-date version of
-[GAP](http://www.gap-system.org) and instructions on how to install it can be
-obtained from the [main GAP webpage](http://www.gap-system.org).
+[GAP][] and instructions on how to install it can be
+obtained from the [main GAP webpage](https://www.gap-system.org).
 
 The following is a summary of the steps that should lead to a successful
-installation of [Digraphs](https://gap-packages.github.io/Digraphs):
+installation of [Digraphs][]:
 
-* get the [IO](http://gap-packages.github.io/io) package version 4.5.1 or higher.
-* get the [orb](http://gap-packages.github.io/orb) package version 4.8.2 or
+* get the [IO](https://gap-packages.github.io/io) package version 4.5.1 or higher.
+* get the [orb](https://gap-packages.github.io/orb) package version 4.8.2 or
   higher.
-* **this step is optional:** certain methods in [Digraphs](https://gap-packages.github.io/Digraphs) require the [Grape](http://www.maths.qmul.ac.uk/~leonard/grape/) package to be available; a full list of these functions can be found in the first chapter of the manual.  To use these functions make sure that the [Grape](http://www.maths.qmul.ac.uk/~leonard/grape/) package version 4.8.1 or higher is available.
+* **this step is optional:** certain methods in [Digraphs][] require the [Grape](https://gap-packages.github.io/grape/) package to be available; a full list of these functions can be found in the first chapter of the manual.  To use these functions make sure that the [Grape](http://www.maths.qmul.ac.uk/~leonard/grape/) package version 4.8.1 or higher is available.
 * download the package archive `digraphs-x.x.x.tar.gz` from the
-  [Digraphs](https://gap-packages.github.io/Digraphs) webpage.
+  [Digraphs][] webpage.
 * unzip and untar the file `digraphs-x.x.x.tar.gz` using, for example,
   ```
     gunzip digraphs-x.x.x.tar.gz; tar xvf digraphs-x.x.x.tar
@@ -48,17 +48,17 @@ installation of [Digraphs](https://gap-packages.github.io/Digraphs):
   directories `lib`, `doc` and so on. Move the directory `digraphs-x.x.x` into the
   `pkg` directory (if it is not there already).
 * compile the kernel module; more details below.
-* start [GAP](http://www.gap-system.org) in the usual way.
+* start [GAP][] in the usual way.
 * type `LoadPackage("digraphs");`
 
 ## Compiling the kernel module
 
-The [Digraphs](https://gap-packages.github.io/Digraphs)
-package has a [GAP](http://www.gap-system.org) kernel component written in
+The [Digraphs][]
+package has a [GAP][] kernel component written in
 C which has to be compiled for the package to work.  This component contains
-certain low-level functions required by [Digraphs](https://gap-packages.github.io/Digraphs).
+certain low-level functions required by [Digraphs][].
 
-It is not possible to use the [Digraphs](https://gap-packages.github.io/Digraphs) package without compiling it.
+It is not possible to use the [Digraphs][] package without compiling it.
 
 To compile the kernel component inside the `digraphs-x.x.x` directory, type
 
@@ -66,28 +66,35 @@ To compile the kernel component inside the `digraphs-x.x.x` directory, type
     make
 
 If you installed the package in a `pkg` directory other than the standard `pkg`
-directory in your [GAP](http://www.gap-system.org) installation, then you have
+directory in your [GAP][] installation, then you have
 to do two things. Firstly during compilation you have to use the option
 `--with-gaproot=PATH` of the `configure` script where `PATH` is a path to the
-main [GAP](http://www.gap-system.org) root directory (if not given, the default
+main [GAP][] root directory (if not given, the default
 `../..` is assumed).
 
-If you installed [GAP](http://www.gap-system.org) on several architectures, you
+If you installed [GAP][] on several architectures, you
 must execute the configure/make step for each of the architectures. You can
 either do this immediately after configuring and compiling
-[GAP](http://www.gap-system.org) itself on this architecture, or alternatively
-(when using version 4.5 of [GAP](http://www.gap-system.org) or newer) set the
+[GAP][] itself on this architecture, or alternatively
+(when using version 4.5 of [GAP][] or newer) set the
 environment variable `CONFIGNAME` to the name of the configuration you used
-when compiling [GAP](http://www.gap-system.org) before running `./configure`.
+when compiling [GAP][] before running `./configure`.
 Note however that your compiler choice and flags (environment variables `CC`
 and `CFLAGS`) need to be chosen to match the setup of the original
-[GAP](http://www.gap-system.org) compilation. For example you have to specify
+[GAP][] compilation. For example you have to specify
 32-bit or 64-bit mode correctly!
 
 Digraphs vendors `bliss` and `planarity` libraries in `extern` directory. If you
 wish to use your system copy of `bliss` and `planarity`, use the configure options
 `--with-external-bliss` and `--with-external-planarity`.
 
-If you wish to install a [development version of the Digraphs package](https://www.github.com/gap-packages/Digraphs), then you must first run the command `./autogen.sh` before compilation. However, development versions of the package may be unstable, and we recommend using the most recently released version of the package when possible.
+If you wish to install a [development version of the Digraphs
+package](https://github.com/gap-packages/Digraphs), then you must first run
+the command `./autogen.sh` before compilation. However, development versions
+of the package may be unstable, and we recommend using the most recently
+released version of the package when possible.
 
 Enjoy!
+
+[Digraphs]: https://gap-packages.github.io/Digraphs
+[GAP]: https://www.gap-system.org


### PR DESCRIPTION
- GAP website uses https, not http
- instead of repeating links again and again, use a reference style link,
  with an implicit link name
- Update grape homepage URL

Personally, I'd also drop many of those links, because they make it very hard to read the README as a plain text file, which normally is one of the big strengths of using Markdown. I am pretty sure user's won't complain if not every occurrence of the words GAP and Digraphs is a link :-). But since this isn't my decision, I limited my PR to the minimum needed.