### PR TITLE
Improve String method for a digraph, to give shorter strings

### DIFF
--- a/doc/io.xml
+++ b/doc/io.xml
@@ -162,15 +162,10 @@ gap> ReadDigraphs(file, 9);
   <Oper Name="String" Arg="digraph"/>
   <Returns>A string.</Returns>
   <Description>
-    Returns a string <C>string</C> containing a function and a
-    representation of <A>digraph</A> related to that function,
-    such that when the output of <C>Print(string)</C> is run,
-    <A>digraph</A> is returned.<P/>
-
-    If it is shorter than 60 characters, the <C>OutNeighbours</C>
-    representation of <A>digraph</A> is used. Otherwise, the shortest
-    of the <C>Digraph6String</C>, <C>Graph6String</C>,
-    <C>DiSparse6String</C> and <C>Sparse6String</C> are used.<P/>
+    Returns a string of minimal character length <C>string</C>
+    containing a function and a representation of <A>digraph</A>
+    related to that function, such that when the output of
+    <C>Print(string)</C> is run, <A>digraph</A> is returned.<P/>
 
     Note that it is necessary to <C>Print</C> the output of this
     function to be able to copy, paste and run the output to create

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -170,15 +170,13 @@ gap> ReadDigraphs(file, 9);
     Note that it is necessary to <C>Print</C> the output of this
     function to be able to copy, paste and run the output to create
     <A>digraph</A>, due to character escaping in the strings involved.
+    One can also run <C>Print</C> directly on <A>digraph</A> to achieve
+    this.
     <Log><![CDATA[
 gap> D := CycleDigraph(3);
 <immutable cycle digraph with 3 vertices>
-gap> String(D);
-"Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
-gap> Print(last);
-Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);
-gap> Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);
-<immutable digraph with 3 vertices, 3 edges>
+gap> Print(D);
+CycleDigraph(3);
 gap> G := PetersenGraph(IsMutableDigraph);
 <mutable digraph with 10 vertices, 30 edges>
 gap> String(G);

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -159,19 +159,26 @@ gap> ReadDigraphs(file, 9);
 
 <#GAPDoc Label="String">
 <ManSection>
-  <Oper Name="String" Arg="digraph"/>
+  <Attr Name="String" Arg="digraph"/>
+  <Oper Name="PrintString" Arg="digraph"/>
   <Returns>A string.</Returns>
   <Description>
-    Returns a string of minimal character length <C>string</C>
-    containing a function and a representation of <A>digraph</A>
-    related to that function, such that when the output of
-    <C>Print(string)</C> is run, <A>digraph</A> is returned.<P/>
+    Returns a string <C>string</C> such that <C>EvalString(string)</C>
+    is equal to <A>digraph</A>, and has the same immutability.
+    See <Ref Func="EvalString" BookName="ref" />.
+    <P/>
 
-    Note that it is necessary to <C>Print</C> the output of this
-    function to be able to copy, paste and run the output to create
-    <A>digraph</A>, due to character escaping in the strings involved.
-    One can also run <C>Print</C> directly on <A>digraph</A> to achieve
-    this.
+    The methods installed for <C>String</C> make some attempts to
+    ensure that <C>string</C> has as short a length as possible, but
+    there may exist shorter strings that also evaluate to <A>digraph</A>.
+    <P/>
+
+    It is possible that <C>string</C> may contain escaped special
+    characters. To obtain a representation of <A>digraph</A> that
+    can be entered as GAP input, please use
+    <Ref Func="Print" BookName="ref" />.
+    Note that <C>Print</C> for a digraph  delegates to
+    <C>PrintString</C>, which delegates to <C>String</C>.
     <Log><![CDATA[
 gap> D := CycleDigraph(3);
 <immutable cycle digraph with 3 vertices>

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -162,33 +162,30 @@ gap> ReadDigraphs(file, 9);
   <Oper Name="String" Arg="digraph"/>
   <Returns>A string.</Returns>
   <Description>
-    Returns a string <C>string</C> containing a function and a representation of
-    <A>digraph</A> related to that function, such that when <C>Print(string)</C>
-    is run, <A>digraph</A> is returned.<P/>
+    Returns a string <C>string</C> containing a function and a
+    representation of <A>digraph</A> related to that function,
+    such that when the output of <C>Print(string)</C> is run,
+    <A>digraph</A> is returned.<P/>
 
-    If it is shorter than 60 characters, the <C>OutNeighbours</C> representation
-    of <A>digraph</A> is used. Otherwise, the shortest of the
-    <C>Digraph6String</C>, <C>Graph6String</C>, <C>DiSparse6String</C> and
-    <C>Sparse6String</C> are used.<P/>
+    If it is shorter than 60 characters, the <C>OutNeighbours</C>
+    representation of <A>digraph</A> is used. Otherwise, the shortest
+    of the <C>Digraph6String</C>, <C>Graph6String</C>,
+    <C>DiSparse6String</C> and <C>Sparse6String</C> are used.<P/>
 
-    Note that it is necessary to <C>Print</C> the output of this function to
-    be able to copy, paste and run the output to create <A>digraph</A>, due
-    to character escaping in the strings involved.
+    Note that it is necessary to <C>Print</C> the output of this
+    function to be able to copy, paste and run the output to create
+    <A>digraph</A>, due to character escaping in the strings involved.
     <Example><![CDATA[
-gap> D := CycleDigraph(5);
-<immutable cycle digraph with 5 vertices>
+gap> D := CycleDigraph(3);
+<immutable cycle digraph with 3 vertices>
 gap> String(D);
-"Digraph(IsImmutableDigraph, [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 1 ] ])"
-gap> Print(last);
-Digraph(IsImmutableDigraph, [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 1 ] ])
-gap> Digraph(IsImmutableDigraph, [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 1 ] ]);
-<immutable digraph with 5 vertices, 5 edges>
+"Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
+gap> Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);
+<immutable digraph with 3 vertices, 3 edges>
 gap> G := PetersenGraph(IsMutableDigraph);
 <mutable digraph with 10 vertices, 30 edges>
 gap> String(G);
 "DigraphFromGraph6String(IsMutableDigraph, \"IheA@GUAo\");"
-gap> Print(last); 
-DigraphFromGraph6String(IsMutableDigraph, "IheA@GUAo");
 gap> DigraphFromGraph6String(IsMutableDigraph, "IheA@GUAo");
 <mutable digraph with 10 vertices, 30 edges>
 ]]></Example>

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -164,7 +164,7 @@ gap> ReadDigraphs(file, 9);
   <Returns>A string.</Returns>
   <Description>
     Returns a string <C>string</C> such that <C>EvalString(string)</C>
