### PR TITLE
Add InstallMethodThatReturnsDigraph

### DIFF
--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -73,15 +73,14 @@ DeclareAttribute("DIGRAPHS_ConnectivityData", IsDigraph, "mutable");
 
 # Things that are attributes for immutable digraphs, but operations for mutable.
 
-DeclareOperation("DigraphReverse", [IsDigraph]);
-DeclareAttribute("DigraphReverseAttr", IsDigraph);
-DeclareOperation("DigraphDual", [IsDigraph]);
-DeclareAttribute("DigraphDualAttr", IsDigraph);
-DeclareOperation("ReducedDigraph", [IsDigraph]);
-DeclareAttribute("ReducedDigraphAttr", IsDigraph);
+DeclareAttributeThatReturnsDigraph("DigraphReverse", IsDigraph);
+DeclareAttributeThatReturnsDigraph("DigraphDual", IsDigraph);
+DeclareAttributeThatReturnsDigraph("ReducedDigraph", IsDigraph);
+DeclareAttributeThatReturnsDigraph("DigraphRemoveAllMultipleEdges", IsDigraph);
 
-DeclareOperation("DigraphRemoveAllMultipleEdges", [IsDigraph]);
-DeclareAttribute("DigraphRemoveAllMultipleEdgesAttr", IsDigraph);
+# TODO replace all DeclareOperations below to DeclareAttributeThatReturnsDigraph,
+# and remove the *Attr versions.
+
 DeclareOperation("DigraphAddAllLoops", [IsDigraph]);
 DeclareAttribute("DigraphAddAllLoopsAttr", IsDigraph);
 DeclareOperation("DigraphRemoveLoops", [IsDigraph]);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -1356,6 +1356,7 @@ end);
 
 # Things that are attributes for immutable digraphs, but operations for mutable.
 
+# Don't use InstallMethodThatReturnsDigraph since we can do better in this case.
 InstallMethod(DigraphReverse, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
@@ -1376,13 +1377,7 @@ function(D)
   return D;
 end);
 
