### PR TITLE
kernel: optimize OutNeighbours

### DIFF
--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -73,9 +73,15 @@ Int DigraphNrVertices(Obj D) {
   return LEN_LIST(FuncOutNeighbours(0L, D));
 }
 
+static Int RNamOutNeighbours        = 0;
+
+
 Obj FuncOutNeighbours(Obj self, Obj D) {
-  if (IsbPRec(D, RNamName("OutNeighbours"))) {
-    return ElmPRec(D, RNamName("OutNeighbours"));
+  if (!RNamOutNeighbours) {
+    RNamOutNeighbours = RNamName("OutNeighbours");
+  }
+  if (IsbPRec(D, RNamOutNeighbours)) {
+    return ElmPRec(D, RNamOutNeighbours);
   } else {
     ErrorQuit(
         "the `OutNeighbours` component is not set for this digraph,", 0L, 0L);


### PR DESCRIPTION
I'm writing some code that involves a very large number of calls to the homomorphism finding code for relatively small digraphs. One things that stood out when profiling that code was that `DigraphNrVertices` uses more time than maybe necessary. This PR optimises the C code for `DigraphNrVertices`.

In the `stable-1.0` branch:
~~~~
gap> D := CompleteDigraph(2);;
gap> for i in [1 .. 100000] do
> HomomorphismDigraphsFinder(D, D, fail, [], 1, 2, 0, [1, 2],
> [], [[1, 2]], [[1, 2]]);
> od;
gap> time;
1205
~~~~

with this PR:

~~~~
gap> D := CompleteDigraph(2);;
gap> for i in [1 .. 100000] do
> HomomorphismDigraphsFinder(D, D, fail, [], 1, 2, 0, [1, 2],
> [], [[1, 2]], [[1, 2]]);
> od;
gap> time;
1073
~~~~

a modest saving, but a saving nonetheless.
