### PR TITLE
Fix ViewString for known non-complete digraphs

### DIFF
--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -449,7 +449,7 @@ function(D)
     elif HasIsChainDigraph(D) and IsChainDigraph(D) then
       Append(str, "chain ");
       display_nredges := false;
-    elif HasIsCompleteDigraph(D) and IsDigraph(D) then
+    elif HasIsCompleteDigraph(D) and IsCompleteDigraph(D) then
       Append(str, "complete ");
       display_nredges := false;
     elif HasIsCompleteBipartiteDigraph(D) and IsCompleteBipartiteDigraph(D) then

--- a/tst/testinstall.tst
+++ b/tst/testinstall.tst
@@ -328,6 +328,13 @@ gap> D := NullDigraph(IsMutableDigraph, 10);
 gap> MakeImmutable(D);
 <immutable empty digraph with 10 vertices>
 
+# Issue 272: ViewString for known non-complete digraphs
+gap> D := Digraph([[2], []]);;
+gap> IsCompleteDigraph(D);
+false
+gap> D;
+<immutable digraph with 2 vertices, 1 edge>
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(gr2);
 gap> Unbind(gr);


### PR DESCRIPTION
The problem was that there was `IsDigraph(D)` written rather than `IsCompleteDigraph(D)`.

Closes #272.