### PR TITLE
Fix error in DotPartialOrderDigraph

### DIFF
--- a/doc/labels.xml
+++ b/doc/labels.xml
@@ -27,25 +27,37 @@
     <C>vertices</C>, then the labels of the vertices are set to the value of
     this component.<P/>
 
-    Induced subdigraphs, and other operations which create new digraphs from
+    Induced subdigraphs, and some other operations which create new digraphs from
     old ones, inherit their labels from their parents.
 
     <Example><![CDATA[
-gap> gr := DigraphFromDigraph6String("&DHUEe_");
+gap> D := DigraphFromDigraph6String("&DHUEe_");
 <immutable digraph with 5 vertices, 11 edges>
-gap> DigraphVertexLabel(gr, 3);
+gap> DigraphVertexLabel(D, 3);
 3
-gap> gr := Digraph(["a", "b", "c"], [], []);
+gap> D := Digraph(["a", "b", "c"], [], []);
 <immutable empty digraph with 3 vertices>
-gap> DigraphVertexLabel(gr, 2);
+gap> DigraphVertexLabel(D, 2);
 "b"
-gap> SetDigraphVertexLabel(gr, 2, "d");
-gap> DigraphVertexLabel(gr, 2);
+gap> SetDigraphVertexLabel(D, 2, "d");
+gap> DigraphVertexLabel(D, 2);
 "d"
-gap> gr := InducedSubdigraph(gr, [1, 2]);
+gap> D := InducedSubdigraph(D, [1, 2]);
 <immutable empty digraph with 2 vertices>
-gap> DigraphVertexLabel(gr, 2);
-"d"]]></Example>
+gap> DigraphVertexLabel(D, 2);
+"d"
+gap> D := Digraph(IsMutableDigraph, ["e", "f", "g"], [], []);
+<mutable empty digraph with 3 vertices>
+gap> DigraphVertexLabel(D, 1);
+"e"
+gap> SetDigraphVertexLabel(D, 1, "h");
+gap> DigraphVertexLabel(D, 1);
+"h"
+gap> InducedSubdigraph(D, [1, 2]);
+<mutable empty digraph with 2 vertices>
+gap> DigraphVertexLabel(D, 1);
+"h"
+]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -73,21 +85,31 @@ gap> DigraphVertexLabel(gr, 2);
     old ones, inherit their labels from their parents.
 
     <Example><![CDATA[
-gap> gr := DigraphFromDigraph6String("&DHUEe_");
+gap> D := DigraphFromDigraph6String("&DHUEe_");
 <immutable digraph with 5 vertices, 11 edges>
-gap> DigraphVertexLabels(gr);
+gap> DigraphVertexLabels(D);
 [ 1 .. 5 ]
-gap> gr := Digraph(["a", "b", "c"], [], []);
+gap> D := Digraph(["a", "b", "c"], [], []);
 <immutable empty digraph with 3 vertices>
-gap> DigraphVertexLabels(gr);
+gap> DigraphVertexLabels(D);
 [ "a", "b", "c" ]
-gap> SetDigraphVertexLabel(gr, 2, "d");
-gap> DigraphVertexLabels(gr);
+gap> SetDigraphVertexLabel(D, 2, "d");
+gap> DigraphVertexLabels(D);
 [ "a", "d", "c" ]
-gap> gr := InducedSubdigraph(gr, [1, 3]);
+gap> D := InducedSubdigraph(D, [1, 3]);
 <immutable empty digraph with 2 vertices>
-gap> DigraphVertexLabels(gr);
-[ "a", "c" ]]]></Example>
+gap> DigraphVertexLabels(D);
+[ "a", "c" ]
+gap> D := Digraph(IsMutableDigraph, ["e", "f", "g"], [], []);
+<mutable empty digraph with 3 vertices>
+gap> SetDigraphVertexLabels(D, ["h", "i", "j"]);
+gap> DigraphVertexLabels(D);
+[ "h", "i", "j" ]
+gap> InducedSubdigraph(D, [1, 3]);
+<mutable empty digraph with 2 vertices>
+gap> DigraphVertexLabels(D);
+[ "h", "j" ]
+]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -112,17 +134,29 @@ gap> DigraphVertexLabels(gr);
     See also <Ref Oper="DigraphEdgeLabels"/>.
 
     <Example><![CDATA[
-gap> gr := DigraphFromDigraph6String("&DHUEe_");
+gap> D := DigraphFromDigraph6String("&DHUEe_");
 <immutable digraph with 5 vertices, 11 edges>
-gap> DigraphEdgeLabel(gr, 3, 1);
+gap> DigraphEdgeLabel(D, 3, 1);
 1
-gap> SetDigraphEdgeLabel(gr, 2, 5, [42]);
-gap> DigraphEdgeLabel(gr, 2, 5);
+gap> SetDigraphEdgeLabel(D, 2, 5, [42]);
+gap> DigraphEdgeLabel(D, 2, 5);
 [ 42 ]
-gap> gr := InducedSubdigraph(gr, [2, 5]);
+gap> D := InducedSubdigraph(D, [2, 5]);
 <immutable digraph with 2 vertices, 3 edges>
-gap> DigraphEdgeLabel(gr, 1, 2);
-[ 42 ]]]></Example>
+gap> DigraphEdgeLabel(D, 1, 2);
+[ 42 ]
+gap> D := ChainDigraph(IsMutableDigraph, 5);
+<mutable digraph with 5 vertices, 4 edges>
+gap> DigraphEdgeLabel(D, 2, 3);
+1
+gap> SetDigraphEdgeLabel(D, 4, 5, [1729]);
+gap> DigraphEdgeLabel(D, 4, 5);
+[ 1729 ]
+gap> InducedSubdigraph(D, [4, 5]);
+<mutable digraph with 2 vertices, 1 edge>
+gap> DigraphEdgeLabel(D, 1, 2);
+[ 1729 ]
+]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>
@@ -158,19 +192,32 @@ gap> DigraphEdgeLabel(gr, 1, 2);
     from old ones, inherit their labels from their parents.
 
     <Example><![CDATA[
-gap> gr := DigraphFromDigraph6String("&DHUEe_");
+gap> D := DigraphFromDigraph6String("&DHUEe_");
 <immutable digraph with 5 vertices, 11 edges>
-gap> DigraphEdgeLabels(gr);
+gap> DigraphEdgeLabels(D);
 [ [ 1 ], [ 1, 1, 1 ], [ 1 ], [ 1, 1, 1 ], [ 1, 1, 1 ] ]
-gap> SetDigraphEdgeLabel(gr, 2, 1, "d");
-gap> DigraphEdgeLabels(gr);
+gap> SetDigraphEdgeLabel(D, 2, 1, "d");
+gap> DigraphEdgeLabels(D);
 [ [ 1 ], [ "d", 1, 1 ], [ 1 ], [ 1, 1, 1 ], [ 1, 1, 1 ] ]
-gap> gr := InducedSubdigraph(gr, [1, 2, 3]);
+gap> D := InducedSubdigraph(D, [1, 2, 3]);
 <immutable digraph with 3 vertices, 4 edges>
-gap> DigraphEdgeLabels(gr);
+gap> DigraphEdgeLabels(D);
 [ [ 1 ], [ "d", 1 ], [ 1 ] ]
-gap> OutNeighbours(gr);
+gap> OutNeighbours(D);
 [ [ 3 ], [ 1, 3 ], [ 1 ] ]
+gap> D := CompleteBipartiteDigraph(IsMutableDigraph, 2, 3);
+<mutable digraph with 5 vertices, 12 edges>
+gap> DigraphEdgeLabels(D);
+[ [ 1, 1, 1 ], [ 1, 1, 1 ], [ 1, 1 ], [ 1, 1 ], [ 1, 1 ] ]
+gap> SetDigraphEdgeLabel(D, 2, 4, "a");
+gap> DigraphEdgeLabels(D);
+[ [ 1, 1, 1 ], [ 1, "a", 1 ], [ 1, 1 ], [ 1, 1 ], [ 1, 1 ] ]
+gap> InducedSubdigraph(D, [1, 2, 3, 4]);
+<mutable digraph with 4 vertices, 8 edges>
+gap> DigraphEdgeLabels(D);
+[ [ 1, 1 ], [ 1, "a" ], [ 1, 1 ], [ 1, 1 ] ]
+gap> OutNeighbors(D);
+[ [ 3, 4 ], [ 3, 4 ], [ 1, 2 ], [ 1, 2 ] ]
 ]]></Example>
   </Description>
 </ManSection>

--- a/gap/display.gi
+++ b/gap/display.gi
@@ -216,6 +216,7 @@ function(D)
   if not IsPartialOrderDigraph(D) then
     ErrorNoReturn("the argument <D> must be a partial order digraph,");
   fi;
+  D := DigraphMutableCopyIfMutable(D);
   return DotDigraph(DigraphReflexiveTransitiveReduction(D));
 end);
 


### PR DESCRIPTION
While working on display.xml I came across a bug in `DotPartialOrderDigraph` - it modifies mutable digraphs in place instead of making a copy. This PR fixes it.