-    is equal to <A>digraph</A>, and has the same immutability.
+    is equal to <A>digraph</A>, and has the same mutability.
     See <Ref Func="EvalString" BookName="ref" />.
     <P/>
 

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -157,6 +157,45 @@ gap> ReadDigraphs(file, 9);
 </ManSection>
 <#/GAPDoc>
 
+<#GAPDoc Label="String">
+<ManSection>
+  <Oper Name="String" Arg="digraph"/>
+  <Returns>A string.</Returns>
+  <Description>
+    Returns a string <C>string</C> containing a function and a representation of
+    <A>digraph</A> related to that function, such that when <C>Print(string)</C>
+    is run, <A>digraph</A> is returned.<P/>
+
+    If it is shorter than 60 characters, the <C>OutNeighbours</C> representation
+    of <A>digraph</A> is used. Otherwise, the shortest of the
+    <C>Digraph6String</C>, <C>Graph6String</C>, <C>DiSparse6String</C> and
+    <C>Sparse6String</C> are used.<P/>
+
+    Note that it is necessary to <C>Print</C> the output of this function to
+    be able to copy, paste and run the output to create <A>digraph</A>, due
+    to character escaping in the strings involved.
+    <Example><![CDATA[
+gap> D := CycleDigraph(5);
+<immutable cycle digraph with 5 vertices>
+gap> String(D);
+"Digraph(IsImmutableDigraph, [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 1 ] ])"
+gap> Print(last);
+Digraph(IsImmutableDigraph, [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 1 ] ])
+gap> Digraph(IsImmutableDigraph, [ [ 2 ], [ 3 ], [ 4 ], [ 5 ], [ 1 ] ]);
+<immutable digraph with 5 vertices, 5 edges>
+gap> G := PetersenGraph(IsMutableDigraph);
+<mutable digraph with 10 vertices, 30 edges>
+gap> String(G);
+"DigraphFromGraph6String(IsMutableDigraph, \"IheA@GUAo\");"
+gap> Print(last); 
+DigraphFromGraph6String(IsMutableDigraph, "IheA@GUAo");
+gap> DigraphFromGraph6String(IsMutableDigraph, "IheA@GUAo");
+<mutable digraph with 10 vertices, 30 edges>
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
 <#GAPDoc Label="DigraphFromGraph6String">
 <ManSection>
   <Oper Name="DigraphFromGraph6String"    Arg="[filt, ]str"/>

--- a/doc/io.xml
+++ b/doc/io.xml
@@ -175,20 +175,24 @@ gap> ReadDigraphs(file, 9);
     Note that it is necessary to <C>Print</C> the output of this
     function to be able to copy, paste and run the output to create
     <A>digraph</A>, due to character escaping in the strings involved.
-    <Example><![CDATA[
+    <Log><![CDATA[
 gap> D := CycleDigraph(3);
 <immutable cycle digraph with 3 vertices>
 gap> String(D);
 "Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
+gap> Print(last);
+Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);
 gap> Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);
 <immutable digraph with 3 vertices, 3 edges>
 gap> G := PetersenGraph(IsMutableDigraph);
 <mutable digraph with 10 vertices, 30 edges>
 gap> String(G);
 "DigraphFromGraph6String(IsMutableDigraph, \"IheA@GUAo\");"
+gap> Print(last);
+DigraphFromGraph6String(IsMutableDigraph, "IheA@GUAo");
 gap> DigraphFromGraph6String(IsMutableDigraph, "IheA@GUAo");
 <mutable digraph with 10 vertices, 30 edges>
-]]></Example>
+]]></Log>
   </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/z-chap9.xml