-InstallMethod(DigraphReverse, "for a digraph with known digraph reverse",
-[IsDigraph and HasDigraphReverseAttr], SUM_FLAGS, DigraphReverseAttr);
-
-InstallMethod(DigraphReverseAttr, "for an immutable digraph",
-[IsImmutableDigraph], DigraphReverse);
-
-InstallMethod(DigraphDual, "for a digraph by out-neighbours",
+InstallMethodThatReturnsDigraph(DigraphDual, "for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local nodes, C, list, i;
@@ -1409,13 +1404,8 @@ function(D)
   return C;
 end);
 
-InstallMethod(DigraphDual, "for a digraph with known dual",
-[IsDigraph and HasDigraphDualAttr], SUM_FLAGS, DigraphDualAttr);
-
-InstallMethod(DigraphDualAttr, "for an immutable digraph", [IsImmutableDigraph],
-DigraphDual);
-
-InstallMethod(ReducedDigraph, "for a digraph by out-neighbours",
+InstallMethodThatReturnsDigraph(ReducedDigraph,
+"for a digraph by out-neighbours",
 [IsDigraphByOutNeighboursRep],
 function(D)
   local v, niv, old, C, i;
@@ -1435,18 +1425,8 @@ function(D)
     fi;
   od;
   C := InducedSubdigraph(D, ListBlist(v, niv));
-  # Store result if input (and hence output) immutable
-  if IsImmutableDigraph(D) then
-    SetReducedDigraphAttr(D, C);
-  fi;
   return C;
 end);
-
-InstallMethod(ReducedDigraph, "for a digraph with known reduced digraph",
-[IsDigraph and HasReducedDigraphAttr], SUM_FLAGS, ReducedDigraphAttr);
-
-InstallMethod(ReducedDigraphAttr, "for an immutable digraph",
-[IsImmutableDigraph], ReducedDigraph);
 
 InstallMethod(DigraphRemoveAllMultipleEdges,
 "for a mutable digraph by out-neighbours",
@@ -1475,10 +1455,8 @@ function(D)
   return D;
 end);
 
-InstallMethod(DigraphRemoveAllMultipleEdges, "for an immutable digraph",
-[IsImmutableDigraph], DigraphRemoveAllMultipleEdgesAttr);
-
-InstallMethod(DigraphRemoveAllMultipleEdgesAttr, "for an immutable digraph",
+InstallMethodThatReturnsDigraph(DigraphRemoveAllMultipleEdges,
+"for an immutable digraph",
 [IsImmutableDigraph],
 function(D)
   if IsMultiDigraph(D) then

--- a/gap/digraphs.g
+++ b/gap/digraphs.g
@@ -8,9 +8,11 @@
 #############################################################################
 ##
 
-DeclareOperation("DeclareAttributeReturnsDigraph", [IsString, IsOperation]);
+DeclareOperation("DeclareAttributeThatReturnsDigraph", [IsString, IsOperation]);
+DeclareOperation("InstallMethodThatReturnsDigraph",
+                 [IsOperation, IsString, IsList, IsFunction]);
 
-InstallMethod(DeclareAttributeReturnsDigraph, "for a string",
+InstallMethod(DeclareAttributeThatReturnsDigraph, "for a string",
 [IsString, IsOperation],
 function(oper_name, filt)
   local attr_name, has_attr_name, oper, attr, has_attr;
@@ -30,4 +32,24 @@ function(oper_name, filt)
   InstallMethod(attr, "for an immutable digraph", [IsImmutableDigraph], oper);
   # Now it suffices to install a method for the oper and a subcategory of
   # filt and this ought to just work.
+end);
+
+InstallMethod(InstallMethodThatReturnsDigraph,
+"for an operation, info string, list of argument filters, and function",
+[IsOperation, IsString, IsList, IsFunction],
+function(oper, info, filt, func)
+  InstallMethod(oper, info, filt,
+  function(D)
+    local C, attr_name, set_attr;
+    C := func(D);
+    if IsImmutableDigraph(D) then
+      if not IsImmutableDigraph(C) then
+        MakeImmutable(C);
+      fi;
+      attr_name := Concatenation(NameFunction(oper), "Attr");
+      set_attr  := ValueGlobal(Concatenation("Set", attr_name));
+      set_attr(D, C);
+    fi;
+    return C;
+  end);
 end);

--- a/gap/isomorph.gd
+++ b/gap/isomorph.gd
@@ -32,12 +32,12 @@ DeclareOperation("BlissCanonicalLabelling", [IsDigraph, IsHomogeneousList]);
 DeclareAttribute("NautyCanonicalLabelling", IsDigraph);
 DeclareOperation("NautyCanonicalLabelling", [IsDigraph, IsHomogeneousList]);
 
-DeclareAttributeReturnsDigraph("BlissCanonicalDigraph", IsDigraph);
+DeclareAttributeThatReturnsDigraph("BlissCanonicalDigraph", IsDigraph);
 DeclareOperation("BlissCanonicalDigraph", [IsDigraph, IsHomogeneousList]);
 
 #  TODO document 2-arg BlissCanonicalDigraph and NautyCanonicalDigraph
 
-DeclareAttributeReturnsDigraph("NautyCanonicalDigraph", IsDigraph);
+DeclareAttributeThatReturnsDigraph("NautyCanonicalDigraph", IsDigraph);
 DeclareOperation("NautyCanonicalDigraph", [IsDigraph, IsHomogeneousList]);
 
 DeclareOperation("IsIsomorphicDigraph", [IsDigraph, IsDigraph]);

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -206,7 +206,8 @@ end);
 
 # Canonical digraphs
 
-InstallMethod(BlissCanonicalDigraph, "for a digraph", [IsDigraph],
+InstallMethodThatReturnsDigraph(BlissCanonicalDigraph, "for a digraph",
+[IsDigraph],
 function(D)
   if IsMultiDigraph(D) then
     return OnMultiDigraphs(D, BlissCanonicalLabelling(D));
@@ -223,7 +224,8 @@ function(D, colors)
   return OnDigraphs(D, BlissCanonicalLabelling(D, colors));
 end);
 
-InstallMethod(NautyCanonicalDigraph, "for a digraph", [IsDigraph],
+InstallMethodThatReturnsDigraph(NautyCanonicalDigraph, "for a digraph",
+[IsDigraph],
 function(D)
   if not DIGRAPHS_NautyAvailable or IsMultiDigraph(D) then
     Info(InfoWarning, 1, "NautyTracesInterface is not available");


### PR DESCRIPTION
This fixes the changes in #247, and provides a couple of extra examples of the usage of `DeclareMethodThatReturnsDigraph` and `InstallMethodThatReturnsDigraph`.