### PR TITLE
Update grape.xml documentation

### DIFF
--- a/doc/grape.xml
+++ b/doc/grape.xml
@@ -39,14 +39,7 @@ rec(
 gap> Digraph(Petersen);
 <immutable digraph with 10 vertices, 30 edges>
 gap> Graph(last) = Petersen;
-true
-gap> D := CycleDigraph(IsMutableDigraph, 2);
-<mutable digraph with 2 vertices, 2 edges>
-gap> Graph(D);
-rec( adjacencies := [ [ 2 ], [ 1 ] ], group := Group(()), isGraph := true,
-  names := [ 1, 2 ], order := 2, representatives := [ 1, 2 ],
-  schreierVector := [ -1, -2 ] )
-  ]]></Example>
+true]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -68,7 +61,7 @@ rec( adjacencies := [ [ 2 ], [ 1 ] ], group := Group(()), isGraph := true,
     The digraph created by this operation belongs to the category <Ref
       Filt="IsCayleyDigraph"/>, the group <A>G</A> can be recovered from the
     digraph using <Ref Attr="GroupOfCayleyDigraph"/>, and the generators
-    <A>gens</A> can be obtained using <Ref Attr="GeneratorsOfCayleyDigraph"/>.<P>
+    <A>gens</A> can be obtained using <Ref Attr="GeneratorsOfCayleyDigraph"/>.<P/>
 
     Note that this function can only return an immutable digraph.
 

--- a/doc/grape.xml
+++ b/doc/grape.xml
@@ -13,7 +13,7 @@
   <Oper Name="Graph" Arg="digraph"/>
   <Returns>A &Grape; package graph.</Returns>
   <Description>
-    If <A>digraph</A> is a digraph without multiple edges, then this operation
+    If <A>digraph</A> is a mutable or immutable digraph without multiple edges, then this operation
     returns a &Grape; package graph that is isomorphic to <A>digraph</A>. <P/>
 
     If <A>digraph</A> is a multidigraph, then since &Grape; does not support
@@ -39,7 +39,14 @@ rec(
 gap> Digraph(Petersen);
 <immutable digraph with 10 vertices, 30 edges>
 gap> Graph(last) = Petersen;
-true]]></Example>
+true
+gap> D := CycleDigraph(IsMutableDigraph, 2);
+<mutable digraph with 2 vertices, 2 edges>
+gap> Graph(D);
+rec( adjacencies := [ [ 2 ], [ 1 ] ], group := Group(()), isGraph := true,
+  names := [ 1, 2 ], order := 2, representatives := [ 1, 2 ],
+  schreierVector := [ -1, -2 ] )
+  ]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -56,12 +63,14 @@ true]]></Example>
     a generator <C>g</C> in <A>gens</A> such that <C>x * g = y</C>. <P/>
 
     If the optional second argument <A>gens</A> is not present, then the
-    generators of <A>G</A> are used by default.
+    generators of <A>G</A> are used by default.<P/>
 
     The digraph created by this operation belongs to the category <Ref
       Filt="IsCayleyDigraph"/>, the group <A>G</A> can be recovered from the
     digraph using <Ref Attr="GroupOfCayleyDigraph"/>, and the generators
-    <A>gens</A> can be obtained using <Ref Attr="GeneratorsOfCayleyDigraph"/>.
+    <A>gens</A> can be obtained using <Ref Attr="GeneratorsOfCayleyDigraph"/>.<P>
+
+    Note that this function can only return an immutable digraph.
 
     <Example><![CDATA[
 gap> G := DihedralGroup(8);
@@ -88,7 +97,7 @@ gap> GeneratorsOfCayleyDigraph(digraph);
   <Attr Name="SemigroupOfCayleyDigraph" Arg="digraph"/>
   <Returns>A group or semigroup.</Returns>
   <Description>
-    If <A>digraph</A> is a Cayley graph of a group <C>G</C> and
+    If <A>digraph</A> is an immutable Cayley graph of a group <C>G</C> and
     <A>digraph</A> belongs to the category <Ref Filt="IsCayleyDigraph"/>, then
     <C>GroupOfCayleyDigraph</C> returns <C>G</C>.
     <P/>
@@ -116,7 +125,7 @@ true
   <Attr Name="GeneratorsOfCayleyDigraph" Arg="digraph"/>
   <Returns>A list of generators.</Returns>
   <Description>
-    If <A>digraph</A> is a Cayley graph of a group or semigroup with
+    If <A>digraph</A> is an immutable Cayley graph of a group or semigroup with
     respect to a set of generators <C>gens</C> and <A>digraph</A> belongs to
     the category <Ref Filt="IsCayleyDigraph"/>, then
     <C>GeneratorsOfCayleyDigraph</C> return the list of generators <C>gens</C>
@@ -157,7 +166,9 @@ true]]></Example>
     <P/>
 
     If the optional third argument <A>n</A> is not present, then the largest
-    moved point of the permutation group <A>G</A> is used by default.
+    moved point of the permutation group <A>G</A> is used by default.<P/>
+
+    Note that this function can only return an immutable digraph.
 
     <Example><![CDATA[
 gap> digraph := EdgeOrbitsDigraph(Group((1, 3), (1, 2)(3, 4)),
@@ -183,7 +194,8 @@ gap> RepresentativeOutNeighbours(digraph);
     <A>digraph</A> and with additional edges consisting of the orbit of the
     edge <A>edge</A> under the action of the <Ref Attr="DigraphGroup"/> of
     <A>digraph</A>.  If <A>edge</A> is already an edge in <A>digraph</A>, then
-    <A>digraph</A> is returned unchanged.
+    <A>digraph</A> is returned unchanged. The argument <A>digraph</A> must be
+    an immutable digraph.
     <P/>
 
     An edge is simply a pair of vertices of <A>digraph</A>.
@@ -225,11 +237,11 @@ true
     <A>digraph</A> and with the orbit of the edge <A>edge</A> (under the action
     of the <Ref Attr="DigraphGroup"/> of <A>digraph</A>) removed.
     If <A>edge</A> is not an edge in <A>digraph</A>, then <A>digraph</A> is
-    returned unchanged.
+    returned unchanged. The argument <A>digraph</A> must be an immutable
+    digraph.
     <P/>
 
     An edge is simply a pair of vertices of <A>digraph</A>.
-
     <Example><![CDATA[
 gap> gr1 := CayleyDigraph(DihedralGroup(8));
 <immutable digraph with 8 vertices, 24 edges>


### PR DESCRIPTION
This pull requests updates the documentation in `grape.xml`. The functions can't return mutable digraphs, and nor can they accept them as arguments: the documentation now reflects this.