+++ b/doc/z-chap9.xml
@@ -56,6 +56,7 @@
 	in between.
       </Item>
     </List>
+    <#Include Label="String">
     <#Include Label="DigraphFromGraph6String">
     <#Include Label="Graph6String">
     <#Include Label="DigraphFile">

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -592,20 +592,34 @@ function(D)
                        " )");
 end);
 
-InstallMethod(String, "for an immutable digraph by out-neighbours",
-[IsImmutableDigraph and IsDigraphByOutNeighboursRep],
-function(D)
-  return Concatenation("Digraph( IsImmutableDigraph, ",
-                       String(OutNeighbours(D)),
-                       " )");
-end);
-
 InstallMethod(String, "for a mutable digraph by out-neighbours",
 [IsMutableDigraph and IsDigraphByOutNeighboursRep],
 function(D)
   return Concatenation("Digraph( IsMutableDigraph, ",
                        String(OutNeighbours(D)),
                        " )");
+end);
+
+InstallMethod(String, "for an immutable digraph by out-neighbours",
+[IsImmutableDigraph],
+function(D)
+  local n, streps, lengths, creators_streps, outnbs;
+  outnbs := OutNeighbours(D);
+  if Length(String(outnbs)) <= 60 then
+    return Concatenation("Digraph(", String(outnbs), ")");
+  elif IsSymmetricDigraph(D) then
+    streps := [Graph6String, Sparse6String];
+    creators_streps := ["DigraphFromGraph6String", "DigraphFromSparse6String"];
+  else
+    streps := [Digraph6String, DiSparse6String];
+    creators_streps := ["DigraphFromDigraph6String",
+                        "DigraphFromDiSparse6String"];
+  fi;
+  streps  := List(streps, f -> f(D));
+  lengths := List(streps, s -> Length(s));
+  n   := Position(lengths, Minimum(lengths));
+  return Concatenation(String(creators_streps[n]), "(\"",
+                       streps[n], "\");");
 end);
 
 ########################################################################

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -592,7 +592,7 @@ function(D)
                        " )");
 end);
 
-InstallMethod(String, "for an immutable digraph by out-neighbours",
+InstallMethod(String, "for a digraph",
 [IsDigraph],
 function(D)
   local n, mut, streps, outnbs_rep, lengths, strings, creators_streps;

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -595,26 +595,31 @@ end);
 InstallMethod(String, "for an immutable digraph by out-neighbours",
 [IsDigraph],
 function(D)
-  local n, mut, streps, lengths, creators_streps;
-  if IsImmutableDigraph(D) then
-    mut := "IsImmutableDigraph";
+  local n, mut, streps, outnbs_rep, lengths, strings, creators_streps;
+  if IsMutableDigraph(D) then
+    mut := Concatenation("IsImmutableDigraph", ", ");
   else
-    mut := "IsMutableDigraph";
+    mut := "";
   fi;
   if IsSymmetricDigraph(D) and (not DigraphHasLoops(D)) then
     streps := [Graph6String, Sparse6String];
-    creators_streps := ["DigraphFromGraph6String", "DigraphFromSparse6String"];
+    creators_streps := ["DigraphFromGraph6String",
+                        "DigraphFromSparse6String"];
   else
     streps := [Digraph6String, DiSparse6String];
     creators_streps := ["DigraphFromDigraph6String",
                         "DigraphFromDiSparse6String"];
   fi;
   streps  := List(streps, f -> f(D));
-  lengths := List(streps, s -> Length(s));
-  n   := Position(lengths, Minimum(lengths));
-  return Concatenation(creators_streps[n], "(", mut, ", ", "\"",
-                       ReplacedString(streps[n], "\\", "\\\\"),
-                       "\"", ");");
+  strings := [];
+  for n in [1 .. Length(streps)] do
+    Add(strings, Concatenation(creators_streps[n], "(", mut, ", ", "\"",
+                 ReplacedString(streps[n], "\\", "\\\\"), "\"", ");"));
+  od;
+  outnbs_rep := Concatenation("Digraph(", mut, String(OutNeighbours(D)), ");");
+  Add(strings, String(outnbs_rep));
+  lengths := List(strings, x -> Length(x));
+  return strings[Position(lengths, Minimum(lengths))];
 end);
 
 ########################################################################

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -597,7 +597,7 @@ InstallMethod(String, "for an immutable digraph by out-neighbours",
 function(D)
   local n, mut, streps, outnbs_rep, lengths, strings, creators_streps;
   if IsMutableDigraph(D) then
-    mut := Concatenation("IsImmutableDigraph", ", ");
+    mut := Concatenation("IsMutableDigraph", ", ");
   else
     mut := "";
   fi;
@@ -613,7 +613,7 @@ function(D)
   streps  := List(streps, f -> f(D));
   strings := [];
   for n in [1 .. Length(streps)] do
-    Add(strings, Concatenation(creators_streps[n], "(", mut, ", ", "\"",
+    Add(strings, Concatenation(creators_streps[n], "(", mut, "\"",
                  ReplacedString(streps[n], "\\", "\\\\"), "\"", ");"));
   od;
   outnbs_rep := Concatenation("Digraph(", mut, String(OutNeighbours(D)), ");");

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -576,9 +576,7 @@ function(D)
   return str;
 end);
 
-InstallMethod(PrintString, "for a digraph",
-[IsDigraph],
-D -> String(D));
+InstallMethod(PrintString, "for a digraph", [IsDigraph], String);
 
 InstallMethod(String, "for a digraph",
 [IsDigraph],
@@ -586,11 +584,11 @@ function(D)
   local n, N, i, mut, streps, outnbs_rep, lengths, strings, creators_streps,
         creators_props, props;
   if IsMutableDigraph(D) then
-    mut := Concatenation("IsMutableDigraph", ", ");
+    mut := "IsMutableDigraph, ";
   else
     mut := "";
   fi;
-  if IsSymmetricDigraph(D) and (not DigraphHasLoops(D)) then
+  if IsSymmetricDigraph(D) and not DigraphHasLoops(D) then
     streps := [Graph6String, Sparse6String];
     creators_streps := ["DigraphFromGraph6String",
                         "DigraphFromSparse6String"];
@@ -603,10 +601,10 @@ function(D)
   strings := [];
   for n in [1 .. Length(streps)] do
     Add(strings, Concatenation(creators_streps[n], "(", mut, "\"",
-                 ReplacedString(streps[n], "\\", "\\\\"), "\"", ");"));
+                 ReplacedString(streps[n], "\\", "\\\\"), "\"", ")"));
   od;
 
-  outnbs_rep := Concatenation("Digraph(", mut, String(OutNeighbours(D)), ");");
+  outnbs_rep := Concatenation("Digraph(", mut, String(OutNeighbours(D)), ")");
   Add(strings, String(outnbs_rep));
 
   N              := DigraphNrVertices(D);
@@ -616,7 +614,7 @@ function(D)
                      "EmptyDigraph"];
   for i in [1 .. Length(props)] do
     if props[i](D) then
-      Add(strings, Concatenation(creators_props[i], "(", mut, String(N), ");"));
+      Add(strings, Concatenation(creators_props[i], "(", mut, String(N), ")"));
     fi;
   od;
 

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -595,16 +595,13 @@ end);
 InstallMethod(String, "for an immutable digraph by out-neighbours",
 [IsDigraph],
 function(D)
-  local n, mut, streps, lengths, creators_streps, outnbs;
+  local n, mut, streps, lengths, creators_streps;
   if IsImmutableDigraph(D) then
     mut := "IsImmutableDigraph";
   else
     mut := "IsMutableDigraph";
   fi;
-  outnbs := OutNeighbours(D);
-  if Length(String(outnbs)) <= 60 then
-    return Concatenation("Digraph(", mut, ", ", String(outnbs), ")");
-  elif IsSymmetricDigraph(D) then
+  if IsSymmetricDigraph(D) and (not DigraphHasLoops(D)) then
     streps := [Graph6String, Sparse6String];
     creators_streps := ["DigraphFromGraph6String", "DigraphFromSparse6String"];
   else

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -592,21 +592,18 @@ function(D)
                        " )");
 end);
 
-InstallMethod(String, "for a mutable digraph by out-neighbours",
-[IsMutableDigraph and IsDigraphByOutNeighboursRep],
-function(D)
-  return Concatenation("Digraph( IsMutableDigraph, ",
-                       String(OutNeighbours(D)),
-                       " )");
-end);
-
 InstallMethod(String, "for an immutable digraph by out-neighbours",
-[IsImmutableDigraph],
+[IsDigraph],
 function(D)
-  local n, streps, lengths, creators_streps, outnbs;
+  local n, mut, streps, lengths, creators_streps, outnbs;
+  if IsImmutableDigraph(D) then
+    mut := "IsImmutableDigraph";
+  else
+    mut := "IsMutableDigraph";
+  fi;
   outnbs := OutNeighbours(D);
   if Length(String(outnbs)) <= 60 then
-    return Concatenation("Digraph(", String(outnbs), ")");
+    return Concatenation("Digraph(", mut, ", ", String(outnbs), ")");
   elif IsSymmetricDigraph(D) then
     streps := [Graph6String, Sparse6String];
     creators_streps := ["DigraphFromGraph6String", "DigraphFromSparse6String"];
@@ -618,8 +615,9 @@ function(D)
   streps  := List(streps, f -> f(D));
   lengths := List(streps, s -> Length(s));
   n   := Position(lengths, Minimum(lengths));
-  return Concatenation(String(creators_streps[n]), "(\"",
-                       streps[n], "\");");
+  return Concatenation(creators_streps[n], "(", mut, ", ", "\"",
+                       ReplacedString(streps[n], "\\", "\\\\"),
+                       "\"", ");");
 end);
 
 ########################################################################

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -576,21 +576,9 @@ function(D)
   return str;
 end);
 
-InstallMethod(PrintString, "for an immutable digraph by out-neighbours",
-[IsImmutableDigraph and IsDigraphByOutNeighboursRep],
-function(D)
-  return Concatenation("Digraph( IsImmutableDigraph, ",
-                       PrintString(OutNeighbours(D)),
-                       " )");
-end);
-
-InstallMethod(PrintString, "for a mutable digraph by out-neighbours",
-[IsMutableDigraph and IsDigraphByOutNeighboursRep],
-function(D)
-  return Concatenation("Digraph( IsMutableDigraph, ",
-                       PrintString(OutNeighbours(D)),
-                       " )");
-end);
+InstallMethod(PrintString, "for a digraph",
+[IsDigraph],
+D -> String(D));
 
 InstallMethod(String, "for a digraph",
 [IsDigraph],

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -583,7 +583,8 @@ D -> String(D));
 InstallMethod(String, "for a digraph",
 [IsDigraph],
 function(D)
-  local n, mut, streps, outnbs_rep, lengths, strings, creators_streps;
+  local n, N, i, mut, streps, outnbs_rep, lengths, strings, creators_streps,
+        creators_props, props;
   if IsMutableDigraph(D) then
     mut := Concatenation("IsMutableDigraph", ", ");
   else
@@ -604,8 +605,21 @@ function(D)
     Add(strings, Concatenation(creators_streps[n], "(", mut, "\"",
                  ReplacedString(streps[n], "\\", "\\\\"), "\"", ");"));
   od;
+
   outnbs_rep := Concatenation("Digraph(", mut, String(OutNeighbours(D)), ");");
   Add(strings, String(outnbs_rep));
+
+  N              := DigraphNrVertices(D);
+  props          := [IsCycleDigraph, IsCompleteDigraph, IsChainDigraph,
+                     IsEmptyDigraph];
+  creators_props := ["CycleDigraph", "CompleteDigraph", "ChainDigraph",
+                     "EmptyDigraph"];
+  for i in [1 .. Length(props)] do
+    if props[i](D) then
+      Add(strings, Concatenation(creators_props[i], "(", mut, String(N), ");"));
+    fi;
+  od;
+
   lengths := List(strings, x -> Length(x));
   return strings[Position(lengths, Minimum(lengths))];
 end);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1643,6 +1643,36 @@ gap> IsHamiltonianDigraph(D);;
 gap> D;
 <immutable Hamiltonian digraph with 2 vertices, 2 edges>
 
+# String
+gap> D := GeneralisedPetersenGraph(8, 2);
+<immutable symmetric digraph with 16 vertices, 48 edges>
+gap> String(D);
+"DigraphFromGraph6String(\"OhCGKE?O@@AAAA@@?SOAa\");"
+gap> Print(last);
+DigraphFromGraph6String("OhCGKE?O@@AAAA@@?SOAa");
+gap> G := DigraphFromGraph6String("OhCGKE?O@@AAAA@@?SOAa");
+<immutable digraph with 16 vertices, 48 edges>
+gap> IsIsomorphicDigraph(D, G);
+true
+gap> D := CycleDigraph(IsMutableDigraph, 20);
+<mutable digraph with 20 vertices, 20 edges>
+gap> String(D);
+"DigraphFromDiSparse6String(IsMutableDigraph, \".Sr?s_`abcdefghijklmnopq\");"
+gap> Print(last);
+DigraphFromDiSparse6String(IsMutableDigraph, ".Sr?s_`abcdefghijklmnopq");
+gap> G := DigraphFromDiSparse6String(IsMutableDigraph, ".Sr?s_`abcdefghijklmnopq");
+<mutable digraph with 20 vertices, 20 edges>
+gap> IsIsomorphicDigraph(D, G);
+true
+gap> D := CycleDigraph(3);
+<immutable cycle digraph with 3 vertices>
+gap> String(D);
+"Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
+gap> D := EmptyDigraph(0);
+<immutable empty digraph with 0 vertices>
+gap> String(D);
+"Digraph([ ]);"
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(G);
 gap> Unbind(adj);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1030,7 +1030,7 @@ gap> gr2 := DigraphCopy(gr1);
 gap> String(gr2);
 "Digraph([ ]);"
 gap> PrintString(gr2);
-"Digraph( IsImmutableDigraph, [ ] )"
+"Digraph([ ]);"
 
 # Tests for DigraphCopy originally located in oper.tst
 gap> gr := Digraph([[6, 1, 2, 3], [6], [2, 2, 3], [1, 1], [6, 5],
@@ -1213,7 +1213,7 @@ gap> list := [[1, 2], []];
 gap> D := DigraphNC(IsMutableDigraph, list);
 <mutable digraph with 2 vertices, 2 edges>
 gap> PrintString(D);
-"Digraph( IsMutableDigraph, [ [ 1, 2 ], [ ] ] )"
+"Digraph(IsMutableDigraph, [ [ 1, 2 ], [ ] ]);"
 gap> EvalString(String(D)) = D;
 true
 gap> DigraphByAdjacencyMatrix(IsMutableDigraph, []);
@@ -1647,11 +1647,15 @@ gap> D;
 gap> D := CycleDigraph(3);
 <immutable cycle digraph with 3 vertices>
 gap> String(D);
-"Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
-gap> D := CycleDigraph(16);
-<immutable cycle digraph with 16 vertices>
+"CycleDigraph(3);"
+gap> D := CycleDigraph(IsMutableDigraph, 16);
+<mutable digraph with 16 vertices, 16 edges>
+gap> DigraphAddVertex(D, 17);
+<mutable digraph with 17 vertices, 16 edges>
+gap> DigraphAddEdge(D, [17, 1]);
+<mutable digraph with 17 vertices, 17 edges>
 gap> String(D);
-"DigraphFromDiSparse6String(\".On?o_`abcdefghijklm\");"
+"DigraphFromDiSparse6String(IsMutableDigraph, \".Pn?_p_`abcdefghijklm\");"
 gap> G := CompleteBipartiteDigraph(IsMutableDigraph, 5, 5);
 <mutable digraph with 10 vertices, 50 edges>
 gap> String(G);
@@ -1660,6 +1664,10 @@ gap> D := Digraph([]);
 <immutable empty digraph with 0 vertices>
 gap> String(D);
 "Digraph([ ]);"
+gap> D := CompleteDigraph(7);
+<immutable complete digraph with 7 vertices>
+gap> String(D);
+"CompleteDigraph(7);"
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(G);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1028,9 +1028,9 @@ gap> gr1 := EmptyDigraph(0);;
 gap> gr2 := DigraphCopy(gr1);
 <immutable empty digraph with 0 vertices>
 gap> String(gr2);
-"Digraph([ ]);"
+"Digraph([ ])"
 gap> PrintString(gr2);
-"Digraph([ ]);"
+"Digraph([ ])"
 
 # Tests for DigraphCopy originally located in oper.tst
 gap> gr := Digraph([[6, 1, 2, 3], [6], [2, 2, 3], [1, 1], [6, 5],
@@ -1213,7 +1213,7 @@ gap> list := [[1, 2], []];
 gap> D := DigraphNC(IsMutableDigraph, list);
 <mutable digraph with 2 vertices, 2 edges>
 gap> PrintString(D);
-"Digraph(IsMutableDigraph, [ [ 1, 2 ], [ ] ]);"
+"Digraph(IsMutableDigraph, [ [ 1, 2 ], [ ] ])"
 gap> EvalString(String(D)) = D;
 true
 gap> DigraphByAdjacencyMatrix(IsMutableDigraph, []);
@@ -1647,7 +1647,7 @@ gap> D;
 gap> D := CycleDigraph(3);
 <immutable cycle digraph with 3 vertices>
 gap> String(D);
-"CycleDigraph(3);"
+"CycleDigraph(3)"
 gap> D := CycleDigraph(IsMutableDigraph, 16);
 <mutable digraph with 16 vertices, 16 edges>
 gap> DigraphAddVertex(D, 17);
@@ -1655,19 +1655,25 @@ gap> DigraphAddVertex(D, 17);
 gap> DigraphAddEdge(D, [17, 1]);
 <mutable digraph with 17 vertices, 17 edges>
 gap> String(D);
-"DigraphFromDiSparse6String(IsMutableDigraph, \".Pn?_p_`abcdefghijklm\");"
+"DigraphFromDiSparse6String(IsMutableDigraph, \".Pn?_p_`abcdefghijklm\")"
 gap> G := CompleteBipartiteDigraph(IsMutableDigraph, 5, 5);
 <mutable digraph with 10 vertices, 50 edges>
 gap> String(G);
-"DigraphFromGraph6String(IsMutableDigraph, \"I?B~vrw}?\");"
+"DigraphFromGraph6String(IsMutableDigraph, \"I?B~vrw}?\")"
 gap> D := Digraph([]);
 <immutable empty digraph with 0 vertices>
 gap> String(D);
-"Digraph([ ]);"
+"Digraph([ ])"
 gap> D := CompleteDigraph(7);
 <immutable complete digraph with 7 vertices>
 gap> String(D);
-"CompleteDigraph(7);"
+"CompleteDigraph(7)"
+gap> D := EvalString(
+> "DigraphFromDigraph6String(\"&N~~nf~v~~~~u\\\\mvf~vvv~Zzv|vNxuxVw~|v~Lro\")"
+> );
+<immutable digraph with 15 vertices, 182 edges>
+gap> String(D);
+"DigraphFromDigraph6String(\"&N~~nf~v~~~~u\\\\mvf~vvv~Zzv|vNxuxVw~|v~Lro\")"
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(G);

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1028,7 +1028,7 @@ gap> gr1 := EmptyDigraph(0);;
 gap> gr2 := DigraphCopy(gr1);
 <immutable empty digraph with 0 vertices>
 gap> String(gr2);
-"Digraph( IsImmutableDigraph, [ ] )"
+"Digraph([ ]);"
 gap> PrintString(gr2);
 "Digraph( IsImmutableDigraph, [ ] )"
 
@@ -1644,31 +1644,19 @@ gap> D;
 <immutable Hamiltonian digraph with 2 vertices, 2 edges>
 
 # String
-gap> D := GeneralisedPetersenGraph(8, 2);
-<immutable symmetric digraph with 16 vertices, 48 edges>
-gap> String(D);
-"DigraphFromGraph6String(\"OhCGKE?O@@AAAA@@?SOAa\");"
-gap> Print(last);
-DigraphFromGraph6String("OhCGKE?O@@AAAA@@?SOAa");
-gap> G := DigraphFromGraph6String("OhCGKE?O@@AAAA@@?SOAa");
-<immutable digraph with 16 vertices, 48 edges>
-gap> IsIsomorphicDigraph(D, G);
-true
-gap> D := CycleDigraph(IsMutableDigraph, 20);
-<mutable digraph with 20 vertices, 20 edges>
-gap> String(D);
-"DigraphFromDiSparse6String(IsMutableDigraph, \".Sr?s_`abcdefghijklmnopq\");"
-gap> Print(last);
-DigraphFromDiSparse6String(IsMutableDigraph, ".Sr?s_`abcdefghijklmnopq");
-gap> G := DigraphFromDiSparse6String(IsMutableDigraph, ".Sr?s_`abcdefghijklmnopq");
-<mutable digraph with 20 vertices, 20 edges>
-gap> IsIsomorphicDigraph(D, G);
-true
 gap> D := CycleDigraph(3);
 <immutable cycle digraph with 3 vertices>
 gap> String(D);
 "Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
-gap> D := EmptyDigraph(0);
+gap> D := CycleDigraph(16);
+<immutable cycle digraph with 16 vertices>
+gap> String(D);
+"DigraphFromDiSparse6String(\".On?o_`abcdefghijklm\");"
+gap> G := CompleteBipartiteDigraph(IsMutableDigraph, 5, 5);
+<mutable digraph with 10 vertices, 50 edges>
+gap> String(G);
+"DigraphFromGraph6String(IsMutableDigraph, \"I?B~vrw}?\");"
+gap> D := Digraph([]);
 <immutable empty digraph with 0 vertices>
 gap> String(D);
 "Digraph([ ]);"

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -25,24 +25,24 @@ gap> Digraph([[2], []]);
 gap> gr := Digraph([[1, 2], [2], []]);
 <immutable digraph with 3 vertices, 3 edges>
 gap> PrintString(gr);
-"DigraphFromDigraph6String(\"&Bq?\");"
+"DigraphFromDigraph6String(\"&Bq?\")"
 gap> String(gr);
-"DigraphFromDigraph6String(\"&Bq?\");"
+"DigraphFromDigraph6String(\"&Bq?\")"
 gap> gr := Digraph([[2], [1], [], [3]]);
 <immutable digraph with 4 vertices, 3 edges>
 gap> PrintString(gr);
-"DigraphFromDigraph6String(\"&CQ?G\");"
+"DigraphFromDigraph6String(\"&CQ?G\")"
 gap> String(gr);
-"DigraphFromDigraph6String(\"&CQ?G\");"
+"DigraphFromDigraph6String(\"&CQ?G\")"
 gap> r := rec(DigraphVertices := [1, 2, 3], 
 >             DigraphSource := [1, 2], 
 >             DigraphRange := [2, 3]);;
 gap> gr := Digraph(r);
 <immutable digraph with 3 vertices, 2 edges>
 gap> PrintString(gr);
-"ChainDigraph(3);"
+"ChainDigraph(3)"
 gap> String(gr);
-"ChainDigraph(3);"
+"ChainDigraph(3)"
 
 #  DotDigraph and DotSymmetricDigraph
 gap> r := rec(DigraphVertices := [1 .. 3], DigraphSource := [1, 1, 1, 1],

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -27,13 +27,13 @@ gap> gr := Digraph([[1, 2], [2], []]);
 gap> PrintString(gr);
 "Digraph( IsImmutableDigraph, [ [ 1, 2 ], [ 2 ], [ ] ] )"
 gap> String(gr);
-"Digraph( IsImmutableDigraph, [ [ 1, 2 ], [ 2 ], [ ] ] )"
+"DigraphFromDigraph6String(\"&Bq?\");"
 gap> gr := Digraph([[2], [1], [], [3]]);
 <immutable digraph with 4 vertices, 3 edges>
 gap> PrintString(gr);
 "Digraph( IsImmutableDigraph, [ [ 2 ], [ 1 ], [ ], [ 3 ] ] )"
 gap> String(gr);
-"Digraph( IsImmutableDigraph, [ [ 2 ], [ 1 ], [ ], [ 3 ] ] )"
+"DigraphFromDigraph6String(\"&CQ?G\");"
 gap> r := rec(DigraphVertices := [1, 2, 3], 
 >             DigraphSource := [1, 2], 
 >             DigraphRange := [2, 3]);;
@@ -42,7 +42,7 @@ gap> gr := Digraph(r);
 gap> PrintString(gr);
 "Digraph( IsImmutableDigraph, [ [ 2 ], [ 3 ], [ ] ] )"
 gap> String(gr);
-"Digraph( IsImmutableDigraph, [ [ 2 ], [ 3 ], [ ] ] )"
+"Digraph([ [ 2 ], [ 3 ], [ ] ]);"
 
 #  DotDigraph and DotSymmetricDigraph
 gap> r := rec(DigraphVertices := [1 .. 3], DigraphSource := [1, 1, 1, 1],

--- a/tst/standard/display.tst
+++ b/tst/standard/display.tst
@@ -25,13 +25,13 @@ gap> Digraph([[2], []]);
 gap> gr := Digraph([[1, 2], [2], []]);
 <immutable digraph with 3 vertices, 3 edges>
 gap> PrintString(gr);
-"Digraph( IsImmutableDigraph, [ [ 1, 2 ], [ 2 ], [ ] ] )"
+"DigraphFromDigraph6String(\"&Bq?\");"
 gap> String(gr);
 "DigraphFromDigraph6String(\"&Bq?\");"
 gap> gr := Digraph([[2], [1], [], [3]]);
 <immutable digraph with 4 vertices, 3 edges>
 gap> PrintString(gr);
-"Digraph( IsImmutableDigraph, [ [ 2 ], [ 1 ], [ ], [ 3 ] ] )"
+"DigraphFromDigraph6String(\"&CQ?G\");"
 gap> String(gr);
 "DigraphFromDigraph6String(\"&CQ?G\");"
 gap> r := rec(DigraphVertices := [1, 2, 3], 
@@ -40,9 +40,9 @@ gap> r := rec(DigraphVertices := [1, 2, 3],
 gap> gr := Digraph(r);
 <immutable digraph with 3 vertices, 2 edges>
 gap> PrintString(gr);
-"Digraph( IsImmutableDigraph, [ [ 2 ], [ 3 ], [ ] ] )"
+"ChainDigraph(3);"
 gap> String(gr);
-"Digraph([ [ 2 ], [ 3 ], [ ] ]);"
+"ChainDigraph(3);"
 
 #  DotDigraph and DotSymmetricDigraph
 gap> r := rec(DigraphVertices := [1 .. 3], DigraphSource := [1, 1, 1, 1],


### PR DESCRIPTION
This pull request improves the `String` method for Digraphs, as suggested in #233. With these changes, for a digraph `D`, `String(D)` returns a string `str` of minimal length such that when the output of `Print(str)` is run, `D` is returned. This is advantageous in that a user need no longer compare the length of the `OutNeighbours` representation, the `Digraph6String` representation, the `DiSparse6String` representation, etc. For example,
~~~
gap> D := CycleDigraph(IsMutableDigraph, 20);
<mutable digraph with 20 vertices, 20 edges>
gap> String(D);
"DigraphFromDiSparse6String(IsMutableDigraph, \".Sr?s_`abcdefghijklmnopq\");"
gap> Print(last);
DigraphFromDiSparse6String(IsMutableDigraph, ".Sr?s_`abcdefghijklmnopq");
gap> DigraphFromDiSparse6String(IsMutableDigraph, ".Sr?s_`abcdefghijklmnopq");
<mutable digraph with 20 vertices, 20 edges>
~~~

~~~
gap> D := CycleDigraph(3);
<immutable cycle digraph with 3 vertices>
gap> String(D);
"Digraph([ [ 2 ], [ 3 ], [ 1 ] ]);"
~~~