### PR TITLE
No malloc bliss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ missing
 *.swo
 coverage
 .ipynb_checkpoints
+bliss
+*.a

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -26,7 +26,7 @@ _STANDREWSCS := Concatenation(["Jack Cole Building, North Haugh, ",
 SetPackageInfo(rec(
 PackageName := "Digraphs",
 Subtitle := "Graphs, digraphs, and multidigraphs in GAP",
-Version := "1.0.3",
+Version := "1.0.4dev",
 Date := "29/11/2019",  # dd/mm/yyyy format
 License := "GPL-3.0-or-later",
 ArchiveFormats := ".tar.gz",

--- a/extern/bliss-0.73/.clang-format
+++ b/extern/bliss-0.73/.clang-format
@@ -1,0 +1,104 @@
+---
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true 
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CompactNamespaces: false
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:  ['RANGES_FOR', 'FOREACH']
+IncludeBlocks: Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+Language:        Cpp
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 200
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 100
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp03
+TabWidth:        2
+UseTab:          Never
+...
+

--- a/extern/bliss-0.73/bignum.hh
+++ b/extern/bliss-0.73/bignum.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/bliss.cc
+++ b/extern/bliss-0.73/bliss.cc
@@ -10,9 +10,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -52,11 +52,11 @@ static void
 usage(FILE* const fp, const char* argv0)
 {
   const char* program_name;
-  
+
   program_name = rindex(argv0, '/');
-  
+
   if(program_name) program_name++;
-  else program_name = argv0;  
+  else program_name = argv0;
   if(!program_name or *program_name == 0) program_name = "bliss";
 
   fprintf(fp, "bliss version %s (compiled "__DATE__")\n", bliss_digraphs::version);
@@ -187,7 +187,7 @@ main(const int argc, const char** argv)
   bliss_digraphs::AbstractGraph* g = 0;
 
   parse_options(argc, argv);
-  
+
   /* Parse splitting heuristics */
   bliss_digraphs::Digraph::SplittingHeuristic shs_directed = bliss_digraphs::Digraph::shs_fsm;
   bliss_digraphs::Graph::SplittingHeuristic shs_undirected = bliss_digraphs::Graph::shs_fsm;
@@ -246,13 +246,13 @@ main(const int argc, const char** argv)
       /* Read undirected graph in the DIMACS format */
       g = bliss_digraphs::Graph::read_dimacs(infile);
     }
-  
+
   if(infile != stdin)
     fclose(infile);
 
   if(!g)
     _fatal("Failed to read the graph, aborting");
-  
+
   if(verbose_level >= 2)
     {
       fprintf(verbstr, "Graph read in %.2f seconds\n", timer.get_duration());

--- a/extern/bliss-0.73/bliss.cc
+++ b/extern/bliss-0.73/bliss.cc
@@ -59,7 +59,7 @@ usage(FILE* const fp, const char* argv0)
   else program_name = argv0;
   if(!program_name or *program_name == 0) program_name = "bliss";
 
-  fprintf(fp, "bliss version %s (compiled "__DATE__")\n", bliss_digraphs::version);
+//  fprintf(fp, "bliss version %s (compiled "__DATE__")\n", bliss_digraphs::version);
   fprintf(fp, "Copyright 2003-2015 Tommi Junttila\n");
   fprintf(fp,
 "\n"
@@ -281,15 +281,16 @@ main(const int argc, const char** argv)
   else
     {
       /* Canonical labeling and automorphism group */
-      const unsigned int* cl = g->canonical_form(stats, &report_aut, stdout);
+      bliss_digraphs::uint_pointer_to_const_substitute cl
+          = g->canonical_form(stats, &report_aut, stdout);
 
       fprintf(stdout, "Canonical labeling: ");
-      bliss_digraphs::print_permutation(stdout, g->get_nof_vertices(), cl, 1);
+      bliss_digraphs::print_permutation(stdout, g->get_nof_vertices(), &(*cl), 1);
       fprintf(stdout, "\n");
 
       if(opt_output_can_file)
 	{
-	  bliss_digraphs::AbstractGraph* cf = g->permute(cl);
+	  bliss_digraphs::AbstractGraph* cf = g->permute(&(*cl));
 	  FILE* const fp = fopen(opt_output_can_file, "w");
 	  if(!fp)
 	    _fatal("Cannot open '%s' for outputting the canonical form, aborting", opt_output_can_file);

--- a/extern/bliss-0.73/bliss_C.cc
+++ b/extern/bliss-0.73/bliss_C.cc
@@ -171,7 +171,7 @@ bliss_digraphs_find_canonical_labeling(BlissGraph *graph,
   assert(graph);
   assert(graph->g);
 
-  canonical_labeling = graph->g->canonical_form(s, hook, hook_user_param);
+  canonical_labeling = &(*graph->g->canonical_form(s, hook, hook_user_param));
 
   if(stats)
     {

--- a/extern/bliss-0.73/bliss_C.cc
+++ b/extern/bliss-0.73/bliss_C.cc
@@ -9,9 +9,9 @@ extern "C" {
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -170,7 +170,7 @@ bliss_digraphs_find_canonical_labeling(BlissGraph *graph,
   const unsigned int *canonical_labeling = 0;
   assert(graph);
   assert(graph->g);
-  
+
   canonical_labeling = graph->g->canonical_form(s, hook, hook_user_param);
 
   if(stats)

--- a/extern/bliss-0.73/bliss_C.cc
+++ b/extern/bliss-0.73/bliss_C.cc
@@ -60,6 +60,23 @@ void bliss_digraphs_write_dimacs(BlissGraph *graph, FILE *fp)
 }
 
 extern "C"
+void bliss_digraphs_clear(BlissGraph *graph)
+{
+  assert(graph);
+  assert(graph->g);
+  graph->g->clear();
+}
+
+  extern "C"
+void bliss_digraphs_change_color(BlissGraph* graph, const unsigned int vertex, const unsigned int color)
+{
+  assert(graph);
+  assert(graph->g);
+  graph->g->change_color(vertex, color);
+}
+
+
+extern "C"
 void bliss_digraphs_release(BlissGraph *graph)
 {
   assert(graph);

--- a/extern/bliss-0.73/bliss_C.h
+++ b/extern/bliss-0.73/bliss_C.h
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -102,6 +102,8 @@ void bliss_digraphs_write_dimacs(BlissGraph *graph, FILE *fp);
  */
 void bliss_digraphs_release(BlissGraph *graph);
 
+void bliss_digraphs_clear(BlissGraph *graph);
+void bliss_digraphs_change_color(BlissGraph* graph, const unsigned int vertex, const unsigned int color);
 
 /**
  * Print the graph in graphviz dot format.

--- a/extern/bliss-0.73/defs.cc
+++ b/extern/bliss-0.73/defs.cc
@@ -5,9 +5,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/defs.hh
+++ b/extern/bliss-0.73/defs.hh
@@ -7,9 +7,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/graph.cc
+++ b/extern/bliss-0.73/graph.cc
@@ -264,14 +264,14 @@ AbstractGraph::reset_permutation(uint_pointer_substitute perm)
 }
 
 bool
-AbstractGraph::is_automorphism(uint_pointer_substitute const perm)
+AbstractGraph::is_automorphism(uint_pointer_substitute const)
 {
   _INTERNAL_ERROR();
   return false;
 }
 
 bool
-AbstractGraph::is_automorphism(const std::vector<unsigned int>& perm) const
+AbstractGraph::is_automorphism(const std::vector<unsigned int>&) const
 {
   _INTERNAL_ERROR();
   return false;
@@ -3108,7 +3108,7 @@ Digraph::make_initial_equitable_partition()
  *-------------------------------------------------------------------------*/
 
 Partition::Cell*
-Digraph::find_next_cell_to_be_splitted(Partition::Cell* cell)
+Digraph::find_next_cell_to_be_splitted(Partition::Cell* )
 {
   switch(sh) {
   case shs_f:   return sh_first();
@@ -3437,7 +3437,7 @@ Digraph::initialize_certificate()
  * Slow, mainly for debugging and validation purposes.
  */
 bool
-Digraph::is_automorphism(unsigned int* const perm)
+Digraph::is_automorphism(uint_pointer_substitute const perm)
 {
   std::set<unsigned int, std::less<unsigned int> > edges1;
   std::set<unsigned int, std::less<unsigned int> > edges2;
@@ -4948,7 +4948,7 @@ void Graph::make_initial_equitable_partition()
 
 
 Partition::Cell*
-Graph::find_next_cell_to_be_splitted(Partition::Cell* cell)
+Graph::find_next_cell_to_be_splitted(Partition::Cell*)
 {
   switch(sh) {
   case shs_f:   return sh_first();
@@ -5230,7 +5230,7 @@ Graph::initialize_certificate()
  *-------------------------------------------------------------------------*/
 
 bool
-Graph::is_automorphism(unsigned int* const perm)
+Graph::is_automorphism(uint_pointer_substitute const perm)
 {
   std::set<unsigned int, std::less<unsigned int> > edges1;
   std::set<unsigned int, std::less<unsigned int> > edges2;

--- a/extern/bliss-0.73/graph.cc
+++ b/extern/bliss-0.73/graph.cc
@@ -227,7 +227,7 @@ void
 AbstractGraph::update_labeling(labeling_type labeling)
 {
   const unsigned int N = get_nof_vertices();
-  unsigned int* ep = p.elements;
+  Partition::uint_ptr_type ep = p.elements;
   for(unsigned int i = 0; i < N; i++, ep++)
     labeling[*ep] = i;
 }
@@ -241,7 +241,7 @@ AbstractGraph::update_labeling_and_its_inverse(labeling_type const labeling,
                                                labeling_type const labeling_inv)
 {
   const unsigned int N = get_nof_vertices();
-  unsigned int* ep = p.elements;
+  Partition::uint_ptr_type  ep = p.elements;
   labeling_type clip = labeling_inv;
 
   for(unsigned int i = 0; i < N; ) {
@@ -951,7 +951,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
                       continue;
                     }
                   const std::vector<bool>& mcrs = long_prune_get_mcrs(i);
-                  unsigned int* ep = p.elements + cell->first;
+                  Partition::uint_ptr_type ep = p.elements + cell->first;
                   for(unsigned int j = cell->length; j > 0; j--, ep++) {
                     if(mcrs[*ep] == false)
                       current_node.long_prune_redundant.insert(*ep);
@@ -967,8 +967,8 @@ AbstractGraph::search(const bool canonical, Stats& stats)
        */
       {
         unsigned int  next_split_element = UINT_MAX;
-        unsigned int* next_split_element_pos = 0;
-        unsigned int* ep = p.elements + cell->first;
+        Partition::uint_ptr_type next_split_element_pos;
+        Partition::uint_ptr_type ep = p.elements + cell->first;
         if(current_node.fp_on)
           {
             /* Find the next larger splitting element that is
@@ -2429,7 +2429,7 @@ Digraph::refine_according_to_invariant(unsigned int (*inv)(const Digraph* const 
     {
 
       Partition::Cell* const next_cell = cell->next_nonsingleton;
-      const unsigned int* ep = p.elements + cell->first;
+      Partition::const_uint_ptr_type ep = p.elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
         {
           unsigned int ival = inv(this, *ep);
@@ -2473,7 +2473,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
       eqref_hash.update(cell->length);
     }
 
-  const unsigned int* ep = p.elements + cell->first;
+  Partition::const_uint_ptr_type ep = p.elements + cell->first;
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
@@ -2693,7 +2693,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
         }
       neighbour_cell->max_ival_count++;
 
-      unsigned int* const swap_position =
+      Partition::uint_ptr_type const swap_position =
         p.elements + neighbour_cell->first + neighbour_cell->length -
         neighbour_cell->max_ival_count;
       *p.in_pos[dest_vertex] = *swap_position;
@@ -2732,8 +2732,8 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
             p.aux_split_in_two(neighbour_cell,
                                neighbour_cell->length -
                                neighbour_cell->max_ival_count);
-          unsigned int* ep = p.elements + new_cell->first;
-          unsigned int* const lp = p.elements+new_cell->first+new_cell->length;
+          Partition::uint_ptr_type ep = p.elements + new_cell->first;
+          Partition::uint_ptr_type const lp = p.elements+new_cell->first+new_cell->length;
           while(ep < lp)
             {
               p.element_to_cell_map[*ep] = new_cell;
@@ -2825,7 +2825,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
         }
       neighbour_cell->max_ival_count++;
 
-      unsigned int* const swap_position =
+      Partition::uint_ptr_type const swap_position =
         p.elements + neighbour_cell->first + neighbour_cell->length -
         neighbour_cell->max_ival_count;
       *p.in_pos[dest_vertex] = *swap_position;
@@ -2863,8 +2863,8 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
             p.aux_split_in_two(neighbour_cell,
                                neighbour_cell->length -
                                neighbour_cell->max_ival_count);
-          unsigned int* ep = p.elements + new_cell->first;
-          unsigned int* const lp = p.elements+new_cell->first+new_cell->length;
+          Partition::uint_ptr_type ep = p.elements + new_cell->first;
+          Partition::uint_ptr_type const lp = p.elements+new_cell->first+new_cell->length;
           while(ep < lp) {
             p.element_to_cell_map[*ep] = new_cell;
             ep++;
@@ -2991,7 +2991,7 @@ Digraph::is_equitable() const
       if(cell->is_unit())
         continue;
 
-      unsigned int* ep = p.elements + cell->first;
+      Partition::uint_ptr_type ep = p.elements + cell->first;
       const Vertex& first_vertex = vertices[*ep++];
 
       /* Count outgoing edges of the first vertex for cells */
@@ -3040,7 +3040,7 @@ Digraph::is_equitable() const
       if(cell->is_unit())
         continue;
 
-      unsigned int* ep = p.elements + cell->first;
+      Partition::uint_ptr_type ep = p.elements + cell->first;
       const Vertex& first_vertex = vertices[*ep++];
 
       /* Count incoming edges of the first vertex for cells */
@@ -4516,7 +4516,7 @@ Graph::refine_according_to_invariant(unsigned int (*inv)(const Graph* const g,
 
       Partition::Cell* const next_cell = cell->next_nonsingleton;
 
-      const unsigned int* ep = p.elements + cell->first;
+      Partition::const_uint_ptr_type ep = p.elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
         {
           const unsigned int ival = inv(this, *ep);
@@ -4569,7 +4569,7 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
       eqref_hash.update(cell->length);
     }
 
-  const unsigned int* ep = p.elements + cell->first;
+  Partition::const_uint_ptr_type ep = p.elements + cell->first;
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
@@ -4714,7 +4714,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
         }
       neighbour_cell->max_ival_count++;
 
-      unsigned int * const swap_position =
+      Partition::uint_ptr_type const swap_position =
         p.elements + neighbour_cell->first + neighbour_cell->length -
         neighbour_cell->max_ival_count;
       *p.in_pos[dest_vertex] = *swap_position;
@@ -4748,8 +4748,8 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
             p.aux_split_in_two(neighbour_cell,
                                neighbour_cell->length -
                                neighbour_cell->max_ival_count);
-          unsigned int *ep = p.elements + new_cell->first;
-          unsigned int * const lp = p.elements+new_cell->first+new_cell->length;
+          Partition::uint_ptr_type ep = p.elements + new_cell->first;
+          Partition::uint_ptr_type const lp = p.elements+new_cell->first+new_cell->length;
           while(ep < lp)
             {
               p.element_to_cell_map[*ep] = new_cell;
@@ -4880,7 +4880,7 @@ bool Graph::is_equitable() const
       if(cell->is_unit())
         continue;
 
-      unsigned int *ep = p.elements + cell->first;
+      Partition::uint_ptr_type ep = p.elements + cell->first;
       const Vertex &first_vertex = vertices[*ep++];
 
       /* Count how many edges lead from the first vertex to

--- a/extern/bliss-0.73/graph.cc
+++ b/extern/bliss-0.73/graph.cc
@@ -66,12 +66,6 @@ AbstractGraph::AbstractGraph()
 
 AbstractGraph::~AbstractGraph()
 {
-  for (size_t i = 0; i != long_prune_mcrs.size(); i++) {
-    std::vector<bool> * ptr = long_prune_mcrs[i];
-    if (ptr != NULL) {
-      delete ptr;
-    }
-  }
   if (p.cr_enabled) {
     p.cr_free();
   }
@@ -419,25 +413,23 @@ AbstractGraph::long_prune_init()
 
   long_prune_deallocate();
   long_prune_fixed.resize(N);
-  long_prune_mcrs.resize(N, 0);
+  long_prune_mcrs.resize(N);
   long_prune_begin = 0;
   long_prune_end = 0;
 }
 
-void
-AbstractGraph::long_prune_deallocate()
-{
+void AbstractGraph::long_prune_deallocate() {
   for (std::vector<std::vector<bool> >::iterator it = long_prune_fixed.begin();
        it < long_prune_fixed.end();
        ++it) {
     it->clear();
   }
-  while(!long_prune_mcrs.empty())
-    {
-      delete long_prune_mcrs.back();
-      long_prune_mcrs.pop_back();
-    }
+  for (std::vector<std::vector<bool> >::iterator it = long_prune_mcrs.begin();
+       it < long_prune_mcrs.end();
+       ++it) {
+    it->clear();
   }
+}
 
 void
 AbstractGraph::long_prune_swap(const unsigned int i, const unsigned int j)
@@ -467,15 +459,15 @@ std::vector<bool>&
 AbstractGraph::long_prune_allocget_mcrs(const unsigned int index)
 {
   const unsigned int i = index % long_prune_max_stored_autss;
-  if(!long_prune_mcrs[i])
-    long_prune_mcrs[i] = new std::vector<bool>(get_nof_vertices());
-  return *long_prune_mcrs[i];
+  if(long_prune_mcrs[i].size() < get_nof_vertices())
+    long_prune_mcrs[i].resize(get_nof_vertices());
+  return long_prune_mcrs[i];
 }
 
 std::vector<bool>&
 AbstractGraph::long_prune_get_mcrs(const unsigned int index)
 {
-  return *long_prune_mcrs[index % long_prune_max_stored_autss];
+  return long_prune_mcrs[index % long_prune_max_stored_autss];
 }
 
 void

--- a/extern/bliss-0.73/graph.cc
+++ b/extern/bliss-0.73/graph.cc
@@ -224,7 +224,7 @@ AbstractGraph::do_refine_to_equitable()
  * then \a labeling will map 0 to 1, 1 to 2, and 2 to 0.
  */
 void
-AbstractGraph::update_labeling(uint_pointer_substitute labeling)
+AbstractGraph::update_labeling(uint_pointer_substitute const labeling)
 {
   const unsigned int N = get_nof_vertices();
   uint_pointer_substitute ep = p.elements;
@@ -276,7 +276,7 @@ AbstractGraph::reset_permutation(uint_pointer_substitute perm)
 }
 
 bool
-AbstractGraph::is_automorphism(uint_pointer_substitute perm)
+AbstractGraph::is_automorphism(uint_pointer_substitute const perm)
 {
   _INTERNAL_ERROR();
   return false;
@@ -489,7 +489,7 @@ AbstractGraph::long_prune_get_mcrs(const unsigned int index)
 }
 
 void
-AbstractGraph::long_prune_add_automorphism(uint_pointer_substitute aut)
+AbstractGraph::long_prune_add_automorphism(uint_pointer_to_const_substitute aut)
 {
   if(long_prune_max_stored_autss == 0)
     return;
@@ -1758,7 +1758,7 @@ AbstractGraph::find_automorphisms(Stats& stats, void (*hook)(void *user_param, u
   best_path_labeling_vec.clear();
 }
 
-uint_pointer_substitute
+uint_pointer_to_const_substitute
 AbstractGraph::canonical_form(Stats& stats, void (*hook)(void *user_param, unsigned int n, const unsigned int *aut), void *user_param) {
   report_hook = hook;
   report_user_param = user_param;

--- a/extern/bliss-0.73/graph.cc
+++ b/extern/bliss-0.73/graph.cc
@@ -224,10 +224,10 @@ AbstractGraph::do_refine_to_equitable()
  * then \a labeling will map 0 to 1, 1 to 2, and 2 to 0.
  */
 void
-AbstractGraph::update_labeling(labeling_type labeling)
+AbstractGraph::update_labeling(uint_pointer_substitute labeling)
 {
   const unsigned int N = get_nof_vertices();
-  Partition::uint_ptr_type ep = p.elements;
+  uint_pointer_substitute ep = p.elements;
   for(unsigned int i = 0; i < N; i++, ep++)
     labeling[*ep] = i;
 }
@@ -237,12 +237,12 @@ AbstractGraph::update_labeling(labeling_type labeling)
  * is also produced and assigned to \a labeling_inv.
  */
 void
-AbstractGraph::update_labeling_and_its_inverse(labeling_type const labeling,
-                                               labeling_type const labeling_inv)
+AbstractGraph::update_labeling_and_its_inverse(uint_pointer_substitute const labeling,
+                                               uint_pointer_substitute const labeling_inv)
 {
   const unsigned int N = get_nof_vertices();
-  Partition::uint_ptr_type  ep = p.elements;
-  labeling_type clip = labeling_inv;
+  uint_pointer_substitute  ep = p.elements;
+  uint_pointer_substitute clip = labeling_inv;
 
   for(unsigned int i = 0; i < N; ) {
     labeling[*ep] = i;
@@ -268,7 +268,7 @@ AbstractGraph::update_labeling_and_its_inverse(labeling_type const labeling,
  * Reset the permutation \a perm to the identity permutation.
  */
 void
-AbstractGraph::reset_permutation(labeling_type perm)
+AbstractGraph::reset_permutation(uint_pointer_substitute perm)
 {
   const unsigned int N = get_nof_vertices();
   for(unsigned int i = 0; i < N; i++, perm++)
@@ -276,7 +276,7 @@ AbstractGraph::reset_permutation(labeling_type perm)
 }
 
 bool
-AbstractGraph::is_automorphism(labeling_type perm)
+AbstractGraph::is_automorphism(uint_pointer_substitute perm)
 {
   _INTERNAL_ERROR();
   return false;
@@ -489,7 +489,7 @@ AbstractGraph::long_prune_get_mcrs(const unsigned int index)
 }
 
 void
-AbstractGraph::long_prune_add_automorphism(labeling_type aut)
+AbstractGraph::long_prune_add_automorphism(uint_pointer_substitute aut)
 {
   if(long_prune_max_stored_autss == 0)
     return;
@@ -540,7 +540,7 @@ AbstractGraph::long_prune_add_automorphism(labeling_type aut)
  *-------------------------------------------------------------------------*/
 
 void
-AbstractGraph::update_orbit_information(Orbit& o, labeling_type perm)
+AbstractGraph::update_orbit_information(Orbit& o, uint_pointer_substitute perm)
 {
   const unsigned int N = get_nof_vertices();
   for(unsigned int i = 0; i < N; i++)
@@ -951,7 +951,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
                       continue;
                     }
                   const std::vector<bool>& mcrs = long_prune_get_mcrs(i);
-                  Partition::uint_ptr_type ep = p.elements + cell->first;
+                  uint_pointer_substitute ep = p.elements + cell->first;
                   for(unsigned int j = cell->length; j > 0; j--, ep++) {
                     if(mcrs[*ep] == false)
                       current_node.long_prune_redundant.insert(*ep);
@@ -967,8 +967,8 @@ AbstractGraph::search(const bool canonical, Stats& stats)
        */
       {
         unsigned int  next_split_element = UINT_MAX;
-        Partition::uint_ptr_type next_split_element_pos;
-        Partition::uint_ptr_type ep = p.elements + cell->first;
+        uint_pointer_substitute next_split_element_pos;
+        uint_pointer_substitute ep = p.elements + cell->first;
         if(current_node.fp_on)
           {
             /* Find the next larger splitting element that is
@@ -1758,7 +1758,7 @@ AbstractGraph::find_automorphisms(Stats& stats, void (*hook)(void *user_param, u
   best_path_labeling_vec.clear();
 }
 
-labeling_type
+uint_pointer_substitute
 AbstractGraph::canonical_form(Stats& stats, void (*hook)(void *user_param, unsigned int n, const unsigned int *aut), void *user_param) {
   report_hook = hook;
   report_user_param = user_param;
@@ -2429,7 +2429,7 @@ Digraph::refine_according_to_invariant(unsigned int (*inv)(const Digraph* const 
     {
 
       Partition::Cell* const next_cell = cell->next_nonsingleton;
-      Partition::const_uint_ptr_type ep = p.elements + cell->first;
+      uint_pointer_to_const_substitute ep = p.elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
         {
           unsigned int ival = inv(this, *ep);
@@ -2473,7 +2473,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
       eqref_hash.update(cell->length);
     }
 
-  Partition::const_uint_ptr_type ep = p.elements + cell->first;
+  uint_pointer_to_const_substitute ep = p.elements + cell->first;
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
@@ -2693,7 +2693,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
         }
       neighbour_cell->max_ival_count++;
 
-      Partition::uint_ptr_type const swap_position =
+      uint_pointer_substitute const swap_position =
         p.elements + neighbour_cell->first + neighbour_cell->length -
         neighbour_cell->max_ival_count;
       *p.in_pos[dest_vertex] = *swap_position;
@@ -2732,8 +2732,8 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
             p.aux_split_in_two(neighbour_cell,
                                neighbour_cell->length -
                                neighbour_cell->max_ival_count);
-          Partition::uint_ptr_type ep = p.elements + new_cell->first;
-          Partition::uint_ptr_type const lp = p.elements+new_cell->first+new_cell->length;
+          uint_pointer_substitute ep = p.elements + new_cell->first;
+          uint_pointer_substitute const lp = p.elements+new_cell->first+new_cell->length;
           while(ep < lp)
             {
               p.element_to_cell_map[*ep] = new_cell;
@@ -2825,7 +2825,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
         }
       neighbour_cell->max_ival_count++;
 
-      Partition::uint_ptr_type const swap_position =
+      uint_pointer_substitute const swap_position =
         p.elements + neighbour_cell->first + neighbour_cell->length -
         neighbour_cell->max_ival_count;
       *p.in_pos[dest_vertex] = *swap_position;
@@ -2863,8 +2863,8 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
             p.aux_split_in_two(neighbour_cell,
                                neighbour_cell->length -
                                neighbour_cell->max_ival_count);
-          Partition::uint_ptr_type ep = p.elements + new_cell->first;
-          Partition::uint_ptr_type const lp = p.elements+new_cell->first+new_cell->length;
+          uint_pointer_substitute ep = p.elements + new_cell->first;
+          uint_pointer_substitute const lp = p.elements+new_cell->first+new_cell->length;
           while(ep < lp) {
             p.element_to_cell_map[*ep] = new_cell;
             ep++;
@@ -2991,7 +2991,7 @@ Digraph::is_equitable() const
       if(cell->is_unit())
         continue;
 
-      Partition::uint_ptr_type ep = p.elements + cell->first;
+      uint_pointer_substitute ep = p.elements + cell->first;
       const Vertex& first_vertex = vertices[*ep++];
 
       /* Count outgoing edges of the first vertex for cells */
@@ -3040,7 +3040,7 @@ Digraph::is_equitable() const
       if(cell->is_unit())
         continue;
 
-      Partition::uint_ptr_type ep = p.elements + cell->first;
+      uint_pointer_substitute ep = p.elements + cell->first;
       const Vertex& first_vertex = vertices[*ep++];
 
       /* Count incoming edges of the first vertex for cells */
@@ -4516,7 +4516,7 @@ Graph::refine_according_to_invariant(unsigned int (*inv)(const Graph* const g,
 
       Partition::Cell* const next_cell = cell->next_nonsingleton;
 
-      Partition::const_uint_ptr_type ep = p.elements + cell->first;
+      uint_pointer_to_const_substitute ep = p.elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
         {
           const unsigned int ival = inv(this, *ep);
@@ -4569,7 +4569,7 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
       eqref_hash.update(cell->length);
     }
 
-  Partition::const_uint_ptr_type ep = p.elements + cell->first;
+  uint_pointer_to_const_substitute ep = p.elements + cell->first;
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
@@ -4714,7 +4714,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
         }
       neighbour_cell->max_ival_count++;
 
-      Partition::uint_ptr_type const swap_position =
+      uint_pointer_substitute const swap_position =
         p.elements + neighbour_cell->first + neighbour_cell->length -
         neighbour_cell->max_ival_count;
       *p.in_pos[dest_vertex] = *swap_position;
@@ -4748,8 +4748,8 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
             p.aux_split_in_two(neighbour_cell,
                                neighbour_cell->length -
                                neighbour_cell->max_ival_count);
-          Partition::uint_ptr_type ep = p.elements + new_cell->first;
-          Partition::uint_ptr_type const lp = p.elements+new_cell->first+new_cell->length;
+          uint_pointer_substitute ep = p.elements + new_cell->first;
+          uint_pointer_substitute const lp = p.elements+new_cell->first+new_cell->length;
           while(ep < lp)
             {
               p.element_to_cell_map[*ep] = new_cell;
@@ -4880,7 +4880,7 @@ bool Graph::is_equitable() const
       if(cell->is_unit())
         continue;
 
-      Partition::uint_ptr_type ep = p.elements + cell->first;
+      uint_pointer_substitute ep = p.elements + cell->first;
       const Vertex &first_vertex = vertices[*ep++];
 
       /* Count how many edges lead from the first vertex to

--- a/extern/bliss-0.73/graph.cc
+++ b/extern/bliss-0.73/graph.cc
@@ -66,12 +66,6 @@ AbstractGraph::AbstractGraph()
 
 AbstractGraph::~AbstractGraph()
 {
-  for (size_t i = 0; i != long_prune_fixed.size(); i++) {
-    std::vector<bool> * ptr = long_prune_fixed[i];
-    if (ptr != NULL) {
-      delete ptr;
-    }
-  }
   for (size_t i = 0; i != long_prune_mcrs.size(); i++) {
     std::vector<bool> * ptr = long_prune_mcrs[i];
     if (ptr != NULL) {
@@ -424,7 +418,7 @@ AbstractGraph::long_prune_init()
     long_prune_max_stored_autss = nof_fitting_in_max_mem;
 
   long_prune_deallocate();
-  long_prune_fixed.resize(N, 0);
+  long_prune_fixed.resize(N);
   long_prune_mcrs.resize(N, 0);
   long_prune_begin = 0;
   long_prune_end = 0;
@@ -433,44 +427,40 @@ AbstractGraph::long_prune_init()
 void
 AbstractGraph::long_prune_deallocate()
 {
-  while(!long_prune_fixed.empty())
-    {
-      delete long_prune_fixed.back();
-      long_prune_fixed.pop_back();
-    }
+  for (std::vector<std::vector<bool> >::iterator it = long_prune_fixed.begin();
+       it < long_prune_fixed.end();
+       ++it) {
+    it->clear();
+  }
   while(!long_prune_mcrs.empty())
     {
       delete long_prune_mcrs.back();
       long_prune_mcrs.pop_back();
     }
-}
+  }
 
 void
 AbstractGraph::long_prune_swap(const unsigned int i, const unsigned int j)
 {
   const unsigned int real_i = i % long_prune_max_stored_autss;
   const unsigned int real_j = j % long_prune_max_stored_autss;
-  std::vector<bool>* tmp = long_prune_fixed[real_i];
-  long_prune_fixed[real_i] = long_prune_fixed[real_j];
-  long_prune_fixed[real_j] = tmp;
-  tmp = long_prune_mcrs[real_i];
-  long_prune_mcrs[real_i] = long_prune_mcrs[real_j];
-  long_prune_mcrs[real_j] = tmp;
+  std::swap(long_prune_fixed[real_i], long_prune_fixed[real_j]);
+  std::swap(long_prune_mcrs[real_i], long_prune_mcrs[real_j]);
 }
 
 std::vector<bool>&
 AbstractGraph::long_prune_allocget_fixed(const unsigned int index)
 {
   const unsigned int i = index % long_prune_max_stored_autss;
-  if(!long_prune_fixed[i])
-    long_prune_fixed[i] = new std::vector<bool>(get_nof_vertices());
-  return *long_prune_fixed[i];
+  if(long_prune_fixed[i].size() < get_nof_vertices())
+    long_prune_fixed[i].resize(get_nof_vertices());
+  return long_prune_fixed[i];
 }
 
 std::vector<bool>&
 AbstractGraph::long_prune_get_fixed(const unsigned int index)
 {
-  return *long_prune_fixed[index % long_prune_max_stored_autss];
+  return long_prune_fixed[index % long_prune_max_stored_autss];
 }
 
 std::vector<bool>&

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -364,7 +364,7 @@ protected:
 
   unsigned int long_prune_max_stored_autss;
   std::vector<std::vector<bool> >  long_prune_fixed;
-  std::vector<std::vector<bool> *> long_prune_mcrs;
+  std::vector<std::vector<bool> > long_prune_mcrs;
   std::vector<bool> long_prune_temp;
   unsigned int long_prune_begin;
   unsigned int long_prune_end;

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -235,7 +235,7 @@ public:
    * of bliss as well as on some other options (for instance, the splitting
    * heuristic selected with bliss::Graph::set_splitting_heuristic()).
    */
-  uint_pointer_substitute canonical_form(Stats& stats,
+  uint_pointer_to_const_substitute canonical_form(Stats& stats,
 				     void (*hook)(void* user_param,
 						  unsigned int n,
 						  const unsigned int* aut),
@@ -376,7 +376,7 @@ protected:
    * Release the memory allocated for "long prune" data structures.
    */
   void long_prune_deallocate();
-  void long_prune_add_automorphism(uint_pointer_substitute aut);
+  void long_prune_add_automorphism(uint_pointer_to_const_substitute aut);
   std::vector<bool>& long_prune_get_fixed(const unsigned int index);
   std::vector<bool>& long_prune_allocget_fixed(const unsigned int index);
   std::vector<bool>& long_prune_get_mcrs(const unsigned int index);
@@ -444,7 +444,7 @@ protected:
   void reset_permutation(uint_pointer_substitute perm);
 
   /* Mainly for debugging purposes */
-  virtual bool is_automorphism(uint_pointer_substitute perm);
+  virtual bool is_automorphism(uint_pointer_substitute const perm);
 
   std::vector<unsigned int> certificate_current_path;
   std::vector<unsigned int> certificate_first_path;

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -363,7 +363,7 @@ protected:
   static const unsigned int long_prune_options_max_stored_auts = 100;
 
   unsigned int long_prune_max_stored_autss;
-  std::vector<std::vector<bool> *> long_prune_fixed;
+  std::vector<std::vector<bool> >  long_prune_fixed;
   std::vector<std::vector<bool> *> long_prune_mcrs;
   std::vector<bool> long_prune_temp;
   unsigned int long_prune_begin;

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -376,7 +376,7 @@ protected:
    * Release the memory allocated for "long prune" data structures.
    */
   void long_prune_deallocate();
-  void long_prune_add_automorphism(const unsigned int *aut);
+  void long_prune_add_automorphism(labeling_type aut);
   std::vector<bool>& long_prune_get_fixed(const unsigned int index);
   std::vector<bool>& long_prune_allocget_fixed(const unsigned int index);
   std::vector<bool>& long_prune_get_mcrs(const unsigned int index);
@@ -423,24 +423,28 @@ protected:
   std::vector<unsigned int> first_path_labeling_inv_vec;
   labeling_type             first_path_labeling_inv;
   Orbit                     first_path_orbits;
-  unsigned int*             first_path_automorphism;
+
+  std::vector<unsigned int> first_path_automorphism_vec;
+  labeling_type             first_path_automorphism;
 
   std::vector<unsigned int> best_path_labeling_vec;
   labeling_type             best_path_labeling;
   std::vector<unsigned int> best_path_labeling_inv_vec;
   labeling_type             best_path_labeling_inv;
   Orbit         best_path_orbits;
-  unsigned int *best_path_automorphism;
+
+  std::vector<unsigned int> best_path_automorphism_vec;
+  labeling_type             best_path_automorphism;
 
   void update_labeling(labeling_type  const lab);
   void update_labeling_and_its_inverse(labeling_type  const lab,
 				       labeling_type  const lab_inv);
-  void update_orbit_information(Orbit &o, const unsigned int *perm);
+  void update_orbit_information(Orbit &o, labeling_type perm);
 
-  void reset_permutation(unsigned int *perm);
+  void reset_permutation(labeling_type perm);
 
   /* Mainly for debugging purposes */
-  virtual bool is_automorphism(unsigned int* const perm);
+  virtual bool is_automorphism(labeling_type perm);
 
   std::vector<unsigned int> certificate_current_path;
   std::vector<unsigned int> certificate_first_path;

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -40,6 +40,8 @@ namespace bliss_digraphs {
 #include "uintseqhash.hh"
 
 namespace bliss_digraphs {
+  typedef std::vector<unsigned int>::iterator labeling_type;
+  typedef std::vector<unsigned int>::const_iterator const_labeling_type;
 
 /**
  * \brief Statistics returned by the bliss search algorithm.
@@ -233,7 +235,7 @@ public:
    * of bliss as well as on some other options (for instance, the splitting
    * heuristic selected with bliss::Graph::set_splitting_heuristic()).
    */
-  const unsigned int* canonical_form(Stats& stats,
+  labeling_type canonical_form(Stats& stats,
 				     void (*hook)(void* user_param,
 						  unsigned int n,
 						  const unsigned int* aut),
@@ -416,19 +418,23 @@ protected:
    */
   virtual bool is_equitable() const = 0;
 
-  unsigned int *first_path_labeling;
-  unsigned int *first_path_labeling_inv;
-  Orbit         first_path_orbits;
-  unsigned int *first_path_automorphism;
+  std::vector<unsigned int> first_path_labeling_vec;
+  labeling_type             first_path_labeling;
+  std::vector<unsigned int> first_path_labeling_inv_vec;
+  labeling_type             first_path_labeling_inv;
+  Orbit                     first_path_orbits;
+  unsigned int*             first_path_automorphism;
 
-  unsigned int *best_path_labeling;
-  unsigned int *best_path_labeling_inv;
+  std::vector<unsigned int> best_path_labeling_vec;
+  labeling_type             best_path_labeling;
+  std::vector<unsigned int> best_path_labeling_inv_vec;
+  labeling_type             best_path_labeling_inv;
   Orbit         best_path_orbits;
   unsigned int *best_path_automorphism;
 
-  void update_labeling(unsigned int * const lab);
-  void update_labeling_and_its_inverse(unsigned int * const lab,
-				       unsigned int * const lab_inv);
+  void update_labeling(labeling_type  const lab);
+  void update_labeling_and_its_inverse(labeling_type  const lab,
+				       labeling_type  const lab_inv);
   void update_orbit_information(Orbit &o, const unsigned int *perm);
 
   void reset_permutation(unsigned int *perm);
@@ -513,10 +519,6 @@ protected:
    * The number of vertices in the component \a cr_component
    */
   unsigned int cr_component_elements;
-
-
-
-
 };
 
 

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -40,8 +40,8 @@ namespace bliss_digraphs {
 #include "uintseqhash.hh"
 
 namespace bliss_digraphs {
-  typedef std::vector<unsigned int>::iterator labeling_type;
-  typedef std::vector<unsigned int>::const_iterator const_labeling_type;
+  typedef std::vector<unsigned int>::iterator uint_pointer_substitute;
+  typedef std::vector<unsigned int>::const_iterator uint_pointer_to_const_substitute;
 
 /**
  * \brief Statistics returned by the bliss search algorithm.
@@ -235,7 +235,7 @@ public:
    * of bliss as well as on some other options (for instance, the splitting
    * heuristic selected with bliss::Graph::set_splitting_heuristic()).
    */
-  labeling_type canonical_form(Stats& stats,
+  uint_pointer_substitute canonical_form(Stats& stats,
 				     void (*hook)(void* user_param,
 						  unsigned int n,
 						  const unsigned int* aut),
@@ -376,7 +376,7 @@ protected:
    * Release the memory allocated for "long prune" data structures.
    */
   void long_prune_deallocate();
-  void long_prune_add_automorphism(labeling_type aut);
+  void long_prune_add_automorphism(uint_pointer_substitute aut);
   std::vector<bool>& long_prune_get_fixed(const unsigned int index);
   std::vector<bool>& long_prune_allocget_fixed(const unsigned int index);
   std::vector<bool>& long_prune_get_mcrs(const unsigned int index);
@@ -419,32 +419,32 @@ protected:
   virtual bool is_equitable() const = 0;
 
   std::vector<unsigned int> first_path_labeling_vec;
-  labeling_type             first_path_labeling;
+  uint_pointer_substitute             first_path_labeling;
   std::vector<unsigned int> first_path_labeling_inv_vec;
-  labeling_type             first_path_labeling_inv;
+  uint_pointer_substitute             first_path_labeling_inv;
   Orbit                     first_path_orbits;
 
   std::vector<unsigned int> first_path_automorphism_vec;
-  labeling_type             first_path_automorphism;
+  uint_pointer_substitute             first_path_automorphism;
 
   std::vector<unsigned int> best_path_labeling_vec;
-  labeling_type             best_path_labeling;
+  uint_pointer_substitute             best_path_labeling;
   std::vector<unsigned int> best_path_labeling_inv_vec;
-  labeling_type             best_path_labeling_inv;
+  uint_pointer_substitute             best_path_labeling_inv;
   Orbit         best_path_orbits;
 
   std::vector<unsigned int> best_path_automorphism_vec;
-  labeling_type             best_path_automorphism;
+  uint_pointer_substitute             best_path_automorphism;
 
-  void update_labeling(labeling_type  const lab);
-  void update_labeling_and_its_inverse(labeling_type  const lab,
-				       labeling_type  const lab_inv);
-  void update_orbit_information(Orbit &o, labeling_type perm);
+  void update_labeling(uint_pointer_substitute  const lab);
+  void update_labeling_and_its_inverse(uint_pointer_substitute  const lab,
+				       uint_pointer_substitute  const lab_inv);
+  void update_orbit_information(Orbit &o, uint_pointer_substitute perm);
 
-  void reset_permutation(labeling_type perm);
+  void reset_permutation(uint_pointer_substitute perm);
 
   /* Mainly for debugging purposes */
-  virtual bool is_automorphism(labeling_type perm);
+  virtual bool is_automorphism(uint_pointer_substitute perm);
 
   std::vector<unsigned int> certificate_current_path;
   std::vector<unsigned int> certificate_first_path;

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -649,7 +649,7 @@ protected:
 
   void initialize_certificate();
 
-  bool is_automorphism(unsigned int* const perm);
+  bool is_automorphism(uint_pointer_substitute const perm);
 
 
   bool nucr_find_first_component(const unsigned int level);
@@ -829,6 +829,7 @@ protected:
   };
   std::vector<Vertex> vertices;
 
+public:
   void clear() {
     for (std::vector<Vertex>::iterator it = vertices.begin();
          it < vertices.end();
@@ -836,7 +837,7 @@ protected:
       it->clear();
     }
   }
-
+protected:
   void remove_duplicate_edges();
 
   /** \internal
@@ -903,7 +904,7 @@ protected:
 
   void initialize_certificate();
 
-  bool is_automorphism(unsigned int* const perm);
+  bool is_automorphism(uint_pointer_substitute const perm);
 
   void sort_edges();
 

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -579,12 +579,23 @@ protected:
 
     unsigned int color;
     std::vector<unsigned int> edges;
+    void clear() {
+      edges.clear();
+    }
     unsigned int nof_edges() const {return edges.size(); }
   };
   std::vector<Vertex> vertices;
   void sort_edges();
   void remove_duplicate_edges();
-
+public:
+  void clear() {
+    for (std::vector<Vertex>::iterator it = vertices.begin();
+         it < vertices.end();
+         ++it) {
+      it->clear();
+    }
+  }
+protected:
   /** \internal
    * Partition independent invariant.
    * Returns the color of the vertex.
@@ -811,8 +822,21 @@ protected:
     std::vector<unsigned int> edges_in;
     unsigned int nof_edges_in() const {return edges_in.size(); }
     unsigned int nof_edges_out() const {return edges_out.size(); }
+    void clear() {
+      edges_out.clear();
+      edges_in.clear();
+    }
   };
   std::vector<Vertex> vertices;
+
+  void clear() {
+    for (std::vector<Vertex>::iterator it = vertices.begin();
+         it < vertices.end();
+         ++it) {
+      it->clear();
+    }
+  }
+
   void remove_duplicate_edges();
 
   /** \internal

--- a/extern/bliss-0.73/graph.hh
+++ b/extern/bliss-0.73/graph.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -266,7 +266,7 @@ public:
   /**
    * Get a hash value for the graph.
    * \return  the hash value
-   */ 
+   */
   virtual unsigned int get_hash() = 0;
 
   /**
@@ -631,7 +631,7 @@ protected:
   void make_initial_equitable_partition();
 
   void initialize_certificate();
-  
+
   bool is_automorphism(unsigned int* const perm);
 
 
@@ -695,7 +695,7 @@ public:
 
   /**
    * \copydoc AbstractGraph::get_hash()
-   */ 
+   */
   virtual unsigned int get_hash();
 
   /**
@@ -708,7 +708,7 @@ public:
    */
   Graph* permute(const unsigned int* const perm) const;
   Graph* permute(const std::vector<unsigned int>& perm) const;
-  
+
   /**
    * Add a new vertex with color \a color in the graph and return its index.
    */
@@ -744,7 +744,7 @@ public:
    * for both graphs.
    */
   void set_splitting_heuristic(const SplittingHeuristic shs) {sh = shs; }
-  
+
 
 };
 
@@ -934,14 +934,14 @@ public:
 
   /**
    * \copydoc AbstractGraph::get_hash()
-   */ 
+   */
   virtual unsigned int get_hash();
 
   /**
    * Return the number of vertices in the graph.
    */
   unsigned int get_nof_vertices() const {return vertices.size(); }
-  
+
   /**
    * Add a new vertex with color 'color' in the graph and return its index.
    */
@@ -981,7 +981,7 @@ public:
   /**
    * \copydoc AbstractGraph::permute(const unsigned int* const perm) const
    */
-  Digraph* permute(const unsigned int* const perm) const;  
+  Digraph* permute(const unsigned int* const perm) const;
   Digraph* permute(const std::vector<unsigned int>& perm) const;
 };
 

--- a/extern/bliss-0.73/heap.cc
+++ b/extern/bliss-0.73/heap.cc
@@ -7,9 +7,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/heap.cc
+++ b/extern/bliss-0.73/heap.cc
@@ -27,13 +27,6 @@ namespace bliss_digraphs {
 
 Heap::~Heap()
 {
-  if(array)
-    {
-      free(array);
-      array = 0;
-      n = 0;
-      N = 0;
-    }
 }
 
 void Heap::upheap(unsigned int index)
@@ -69,9 +62,8 @@ void Heap::init(const unsigned int size)
 {
   if(size > N)
     {
-      if(array)
-	free(array);
-      array = (unsigned int*)malloc((size + 1) * sizeof(unsigned int));
+      array_vec.resize(size + 1);
+      array = array_vec.begin();
       N = size;
     }
   n = 0;

--- a/extern/bliss-0.73/heap.hh
+++ b/extern/bliss-0.73/heap.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/heap.hh
+++ b/extern/bliss-0.73/heap.hh
@@ -34,8 +34,8 @@ class Heap
   unsigned int n;
   std::vector<unsigned int> array_vec;
 
-  typedef std::vector<unsigned int>::iterator unsigned_int_pointer_substitute;
-  unsigned_int_pointer_substitute array;
+  typedef std::vector<unsigned int>::iterator uint_pointer_substitute;
+  uint_pointer_substitute array;
   void upheap(unsigned int k);
   void downheap(unsigned int k);
 public:

--- a/extern/bliss-0.73/heap.hh
+++ b/extern/bliss-0.73/heap.hh
@@ -1,6 +1,8 @@
 #ifndef BLISS_HEAP_HH
 #define BLISS_HEAP_HH
 
+#include <vector>
+
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
@@ -30,7 +32,10 @@ class Heap
 {
   unsigned int N;
   unsigned int n;
-  unsigned int *array;
+  std::vector<unsigned int> array_vec;
+
+  typedef std::vector<unsigned int>::iterator unsigned_int_pointer_substitute;
+  unsigned_int_pointer_substitute array;
   void upheap(unsigned int k);
   void downheap(unsigned int k);
 public:
@@ -38,7 +43,7 @@ public:
    * Create a new heap.
    * init() must be called after this.
    */
-  Heap() {array = 0; n = 0; N = 0; }
+  Heap() { n = 0; N = 0; }
   ~Heap();
 
   /**

--- a/extern/bliss-0.73/kqueue.hh
+++ b/extern/bliss-0.73/kqueue.hh
@@ -36,6 +36,8 @@ public:
    * Create a new queue with capacity zero.
    * The function init() should be called next.
    */
+  typedef typename std::vector<Type>::iterator type_pointer_substitute;
+
   KQueue();
 
   ~KQueue();
@@ -69,33 +71,27 @@ public:
   /** Push the element \a e in the back of the queue. */
   void push_back(Type e);
 private:
-  Type *entries, *end;
-  Type *head, *tail;
+  type_pointer_substitute entries, end;
+  type_pointer_substitute head, tail;
+  std::vector<Type> entries_vec;
 };
 
 template <class Type>
 KQueue<Type>::KQueue()
 {
-  entries = 0;
-  end = 0;
-  head = 0;
-  tail = 0;
 }
 
 template <class Type>
 KQueue<Type>::~KQueue()
 {
-  if(entries)
-    free(entries);
 }
 
 template <class Type>
 void KQueue<Type>::init(const unsigned int k)
 {
   assert(k > 0);
-  if(entries)
-    free(entries);
-  entries = (Type*)malloc((k + 1) * sizeof(Type));
+  entries_vec.resize(k + 1);
+  entries = entries_vec.begin();
   end = entries + k + 1;
   head = entries;
   tail = head;
@@ -131,7 +127,7 @@ Type KQueue<Type>::front() const
 template <class Type>
 Type KQueue<Type>::pop_front()
 {
-  Type *old_head = head;
+  type_pointer_substitute old_head = head;
   head++;
   if(head == end)
     head = entries;

--- a/extern/bliss-0.73/kqueue.hh
+++ b/extern/bliss-0.73/kqueue.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -44,7 +44,7 @@ public:
    * Initialize the queue to have the capacity to hold at most \a N elements.
    */
   void init(const unsigned int N);
-  
+
   /** Is the queue empty? */
   bool is_empty() const;
 

--- a/extern/bliss-0.73/kstack.hh
+++ b/extern/bliss-0.73/kstack.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/kstack.hh
+++ b/extern/bliss-0.73/kstack.hh
@@ -98,16 +98,16 @@ public:
   int capacity() {return kapacity; }
 private:
   int kapacity;
-  Type *entries;
-  Type *cursor;
+  typedef typename std::vector<Type>::iterator entries_pointer_substitute;
+  std::vector<Type> entries_vec;
+  entries_pointer_substitute entries;
+  entries_pointer_substitute cursor;
 };
 
 template <class Type>
 KStack<Type>::KStack()
 {
   kapacity = 0;
-  entries = 0;
-  cursor = 0;
 }
 
 template <class Type>
@@ -115,7 +115,8 @@ KStack<Type>::KStack(int k)
 {
   assert(k > 0);
   kapacity = k;
-  entries = (Type*)malloc((k+1) * sizeof(Type));
+  entries_vec.resize(k + 1);
+  entries = entries_vec.begin();
   cursor = entries;
 }
 
@@ -123,17 +124,15 @@ template <class Type>
 void KStack<Type>::init(int k)
 {
   assert(k > 0);
-  if(entries)
-    free(entries);
   kapacity = k;
-  entries = (Type*)malloc((k+1) * sizeof(Type));
+  entries_vec.resize(k + 1);
+  entries = entries_vec.begin();
   cursor = entries;
 }
 
 template <class Type>
 KStack<Type>::~KStack()
 {
-  free(entries);
 }
 
 } // namespace bliss_digraphs

--- a/extern/bliss-0.73/orbit.cc
+++ b/extern/bliss-0.73/orbit.cc
@@ -26,35 +26,22 @@ namespace bliss_digraphs {
 
 Orbit::Orbit()
 {
-  orbits = 0;
-  in_orbit = 0;
   nof_elements = 0;
 }
 
 
 Orbit::~Orbit()
 {
-  if(orbits)
-    {
-      free(orbits);
-      orbits = 0;
-    }
-  if(in_orbit)
-    {
-      free(in_orbit);
-      in_orbit = 0;
-    }
-  nof_elements = 0;
 }
 
 
 void Orbit::init(const unsigned int n)
 {
   assert(n > 0);
-  if(orbits) free(orbits);
-  orbits = (OrbitEntry*)malloc(n * sizeof(OrbitEntry));
-  if(in_orbit) free(in_orbit);
-  in_orbit = (OrbitEntry**)malloc(n * sizeof(OrbitEntry*));
+  orbits_vec.resize(n);
+  orbits = orbits_vec.begin();
+  in_orbit_vec.resize(n);
+  in_orbit = in_orbit_vec.begin();
   nof_elements = n;
 
   reset();
@@ -63,8 +50,8 @@ void Orbit::init(const unsigned int n)
 
 void Orbit::reset()
 {
-  assert(orbits);
-  assert(in_orbit);
+  assert(!orbits_vec.empty());
+  assert(!in_orbit_vec.empty());
 
   for(unsigned int i = 0; i < nof_elements; i++)
     {

--- a/extern/bliss-0.73/orbit.cc
+++ b/extern/bliss-0.73/orbit.cc
@@ -6,9 +6,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -136,7 +136,7 @@ unsigned int Orbit::get_minimal_representative(unsigned int element) const
 
 unsigned int Orbit::orbit_size(unsigned int element) const
 {
-  
+
   return(in_orbit[element]->size);
 }
 

--- a/extern/bliss-0.73/orbit.hh
+++ b/extern/bliss-0.73/orbit.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/orbit.hh
+++ b/extern/bliss-0.73/orbit.hh
@@ -1,6 +1,8 @@
 #ifndef BLISS_ORBIT_HH
 #define BLISS_ORBIT_HH
 
+#include <vector>
+
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
@@ -43,8 +45,14 @@ class Orbit
     unsigned int size;
   };
 
-  OrbitEntry *orbits;
-  OrbitEntry **in_orbit;
+  typedef std::vector<OrbitEntry>::iterator orbit_entry_pointer_substitute;
+  std::vector<OrbitEntry>                   orbits_vec;
+  orbit_entry_pointer_substitute orbits;
+
+  typedef std::vector<OrbitEntry *>::iterator
+               orbit_entry_pointer_pointer_substitute;
+  std::vector<OrbitEntry*> in_orbit_vec;
+  orbit_entry_pointer_pointer_substitute in_orbit;
   unsigned int nof_elements;
   unsigned int _nof_orbits;
   void merge_orbits(OrbitEntry *o1, OrbitEntry *o2);

--- a/extern/bliss-0.73/partition.cc
+++ b/extern/bliss-0.73/partition.cc
@@ -36,8 +36,6 @@ Partition::Partition()
     dcs_count[i] = 0;
 
   cr_enabled = false;
-  cr_cells = 0;
-  cr_levels = 0;
 }
 
 
@@ -991,21 +989,11 @@ Partition::cr_init()
 
   cr_enabled = true;
 
-  if (cr_cells) {
-    free(cr_cells);
-  }
-  cr_cells = (CRCell*)malloc(N * sizeof(CRCell));
-  if (!cr_cells) {
-    assert(false && "Mem out");
-  }
+  cr_cells_vec.resize(N);
+  cr_cells = cr_cells_vec.begin();
 
-  if (cr_levels) {
-    free(cr_levels);
-  }
-  cr_levels = (CRCell**)malloc(N * sizeof(CRCell*));
-  if (!cr_levels) {
-    assert(false && "Mem out");
-  }
+  cr_levels_vec.resize(N);
+  cr_levels = cr_levels_vec.begin();
 
   for(unsigned int i = 0; i < N; i++) {
     cr_levels[i] = 0;
@@ -1024,9 +1012,6 @@ Partition::cr_init()
 void
 Partition::cr_free()
 {
-  if(cr_cells) {free(cr_cells); cr_cells = 0; }
-  if(cr_levels) {free(cr_levels); cr_levels = 0; }
-
   cr_created_trail.clear();
   cr_splitted_level_trail.clear();
   cr_bt_info.clear();
@@ -1093,7 +1078,7 @@ Partition::cr_goto_backtrack_point(const unsigned int btpoint)
       while(cr_levels[cr_max_level]) {
 	CRCell *cr_cell = cr_levels[cr_max_level];
 	cr_cell->detach();
-	cr_create_at_level(cr_cell - cr_cells, dest_level);
+	cr_create_at_level(cr_cell - &(*cr_cells), dest_level);
       }
       cr_max_level--;
     }

--- a/extern/bliss-0.73/partition.cc
+++ b/extern/bliss-0.73/partition.cc
@@ -28,7 +28,6 @@ namespace bliss_digraphs {
 Partition::Partition()
 {
   N = 0;
-  invariant_values = 0;
   cells = 0;
   free_cells = 0;
   element_to_cell_map = 0;
@@ -49,7 +48,6 @@ Partition::~Partition()
 {
   if(cells)               {free(cells); cells = 0; }
   if(element_to_cell_map) {free(element_to_cell_map); element_to_cell_map = 0; }
-  if(invariant_values)    {free(invariant_values); invariant_values = 0; }
   N = 0;
 }
 
@@ -72,11 +70,11 @@ void Partition::init(const unsigned int M)
     in_pos_vec[i] = elements + i;
   in_pos = in_pos_vec.begin();
 
-  if(invariant_values)
-    free(invariant_values);
-  invariant_values = (unsigned int*)malloc(N * sizeof(unsigned int));
+  invariant_values_vec.clear();
+  invariant_values_vec.resize(N);
   for(unsigned int i = 0; i < N; i++)
-    invariant_values[i] = 0;
+    invariant_values_vec[i] = 0;
+  invariant_values = invariant_values_vec.begin();
 
   if(cells)
     free(cells);

--- a/extern/bliss-0.73/partition.cc
+++ b/extern/bliss-0.73/partition.cc
@@ -28,7 +28,6 @@ namespace bliss_digraphs {
 Partition::Partition()
 {
   N = 0;
-  cells = 0;
   free_cells = 0;
   element_to_cell_map = 0;
   graph = 0;
@@ -46,7 +45,6 @@ Partition::Partition()
 
 Partition::~Partition()
 {
-  if(cells)               {free(cells); cells = 0; }
   if(element_to_cell_map) {free(element_to_cell_map); element_to_cell_map = 0; }
   N = 0;
 }
@@ -76,22 +74,21 @@ void Partition::init(const unsigned int M)
     invariant_values_vec[i] = 0;
   invariant_values = invariant_values_vec.begin();
 
-  if(cells)
-    free(cells);
-  cells = (Cell*)malloc(N * sizeof(Cell));
+  cells_vec.clear();
+  cells_vec.resize(N);
 
-  cells[0].first = 0;
-  cells[0].length = N;
-  cells[0].max_ival = 0;
-  cells[0].max_ival_count = 0;
-  cells[0].in_splitting_queue = false;
-  cells[0].in_neighbour_heap = false;
-  cells[0].prev = 0;
-  cells[0].next = 0;
-  cells[0].next_nonsingleton = 0;
-  cells[0].prev_nonsingleton = 0;
-  cells[0].split_level = 0;
-  first_cell = &cells[0];
+  cells_vec[0].first = 0;
+  cells_vec[0].length = N;
+  cells_vec[0].max_ival = 0;
+  cells_vec[0].max_ival_count = 0;
+  cells_vec[0].in_splitting_queue = false;
+  cells_vec[0].in_neighbour_heap = false;
+  cells_vec[0].prev = 0;
+  cells_vec[0].next = 0;
+  cells_vec[0].next_nonsingleton = 0;
+  cells_vec[0].prev_nonsingleton = 0;
+  cells_vec[0].split_level = 0;
+  first_cell = &cells_vec[0];
   if(N == 1)
     {
       first_nonsingleton_cell = 0;
@@ -99,25 +96,26 @@ void Partition::init(const unsigned int M)
     }
   else
     {
-      first_nonsingleton_cell = &cells[0];
+      first_nonsingleton_cell = &cells_vec[0];
       discrete_cell_count = 0;
     }
 
   for(unsigned int i = 1; i < N; i++)
     {
-      cells[i].first = 0;
-      cells[i].length = 0;
-      cells[i].max_ival = 0;
-      cells[i].max_ival_count = 0;
-      cells[i].in_splitting_queue = false;
-      cells[i].in_neighbour_heap = false;
-      cells[i].prev = 0;
-      cells[i].next = (i < N-1)?&cells[i+1]:0;
-      cells[i].next_nonsingleton = 0;
-      cells[i].prev_nonsingleton = 0;
+      cells_vec[i].first = 0;
+      cells_vec[i].length = 0;
+      cells_vec[i].max_ival = 0;
+      cells_vec[i].max_ival_count = 0;
+      cells_vec[i].in_splitting_queue = false;
+      cells_vec[i].in_neighbour_heap = false;
+      cells_vec[i].prev = 0;
+      cells_vec[i].next = (i < N-1)?&cells_vec[i+1]:0;
+      cells_vec[i].next_nonsingleton = 0;
+      cells_vec[i].prev_nonsingleton = 0;
     }
+  cells = cells_vec.begin();
   if(N > 1)
-    free_cells = &cells[1];
+    free_cells = &cells_vec[1];
   else
     free_cells = 0;
 

--- a/extern/bliss-0.73/partition.cc
+++ b/extern/bliss-0.73/partition.cc
@@ -188,8 +188,8 @@ Partition::goto_backtrack_point(BacktrackPoint p)
 	  if(next_cell->length == 1)
 	    discrete_cell_count--;
 	  /* Update element_to_cell_map values of elements added in cell */
-	  uint_ptr_type ep = elements + next_cell->first;
-	  uint_ptr_type const lp = ep + next_cell->length;
+	  uint_pointer_substitute ep = elements + next_cell->first;
+	  uint_pointer_substitute const lp = ep + next_cell->length;
 	  for( ; ep < lp; ep++)
 	    element_to_cell_map[*ep] = cell;
 	  /* Update cell parameters */
@@ -241,7 +241,7 @@ Partition::individualize(Partition::Cell * const cell,
 			 const unsigned int element)
 {
 
-  uint_ptr_type const pos = in_pos[element];
+  uint_pointer_substitute const pos = in_pos[element];
 
   const unsigned int last = cell->first + cell->length - 1;
   *pos = elements[last];
@@ -431,12 +431,12 @@ Partition::sort_and_split_cell1(Partition::Cell* const cell)
 
 #define NEW_SORT1
 #ifdef NEW_SORT1
-      uint_ptr_type ep0 = elements + cell->first;
-      uint_ptr_type ep1 = ep0 + cell->length - cell->max_ival_count;
+      uint_pointer_substitute ep0 = elements + cell->first;
+      uint_pointer_substitute ep1 = ep0 + cell->length - cell->max_ival_count;
       if(cell->max_ival_count > cell->length / 2)
 	{
 	  /* There are more ones than zeros, only move zeros */
-	  uint_ptr_type const end = ep0 + cell->length;
+	  uint_pointer_substitute const end = ep0 + cell->length;
 	  while(ep1 < end)
 	    {
 	      while(invariant_values[*ep1] == 0)
@@ -456,7 +456,7 @@ Partition::sort_and_split_cell1(Partition::Cell* const cell)
       else
 	{
 	  /* There are more zeros than ones, only move ones */
-	  uint_ptr_type  const end = ep1;
+	  uint_pointer_substitute  const end = ep1;
 	  while(ep0 < end)
 	    {
 	      while(invariant_values[*ep0] != 0)
@@ -654,7 +654,7 @@ Partition::sort_and_split_cell255(Partition::Cell* const cell,
    * Compute the distribution of invariant values to the count array
    */
   {
-    Partition::const_uint_ptr_type ep = elements + cell->first;
+    uint_pointer_to_const_substitute ep = elements + cell->first;
     const unsigned int ival = invariant_values[*ep];
     dcs_count[ival]++;
     ep++;
@@ -690,7 +690,7 @@ Partition::sort_and_split_cell255(Partition::Cell* const cell,
   /* Do the sorting */
   for(unsigned int i = 0; i <= max_ival; i++)
     {
-      uint_ptr_type ep = elements + cell->first + dcs_start[i];
+      uint_pointer_substitute ep = elements + cell->first + dcs_start[i];
       for(unsigned int j = dcs_count[i]; j > 0; j--)
 	{
 	  while(true)
@@ -730,7 +730,7 @@ bool
 Partition::shellsort_cell(Partition::Cell* const cell)
 {
   unsigned int h;
-  uint_ptr_type  ep;
+  uint_pointer_substitute  ep;
 
 
   if(cell->is_unit())
@@ -778,7 +778,7 @@ Partition::shellsort_cell(Partition::Cell* const cell)
 void
 Partition::clear_ivs(Cell* const cell)
 {
-  uint_ptr_type  ep = elements + cell->first;
+  uint_pointer_substitute  ep = elements + cell->first;
   for(unsigned int i = cell->length; i > 0; i--, ep++)
     invariant_values[*ep] = 0;
 }
@@ -798,8 +798,8 @@ Partition::split_cell(Partition::Cell* const original_cell)
 
   while(true)
     {
-      uint_ptr_type  ep = elements + cell->first;
-      Partition::const_uint_ptr_type  const lp = ep + cell->length;
+      uint_pointer_substitute  ep = elements + cell->first;
+      uint_pointer_to_const_substitute  const lp = ep + cell->length;
       const unsigned int ival = invariant_values[*ep];
       invariant_values[*ep] = 0;
       element_to_cell_map[*ep] = cell;
@@ -899,7 +899,7 @@ Partition::zplit_cell(Partition::Cell* const cell,
       /* Compute max_ival info */
       assert(cell->max_ival == 0);
       assert(cell->max_ival_count == 0);
-      uint_ptr_type ep = elements + cell->first;
+      uint_pointer_substitute ep = elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
 	{
 	  const unsigned int ival = invariant_values[*ep];

--- a/extern/bliss-0.73/partition.cc
+++ b/extern/bliss-0.73/partition.cc
@@ -7,9 +7,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -169,14 +169,14 @@ Partition::goto_backtrack_point(BacktrackPoint p)
     cr_goto_backtrack_point(info.cr_backtrack_point);
 
   const unsigned int dest_refinement_stack_size = info.refinement_stack_size;
-  
+
   assert(refinement_stack.size() >= dest_refinement_stack_size);
   while(refinement_stack.size() > dest_refinement_stack_size)
     {
       RefInfo i = refinement_stack.pop();
       const unsigned int first = i.split_cell_first;
       Cell* cell = get_cell(elements[first]);
-      
+
       if(cell->first != first)
 	{
 	  assert(cell->first < first);
@@ -260,12 +260,12 @@ Partition::individualize(Partition::Cell * const cell,
   in_pos[*pos] = pos;
   elements[last] = element;
   in_pos[element] = elements + last;
-  
+
   Partition::Cell * const new_cell = aux_split_in_two(cell, cell->length-1);
   element_to_cell_map[element] = new_cell;
 
   return new_cell;
-} 
+}
 
 
 
@@ -336,7 +336,7 @@ Partition::aux_split_in_two(Partition::Cell* const cell,
     }
 
   return new_cell;
-} 
+}
 
 
 
@@ -394,7 +394,7 @@ Partition::splitting_queue_add(Cell* const cell)
   if(cell->length <= smallish_cell_threshold)
     splitting_queue.push_front(cell);
   else
-    splitting_queue.push_back(cell);    
+    splitting_queue.push_back(cell);
 }
 
 
@@ -627,7 +627,7 @@ Partition::sort_and_split_cell1(Partition::Cell* const cell)
  * dcs_start[0] = 0 and dcs_start[i+1] = dcs_start[i] + dcs_count[i].
  */
 void
-Partition::dcs_cumulate_count(const unsigned int max) 
+Partition::dcs_cumulate_count(const unsigned int max)
 {
   unsigned int* count_p = dcs_count;
   unsigned int* start_p = dcs_start;
@@ -656,7 +656,7 @@ Partition::sort_and_split_cell255(Partition::Cell* const cell,
       invariant_values[elements[cell->first]] = 0;
       return cell;
     }
-  
+
 #ifdef BLISS_CONSISTENCY_CHECKS
   for(unsigned int i = 0; i < 256; i++)
     assert(dcs_count[i] == 0);
@@ -808,7 +808,7 @@ Partition::split_cell(Partition::Cell* const original_cell)
     original_cell->in_splitting_queue;
   Cell* largest_new_cell = 0;
 
-  while(true) 
+  while(true)
     {
       unsigned int* ep = elements + cell->first;
       const unsigned int* const lp = ep + cell->length;
@@ -829,17 +829,17 @@ Partition::split_cell(Partition::Cell* const original_cell)
 	}
       if(ep == lp)
 	break;
-      
+
       Cell* const new_cell = aux_split_in_two(cell,
 					      (ep - elements) - cell->first);
-      
+
       if(graph and graph->compute_eqref_hash)
 	{
 	  graph->eqref_hash.update(new_cell->first);
 	  graph->eqref_hash.update(new_cell->length);
 	  graph->eqref_hash.update(ival);
 	}
-      
+
       /* Add cells in splitting_queue */
       assert(!new_cell->is_in_splitting_queue());
       if(original_cell_was_in_splitting_queue)
@@ -868,7 +868,7 @@ Partition::split_cell(Partition::Cell* const original_cell)
       cell = new_cell;
     }
 
-  
+
   if(original_cell == cell) {
     /* All the elements in cell had the same invariant value */
     return cell;

--- a/extern/bliss-0.73/partition.cc
+++ b/extern/bliss-0.73/partition.cc
@@ -29,7 +29,6 @@ Partition::Partition()
 {
   N = 0;
   free_cells = 0;
-  element_to_cell_map = 0;
   graph = 0;
   discrete_cell_count = 0;
   /* Initialize a distribution count sorting array. */
@@ -45,7 +44,6 @@ Partition::Partition()
 
 Partition::~Partition()
 {
-  if(element_to_cell_map) {free(element_to_cell_map); element_to_cell_map = 0; }
   N = 0;
 }
 
@@ -119,11 +117,11 @@ void Partition::init(const unsigned int M)
   else
     free_cells = 0;
 
-  if(element_to_cell_map)
-    free(element_to_cell_map);
-  element_to_cell_map = (Cell **)malloc(N * sizeof(Cell *));
+  element_to_cell_map_vec.clear();
+  element_to_cell_map_vec.resize(N);
   for(unsigned int i = 0; i < N; i++)
-    element_to_cell_map[i] = first_cell;
+    element_to_cell_map_vec[i] = first_cell;
+  element_to_cell_map = element_to_cell_map_vec.begin();
 
   splitting_queue.init(N);
   refinement_stack.init(N);

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -157,13 +157,14 @@ public:
   Cell* first_cell;
   Cell* first_nonsingleton_cell;
 
-  typedef std::vector<unsigned int>::iterator uint_ptr_type;
-  typedef std::vector<unsigned int>::const_iterator const_uint_ptr_type;
+  typedef std::vector<unsigned int>::iterator uint_pointer_substitute;
+  typedef std::vector<unsigned int>::const_iterator
+                            uint_pointer_to_const_substitute;
   std::vector<unsigned int> elements_vec;
-  uint_ptr_type elements;
+  uint_pointer_substitute elements;
   /* invariant_values[e] gives the invariant value of the element e */
   std::vector<unsigned int> invariant_values_vec;
-  uint_ptr_type invariant_values;
+  uint_pointer_substitute invariant_values;
   /* element_to_cell_map[e] gives the cell of the element e */
 
   typedef std::vector<Cell*>::iterator
@@ -176,8 +177,8 @@ public:
     return element_to_cell_map_vec[e];
   }
   /* in_pos[e] points to the elements array s.t. *in_pos[e] = e  */
-  std::vector<uint_ptr_type> in_pos_vec;
-  std::vector<uint_ptr_type>::iterator in_pos;
+  std::vector<uint_pointer_substitute> in_pos_vec;
+  std::vector<uint_pointer_substitute>::iterator in_pos;
 
   Partition();
   ~Partition();

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -160,7 +160,8 @@ public:
   std::vector<unsigned int> elements_vec;
   uint_ptr_type elements;
   /* invariant_values[e] gives the invariant value of the element e */
-  unsigned int *invariant_values;
+  std::vector<unsigned int> invariant_values_vec;
+  uint_ptr_type invariant_values;
   /* element_to_cell_map[e] gives the cell of the element e */
   Cell **element_to_cell_map;
   /** Get the cell of the element \a e */

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -255,8 +255,14 @@ private:
       prev_next_ptr = 0;
     }
   };
-  CRCell* cr_cells;
-  CRCell** cr_levels;
+  typedef std::vector<CRCell>::iterator crcell_pointer_substitute;
+  std::vector<CRCell> cr_cells_vec;
+  crcell_pointer_substitute cr_cells;
+
+  typedef std::vector<CRCell*>::iterator crcell_pointer_pointer_substitute;
+  std::vector<CRCell*> cr_levels_vec;
+  crcell_pointer_pointer_substitute cr_levels;
+
   class CR_BTInfo {
   public:
     unsigned int created_trail_index;

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -154,7 +154,11 @@ private:
 public:
   Cell* first_cell;
   Cell* first_nonsingleton_cell;
-  unsigned int *elements;
+
+  typedef std::vector<unsigned int>::iterator uint_ptr_type;
+  typedef std::vector<unsigned int>::const_iterator const_uint_ptr_type;
+  std::vector<unsigned int> elements_vec;
+  uint_ptr_type elements;
   /* invariant_values[e] gives the invariant value of the element e */
   unsigned int *invariant_values;
   /* element_to_cell_map[e] gives the cell of the element e */
@@ -164,7 +168,8 @@ public:
     return element_to_cell_map[e];
   }
   /* in_pos[e] points to the elements array s.t. *in_pos[e] = e  */
-  unsigned int **in_pos;
+  std::vector<uint_ptr_type> in_pos_vec;
+  std::vector<uint_ptr_type>::iterator in_pos;
 
   Partition();
   ~Partition();

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -149,8 +149,8 @@ public:
 private:
   unsigned int N;
   std::vector<Cell> cells_vec;
-  typedef std::vector<Cell>::iterator cells_type;
-  cells_type cells;
+  typedef std::vector<Cell>::iterator cell_pointer_substitute;
+  cell_pointer_substitute cells;
   Cell* free_cells;
   unsigned int discrete_cell_count;
 public:
@@ -165,10 +165,15 @@ public:
   std::vector<unsigned int> invariant_values_vec;
   uint_ptr_type invariant_values;
   /* element_to_cell_map[e] gives the cell of the element e */
-  Cell **element_to_cell_map;
+
+  typedef std::vector<Cell*>::iterator
+      cell_pointer_pointer_substitute;
+
+  std::vector<Cell*> element_to_cell_map_vec;
+  cell_pointer_pointer_substitute element_to_cell_map;
   /** Get the cell of the element \a e */
   Cell* get_cell(const unsigned int e) const {
-    return element_to_cell_map[e];
+    return element_to_cell_map_vec[e];
   }
   /* in_pos[e] points to the elements array s.t. *in_pos[e] = e  */
   std::vector<uint_ptr_type> in_pos_vec;

--- a/extern/bliss-0.73/partition.hh
+++ b/extern/bliss-0.73/partition.hh
@@ -148,7 +148,9 @@ public:
 
 private:
   unsigned int N;
-  Cell* cells;
+  std::vector<Cell> cells_vec;
+  typedef std::vector<Cell>::iterator cells_type;
+  cells_type cells;
   Cell* free_cells;
   unsigned int discrete_cell_count;
 public:

--- a/extern/bliss-0.73/timer.cc
+++ b/extern/bliss-0.73/timer.cc
@@ -5,9 +5,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -46,7 +46,7 @@ double Timer::get_duration()
   struct tms clkticks;
 
   times(&clkticks);
-  double intermediate = 
+  double intermediate =
     ((double) clkticks.tms_utime + (double) clkticks.tms_stime) /
     numTicksPerSec;
   return intermediate - start_time;

--- a/extern/bliss-0.73/timer.cc
+++ b/extern/bliss-0.73/timer.cc
@@ -34,7 +34,7 @@ void Timer::reset()
 {
   struct tms clkticks;
 
-  times(&clkticks);
+//  times(&clkticks);
   start_time =
     ((double) clkticks.tms_utime + (double) clkticks.tms_stime) /
     numTicksPerSec;
@@ -45,7 +45,7 @@ double Timer::get_duration()
 {
   struct tms clkticks;
 
-  times(&clkticks);
+//  times(&clkticks);
   double intermediate =
     ((double) clkticks.tms_utime + (double) clkticks.tms_stime) /
     numTicksPerSec;

--- a/extern/bliss-0.73/timer.hh
+++ b/extern/bliss-0.73/timer.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/uintseqhash.cc
+++ b/extern/bliss-0.73/uintseqhash.cc
@@ -3,9 +3,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/uintseqhash.hh
+++ b/extern/bliss-0.73/uintseqhash.hh
@@ -6,9 +6,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -35,7 +35,7 @@ public:
   UintSeqHash() {h = 0; }
   UintSeqHash(const UintSeqHash &other) {h = other.h; }
   UintSeqHash& operator=(const UintSeqHash &other) {h = other.h; return *this; }
-  
+
   /** Reset the hash value. */
   void reset() {h = 0; }
 

--- a/extern/bliss-0.73/utils.cc
+++ b/extern/bliss-0.73/utils.cc
@@ -5,9 +5,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/extern/bliss-0.73/utils.hh
+++ b/extern/bliss-0.73/utils.hh
@@ -4,9 +4,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.

--- a/src/bitarray.h
+++ b/src/bitarray.h
@@ -294,9 +294,7 @@ static inline void init_bit_array(BitArray* const bit_array,
   DIGRAPHS_ASSERT(nr_bits <= bit_array->nr_bits);
   uint16_t const nr_blocks = NR_BLOCKS_LOOKUP[nr_bits];
   if (val) {
-    memset((void*) bit_array->blocks,
-           ~0,
-           (size_t) sizeof(Block) * nr_blocks);
+    memset((void*) bit_array->blocks, ~0, (size_t) sizeof(Block) * nr_blocks);
   } else {
     memset((void*) bit_array->blocks, 0, (size_t) sizeof(Block) * nr_blocks);
   }

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -73,8 +73,7 @@ Int DigraphNrVertices(Obj D) {
   return LEN_LIST(FuncOutNeighbours(0L, D));
 }
 
-static Int RNamOutNeighbours        = 0;
-
+static Int RNamOutNeighbours = 0;
 
 Obj FuncOutNeighbours(Obj self, Obj D) {
   if (!RNamOutNeighbours) {

--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -125,13 +125,13 @@ void add_edge_graph(Graph* const graph, uint16_t const i, uint16_t const j) {
 
 #ifdef DIGRAPHS_WITH_INCLUDED_BLISS
 static void init_bliss_graph_from_digraph(Digraph const* const  digraph,
-                                        uint16_t const* const colors,
-                                        BlissGraph*           bg) {
+                                          uint16_t const* const colors,
+                                          BlissGraph*           bg) {
   DIGRAPHS_ASSERT(digraph != NULL);
   DIGRAPHS_ASSERT(colors != NULL);
   bliss_digraphs_clear(bg);
-  uint16_t out_color = 0;
-  uint16_t const n = digraph->nr_vertices;
+  uint16_t       out_color = 0;
+  uint16_t const n         = digraph->nr_vertices;
   for (uint16_t i = 0; i < n; i++) {
     out_color = (colors[i] > out_color ? colors[i] + 1 : out_color);
     bliss_digraphs_change_color(bg, i, colors[i]);
@@ -157,9 +157,9 @@ static BlissGraph* new_bliss_graph_from_digraph(Digraph const* const  digraph,
   DIGRAPHS_ASSERT(digraph != NULL);
   DIGRAPHS_ASSERT(colors != NULL);
   BlissGraph*    bg;
-  uint16_t out_color = 0;
-  uint16_t const n = digraph->nr_vertices;
-  bg               = bliss_digraphs_new(0);
+  uint16_t       out_color = 0;
+  uint16_t const n         = digraph->nr_vertices;
+  bg                       = bliss_digraphs_new(0);
   for (uint16_t i = 0; i < n; i++) {
     out_color = (colors[i] > out_color ? colors[i] + 1 : out_color);
     bliss_digraphs_add_vertex(bg, colors[i]);
@@ -243,8 +243,7 @@ static void bliss_hook(void*               user_param_arg,  // perm_coll!
 void automorphisms_digraph(Digraph const* const  digraph,
                            uint16_t const* const colors,
                            PermColl*             out,
-                          BlissGraph* bg
-                           ) {
+                           BlissGraph*           bg) {
   DIGRAPHS_ASSERT(graph != NULL);
   DIGRAPHS_ASSERT(out != NULL);
   DIGRAPHS_ASSERT(bg != NULL);
@@ -287,7 +286,7 @@ void automorphisms_graph(Graph const* const    graph,
   DIGRAPHS_ASSERT(graph != NULL);
   DIGRAPHS_ASSERT(out != NULL);
   clear_perm_coll(out);
-  out->degree = PERM_DEGREE;
+  out->degree    = PERM_DEGREE;
   BlissGraph* bg = new_bliss_graph_from_graph(graph, colors);
   bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
   bliss_digraphs_release(bg);

--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -17,21 +17,21 @@
 #include "src/compiled.h"  // for Obj, Int
 
 // Digraphs headers
-#include "digraphs-debug.h"  // for DIGRAPHS_ASSERT
-#include "schreier-sims.h"   // for PERM_DEGREE
 #include "digraphs-config.h"  // for DIGRAPHS_WITH_INCLUDED_BLISS
+#include "digraphs-debug.h"   // for DIGRAPHS_ASSERT
+#include "schreier-sims.h"    // for PERM_DEGREE
 
 // Bliss headers
 #ifdef DIGRAPHS_WITH_INCLUDED_BLISS
 #include "bliss-0.73/bliss_C.h"  // for bliss_digraphs_release, . . .
 #else
 #include "bliss/bliss_C.h"
-#define bliss_digraphs_add_edge                 bliss_add_edge
-#define bliss_digraphs_new                      bliss_new
-#define bliss_digraphs_add_vertex               bliss_add_vertex
-#define bliss_digraphs_find_canonical_labeling  bliss_find_canonical_labeling
-#define bliss_digraphs_release                  bliss_release
-#define bliss_digraphs_find_automorphisms       bliss_find_automorphisms
+#define bliss_digraphs_add_edge bliss_add_edge
+#define bliss_digraphs_new bliss_new
+#define bliss_digraphs_add_vertex bliss_add_vertex
+#define bliss_digraphs_find_canonical_labeling bliss_find_canonical_labeling
+#define bliss_digraphs_release bliss_release
+#define bliss_digraphs_find_automorphisms bliss_find_automorphisms
 #endif
 
 Digraph* new_digraph(uint16_t const nr_verts) {
@@ -169,7 +169,7 @@ static BlissGraph* new_bliss_graph_from_graph(Graph const* const    graph,
 
 static void bliss_graph_from_graph(Graph const* const    graph,
                                    uint16_t const* const colors,
-                                   BlissGraph* bg) {
+                                   BlissGraph*           bg) {
   // Pr("Here!!\n", 0L, 0L);
   DIGRAPHS_ASSERT(graph != NULL);
   DIGRAPHS_ASSERT(colors != NULL);
@@ -218,11 +218,11 @@ void automorphisms_digraph(Digraph const* const  digraph,
 void automorphisms_graph(Graph const* const    graph,
                          uint16_t const* const colors,
                          PermColl*             out,
-                         BlissGraph* bg) {
+                         BlissGraph*           bg) {
   DIGRAPHS_ASSERT(graph != NULL);
   DIGRAPHS_ASSERT(out != NULL);
   clear_perm_coll(out);
-  out->degree    = PERM_DEGREE;
+  out->degree = PERM_DEGREE;
   bliss_graph_from_graph(graph, colors, bg);
   bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
 }

--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -123,30 +123,87 @@ void add_edge_graph(Graph* const graph, uint16_t const i, uint16_t const j) {
   set_bit_array(graph->neighbours[j], i, true);
 }
 
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+static void init_bliss_graph_from_digraph(Digraph const* const  digraph,
+                                        uint16_t const* const colors,
+                                        BlissGraph*           bg) {
+  DIGRAPHS_ASSERT(digraph != NULL);
+  DIGRAPHS_ASSERT(colors != NULL);
+  bliss_digraphs_clear(bg);
+  uint16_t out_color = 0;
+  uint16_t const n = digraph->nr_vertices;
+  for (uint16_t i = 0; i < n; i++) {
+    out_color = (colors[i] > out_color ? colors[i] + 1 : out_color);
+    bliss_digraphs_change_color(bg, i, colors[i]);
+  }
+  uint16_t const in_color = out_color + 1;
+  for (uint16_t i = 0; i < n; i++) {
+    bliss_digraphs_change_color(bg, i + n, out_color);
+    bliss_digraphs_change_color(bg, i + 2 * n, in_color);
+    bliss_digraphs_add_edge(bg, i, i + n);
+    bliss_digraphs_add_edge(bg, i + 2 * n, i);
+  }
+  for (uint16_t i = 0; i < n; i++) {
+    for (uint16_t j = 0; j < n; j++) {
+      if (is_adjacent_digraph(digraph, i, j)) {
+        bliss_digraphs_add_edge(bg, i + n, j + 2 * n);
+      }
+    }
+  }
+}
+#else
 static BlissGraph* new_bliss_graph_from_digraph(Digraph const* const  digraph,
                                                 uint16_t const* const colors) {
   DIGRAPHS_ASSERT(digraph != NULL);
   DIGRAPHS_ASSERT(colors != NULL);
   BlissGraph*    bg;
+  uint16_t out_color = 0;
   uint16_t const n = digraph->nr_vertices;
   bg               = bliss_digraphs_new(0);
   for (uint16_t i = 0; i < n; i++) {
+    out_color = (colors[i] > out_color ? colors[i] + 1 : out_color);
     bliss_digraphs_add_vertex(bg, colors[i]);
+  }
+  uint16_t const in_color = out_color + 1;
+  for (uint16_t i = n; i < 2 * n; i++) {
+    bliss_digraphs_add_vertex(bg, out_color);
+  }
+  for (uint16_t i = 0; i < n; i++) {
+    bliss_digraphs_add_vertex(bg, in_color);
+    bliss_digraphs_add_edge(bg, i, i + n);
+    bliss_digraphs_add_edge(bg, i + 2 * n, i);
   }
   for (uint16_t i = 0; i < n; i++) {
     for (uint16_t j = 0; j < n; j++) {
       if (is_adjacent_digraph(digraph, i, j)) {
-        uint16_t k = bliss_digraphs_add_vertex(bg, n + 1);
-        uint16_t l = bliss_digraphs_add_vertex(bg, n + 2);
-        bliss_digraphs_add_edge(bg, i, k);
-        bliss_digraphs_add_edge(bg, k, l);
-        bliss_digraphs_add_edge(bg, l, j);
+        bliss_digraphs_add_edge(bg, i + n, j + 2 * n);
       }
     }
   }
   return bg;
 }
+#endif
 
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+static void init_bliss_graph_from_graph(Graph const* const    graph,
+                                        uint16_t const* const colors,
+                                        BlissGraph*           bg) {
+  DIGRAPHS_ASSERT(graph != NULL);
+  DIGRAPHS_ASSERT(colors != NULL);
+  bliss_digraphs_clear(bg);
+  uint16_t const n = graph->nr_vertices;
+  for (uint16_t i = 0; i < n; i++) {
+    bliss_digraphs_change_color(bg, i, colors[i]);
+  }
+  for (uint16_t i = 0; i < n; i++) {
+    for (uint16_t j = 0; j < n; j++) {
+      if (is_adjacent_graph(graph, i, j)) {
+        bliss_digraphs_add_edge(bg, i, j);
+      }
+    }
+  }
+}
+#else
 static BlissGraph* new_bliss_graph_from_graph(Graph const* const    graph,
                                               uint16_t const* const colors) {
   DIGRAPHS_ASSERT(graph != NULL);
@@ -166,27 +223,7 @@ static BlissGraph* new_bliss_graph_from_graph(Graph const* const    graph,
   }
   return bg;
 }
-
-static void bliss_graph_from_graph(Graph const* const    graph,
-                                   uint16_t const* const colors,
-                                   BlissGraph*           bg) {
-  // Pr("Here!!\n", 0L, 0L);
-  DIGRAPHS_ASSERT(graph != NULL);
-  DIGRAPHS_ASSERT(colors != NULL);
-  uint16_t const n = graph->nr_vertices;
-  for (uint16_t i = 0; i < n; i++) {
-    bliss_digraphs_change_color(bg, i, colors[i]);
-  }
-
-  bliss_digraphs_clear(bg);
-  for (uint16_t i = 0; i < n; i++) {
-    for (uint16_t j = 0; j < n; j++) {
-      if (is_adjacent_graph(graph, i, j)) {
-        bliss_digraphs_add_edge(bg, i, j);
-      }
-    }
-  }
-}
+#endif
 
 static void bliss_hook(void*               user_param_arg,  // perm_coll!
                        unsigned int        N,
@@ -202,11 +239,25 @@ static void bliss_hook(void*               user_param_arg,  // perm_coll!
   add_perm_coll((PermColl*) user_param_arg, p);
 }
 
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+void automorphisms_digraph(Digraph const* const  digraph,
+                           uint16_t const* const colors,
+                           PermColl*             out,
+                          BlissGraph* bg
+                           ) {
+  DIGRAPHS_ASSERT(graph != NULL);
+  DIGRAPHS_ASSERT(out != NULL);
+  DIGRAPHS_ASSERT(bg != NULL);
+  clear_perm_coll(out);
+  out->degree = PERM_DEGREE;
+  init_bliss_graph_from_digraph(digraph, colors, bg);
+  bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
+}
+#else
 void automorphisms_digraph(Digraph const* const  digraph,
                            uint16_t const* const colors,
                            PermColl*             out) {
   DIGRAPHS_ASSERT(digraph != NULL);
-  // Pr("Here!!\n", 0L, 0L);
   DIGRAPHS_ASSERT(out != NULL);
   clear_perm_coll(out);
   out->degree    = PERM_DEGREE;
@@ -214,15 +265,31 @@ void automorphisms_digraph(Digraph const* const  digraph,
   bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
   bliss_digraphs_release(bg);
 }
+#endif
 
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
 void automorphisms_graph(Graph const* const    graph,
                          uint16_t const* const colors,
                          PermColl*             out,
                          BlissGraph*           bg) {
   DIGRAPHS_ASSERT(graph != NULL);
   DIGRAPHS_ASSERT(out != NULL);
+  DIGRAPHS_ASSERT(bg != NULL);
   clear_perm_coll(out);
   out->degree = PERM_DEGREE;
-  bliss_graph_from_graph(graph, colors, bg);
+  init_bliss_graph_from_graph(graph, colors, bg);
   bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
 }
+#else
+void automorphisms_graph(Graph const* const    graph,
+                         uint16_t const* const colors,
+                         PermColl*             out) {
+  DIGRAPHS_ASSERT(graph != NULL);
+  DIGRAPHS_ASSERT(out != NULL);
+  clear_perm_coll(out);
+  out->degree = PERM_DEGREE;
+  BlissGraph* bg = new_bliss_graph_from_graph(graph, colors);
+  bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
+  bliss_digraphs_release(bg);
+}
+#endif

--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -167,6 +167,27 @@ static BlissGraph* new_bliss_graph_from_graph(Graph const* const    graph,
   return bg;
 }
 
+static void bliss_graph_from_graph(Graph const* const    graph,
+                                   uint16_t const* const colors,
+                                   BlissGraph* bg) {
+  // Pr("Here!!\n", 0L, 0L);
+  DIGRAPHS_ASSERT(graph != NULL);
+  DIGRAPHS_ASSERT(colors != NULL);
+  uint16_t const n = graph->nr_vertices;
+  for (uint16_t i = 0; i < n; i++) {
+    bliss_digraphs_change_color(bg, i, colors[i]);
+  }
+
+  bliss_digraphs_clear(bg);
+  for (uint16_t i = 0; i < n; i++) {
+    for (uint16_t j = 0; j < n; j++) {
+      if (is_adjacent_graph(graph, i, j)) {
+        bliss_digraphs_add_edge(bg, i, j);
+      }
+    }
+  }
+}
+
 static void bliss_hook(void*               user_param_arg,  // perm_coll!
                        unsigned int        N,
                        const unsigned int* aut) {
@@ -185,6 +206,7 @@ void automorphisms_digraph(Digraph const* const  digraph,
                            uint16_t const* const colors,
                            PermColl*             out) {
   DIGRAPHS_ASSERT(digraph != NULL);
+  // Pr("Here!!\n", 0L, 0L);
   DIGRAPHS_ASSERT(out != NULL);
   clear_perm_coll(out);
   out->degree    = PERM_DEGREE;
@@ -195,12 +217,12 @@ void automorphisms_digraph(Digraph const* const  digraph,
 
 void automorphisms_graph(Graph const* const    graph,
                          uint16_t const* const colors,
-                         PermColl*             out) {
+                         PermColl*             out,
+                         BlissGraph* bg) {
   DIGRAPHS_ASSERT(graph != NULL);
   DIGRAPHS_ASSERT(out != NULL);
   clear_perm_coll(out);
   out->degree    = PERM_DEGREE;
-  BlissGraph* bg = new_bliss_graph_from_graph(graph, colors);
+  bliss_graph_from_graph(graph, colors, bg);
   bliss_digraphs_find_automorphisms(bg, bliss_hook, out, 0);
-  bliss_digraphs_release(bg);
 }

--- a/src/homos-graphs.h
+++ b/src/homos-graphs.h
@@ -95,15 +95,13 @@ static inline bool is_adjacent_graph(Graph const* const graph,
   return get_bit_array(graph->neighbours[i], j);
 }
 
-
 #ifdef DIGRAPHS_WITH_INCLUDED_BLISS
 void automorphisms_graph(Graph const* const,
                          uint16_t const* const,
                          PermColl*,
                          BlissGraph*);
 #else
-void
-automorphisms_graph(Graph const* const, uint16_t const* const, PermColl*);
+void automorphisms_graph(Graph const* const, uint16_t const* const, PermColl*);
 #endif
 
 #endif  // DIGRAPHS_SRC_HOMOS_GRAPHS_H_

--- a/src/homos-graphs.h
+++ b/src/homos-graphs.h
@@ -20,7 +20,16 @@
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT
 #include "perms.h"           // for PermColl
 
-#include "bliss-0.73/bliss_C.h"
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+#include "bliss-0.73/bliss_C.h"  // for bliss_digraphs_release, . . .
+#else
+#include "bliss/bliss_C.h"
+#define bliss_digraphs_add_edge bliss_add_edge
+#define bliss_digraphs_new bliss_new
+#define bliss_digraphs_add_vertex bliss_add_vertex
+#define bliss_digraphs_find_canonical_labeling bliss_find_canonical_labeling
+#define bliss_digraphs_release bliss_release
+#endif
 
 ////////////////////////////////////////////////////////////////////////
 // Directed graphs (digraphs)
@@ -49,9 +58,16 @@ static inline bool is_adjacent_digraph(Digraph const* const digraph,
   return get_bit_array(digraph->out_neighbours[i], j);
 }
 
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+void automorphisms_digraph(Digraph const* const,
+                           uint16_t const* const,
+                           PermColl*,
+                           BlissGraph*);
+#else
 void automorphisms_digraph(Digraph const* const,
                            uint16_t const* const,
                            PermColl*);
+#endif
 
 ////////////////////////////////////////////////////////////////////////
 // Undirected graphs (graphs)
@@ -79,9 +95,15 @@ static inline bool is_adjacent_graph(Graph const* const graph,
   return get_bit_array(graph->neighbours[i], j);
 }
 
+
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
 void automorphisms_graph(Graph const* const,
                          uint16_t const* const,
                          PermColl*,
                          BlissGraph*);
+#else
+void
+automorphisms_graph(Graph const* const, uint16_t const* const, PermColl*);
+#endif
 
 #endif  // DIGRAPHS_SRC_HOMOS_GRAPHS_H_

--- a/src/homos-graphs.h
+++ b/src/homos-graphs.h
@@ -20,6 +20,8 @@
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT
 #include "perms.h"           // for PermColl
 
+#include "bliss-0.73/bliss_C.h"
+
 ////////////////////////////////////////////////////////////////////////
 // Directed graphs (digraphs)
 ////////////////////////////////////////////////////////////////////////
@@ -77,6 +79,9 @@ static inline bool is_adjacent_graph(Graph const* const graph,
   return get_bit_array(graph->neighbours[i], j);
 }
 
-void automorphisms_graph(Graph const* const, uint16_t const* const, PermColl*);
+void automorphisms_graph(Graph const* const,
+                         uint16_t const* const,
+                         PermColl*,
+                         BlissGraph*);
 
 #endif  // DIGRAPHS_SRC_HOMOS_GRAPHS_H_

--- a/src/homos.c
+++ b/src/homos.c
@@ -1774,7 +1774,8 @@ static bool init_data_from_args(Obj digraph1_obj,
 #endif
   } else {
 #ifdef DIGRAPHS_WITH_INCLUDED_BLISS
-    automorphisms_digraph(DIGRAPH2, colors, STAB_GENS[0], BLISS_GRAPH[3 * PERM_DEGREE]);
+    automorphisms_digraph(
+        DIGRAPH2, colors, STAB_GENS[0], BLISS_GRAPH[3 * PERM_DEGREE]);
 #else
     automorphisms_digraph(DIGRAPH2, colors, STAB_GENS[0]);
 #endif

--- a/src/homos.c
+++ b/src/homos.c
@@ -47,6 +47,8 @@
 #include "perms.h"            // for MAXVERTS, UNDEFINED, PermColl, Perm
 #include "schreier-sims.h"    // for PermColl, . . .
 
+#include "bliss-0.73/bliss_C.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 // 1. Macros
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,6 +163,8 @@ static Digraph* DIGRAPH2;
 
 static Graph* GRAPH1;  // Graphs to hold incoming GAP symmetric digraphs
 static Graph* GRAPH2;
+
+static BlissGraph* BLISS_GRAPH[MAXVERTS];
 
 static uint16_t MAP[MAXVERTS];            // partial image list
 static uint16_t COLORS2[MAXVERTS];        // colors of range (di)graph
@@ -1571,10 +1575,12 @@ static bool init_data_from_args(Obj digraph1_obj,
     GRAPH1 = new_graph(MAXVERTS);
     GRAPH2 = new_graph(MAXVERTS);
 
+
     IMAGE_RESTRICT = new_bit_array(MAXVERTS);
     ORB_LOOKUP     = new_bit_array(MAXVERTS);
     REPS           = malloc(MAXVERTS * sizeof(BitArray*));
     for (uint16_t i = 0; i < MAXVERTS; i++) {
+      BLISS_GRAPH[i]      = bliss_digraphs_new(i);
       REPS[i]             = new_bit_array(MAXVERTS);
       BIT_ARRAY_BUFFER[i] = new_bit_array(MAXVERTS);
       MAP_UNDEFINED[i]    = new_bit_array(MAXVERTS);
@@ -1753,7 +1759,7 @@ static bool init_data_from_args(Obj digraph1_obj,
   if (colors == NULL) {
     get_automorphism_group_from_gap(digraph2_obj, STAB_GENS[0]);
   } else if (is_undirected) {
-    automorphisms_graph(GRAPH2, colors, STAB_GENS[0]);
+    automorphisms_graph(GRAPH2, colors, STAB_GENS[0], BLISS_GRAPH[PERM_DEGREE]);
   } else {
     automorphisms_digraph(DIGRAPH2, colors, STAB_GENS[0]);
   }

--- a/src/homos.c
+++ b/src/homos.c
@@ -515,9 +515,9 @@ static void internal_order_map_graph(Graph const* const graph) {
 
 // Helper for the main recursive homomorphism function.
 static ALWAYS_INLINE uint16_t
-                     graph_homo_update_conditions(uint16_t const depth,
-                                                  uint16_t const last_defined,
-                                                  uint16_t const vertex) {
+graph_homo_update_conditions(uint16_t const depth,
+                             uint16_t const last_defined,
+                             uint16_t const vertex) {
   push_conditions(
       CONDITIONS, depth, vertex, GRAPH2->neighbours[MAP[last_defined]]);
   store_size_conditions(CONDITIONS, vertex);
@@ -675,9 +675,9 @@ static void find_graph_homos(uint16_t        depth,
 
 // Helper for the main recursive monomorphism function.
 static ALWAYS_INLINE uint16_t
-                     graph_mono_update_conditions(uint16_t const depth,
-                                                  uint16_t const last_defined,
-                                                  uint16_t const vertex) {
+graph_mono_update_conditions(uint16_t const depth,
+                             uint16_t const last_defined,
+                             uint16_t const vertex) {
   push_conditions(
       CONDITIONS, depth, vertex, GRAPH2->neighbours[MAP[last_defined]]);
   store_size_conditions(CONDITIONS, vertex);
@@ -1049,9 +1049,9 @@ static void init_partial_map_and_find_graph_homos(Obj partial_map_obj,
 
 // Helper for the main recursive homomorphism of digraphs function.
 static ALWAYS_INLINE uint16_t
-                     digraph_homo_update_conditions(uint16_t const depth,
-                                                    uint16_t const last_defined,
-                                                    uint16_t const vertex) {
+digraph_homo_update_conditions(uint16_t const depth,
+                               uint16_t const last_defined,
+                               uint16_t const vertex) {
   if (is_adjacent_digraph(DIGRAPH1, last_defined, vertex)) {
     push_conditions(
         CONDITIONS, depth, vertex, DIGRAPH2->out_neighbours[MAP[last_defined]]);
@@ -1206,9 +1206,9 @@ static void find_digraph_homos(uint16_t        depth,
 
 // Helper for the main recursive monomorphism of digraphs function.
 static ALWAYS_INLINE uint16_t
-                     digraph_mono_update_conditions(uint16_t const depth,
-                                                    uint16_t const last_defined,
-                                                    uint16_t const vertex) {
+digraph_mono_update_conditions(uint16_t const depth,
+                               uint16_t const last_defined,
+                               uint16_t const vertex) {
   push_conditions(CONDITIONS, depth, vertex, NULL);
   if (is_adjacent_digraph(DIGRAPH1, last_defined, vertex)) {
     intersect_bit_arrays(get_conditions(CONDITIONS, vertex),
@@ -1321,9 +1321,9 @@ static void find_digraph_monos(uint16_t        depth,
 
 // Helper for the main recursive embedding digraphs function.
 static ALWAYS_INLINE uint16_t
-                     digraph_embed_update_conditions(uint16_t const depth,
-                                                     uint16_t const last_def,
-                                                     uint16_t const vertex) {
+digraph_embed_update_conditions(uint16_t const depth,
+                                uint16_t const last_def,
+                                uint16_t const vertex) {
   push_conditions(CONDITIONS, depth, vertex, NULL);
   if (is_adjacent_digraph(DIGRAPH1, last_def, vertex)) {
     intersect_bit_arrays(get_conditions(CONDITIONS, vertex),
@@ -1574,7 +1574,6 @@ static bool init_data_from_args(Obj digraph1_obj,
 
     GRAPH1 = new_graph(MAXVERTS);
     GRAPH2 = new_graph(MAXVERTS);
-
 
     IMAGE_RESTRICT = new_bit_array(MAXVERTS);
     ORB_LOOKUP     = new_bit_array(MAXVERTS);

--- a/src/homos.c
+++ b/src/homos.c
@@ -47,7 +47,16 @@
 #include "perms.h"            // for MAXVERTS, UNDEFINED, PermColl, Perm
 #include "schreier-sims.h"    // for PermColl, . . .
 
-#include "bliss-0.73/bliss_C.h"
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+#include "bliss-0.73/bliss_C.h"  // for bliss_digraphs_release, . . .
+#else
+#include "bliss/bliss_C.h"
+#define bliss_digraphs_add_edge bliss_add_edge
+#define bliss_digraphs_new bliss_new
+#define bliss_digraphs_add_vertex bliss_add_vertex
+#define bliss_digraphs_find_canonical_labeling bliss_find_canonical_labeling
+#define bliss_digraphs_release bliss_release
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // 1. Macros
@@ -164,7 +173,7 @@ static Digraph* DIGRAPH2;
 static Graph* GRAPH1;  // Graphs to hold incoming GAP symmetric digraphs
 static Graph* GRAPH2;
 
-static BlissGraph* BLISS_GRAPH[MAXVERTS];
+static BlissGraph* BLISS_GRAPH[3 * MAXVERTS];
 
 static uint16_t MAP[MAXVERTS];            // partial image list
 static uint16_t COLORS2[MAXVERTS];        // colors of range (di)graph
@@ -1758,9 +1767,17 @@ static bool init_data_from_args(Obj digraph1_obj,
   if (colors == NULL) {
     get_automorphism_group_from_gap(digraph2_obj, STAB_GENS[0]);
   } else if (is_undirected) {
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
     automorphisms_graph(GRAPH2, colors, STAB_GENS[0], BLISS_GRAPH[PERM_DEGREE]);
+#else
+    automorphisms_graph(GRAPH2, colors, STAB_GENS[0]);
+#endif
   } else {
+#ifdef DIGRAPHS_WITH_INCLUDED_BLISS
+    automorphisms_digraph(DIGRAPH2, colors, STAB_GENS[0], BLISS_GRAPH[3 * PERM_DEGREE]);
+#else
     automorphisms_digraph(DIGRAPH2, colors, STAB_GENS[0]);
+#endif
   }
   compute_stabs_and_orbit_reps(nr1, nr2, 0, 0, UNDEFINED);
   return true;


### PR DESCRIPTION
The purpose of this PR is to remove the use of `malloc` in the version of bliss that's vendored  by Digraphs. The rationale behind this is the same as in PR #281:

> I'm writing some code that involves a very large number of calls to the homomorphism finding code for relatively small digraphs. 

Another thing that stands out when profiling this is that the top three or four things in the profile are all related to bliss mallocing and freeing memory. This PR will make it possible for the homomorphism finding code in GAP to modify a bliss graph in-place (without any memory allocation or deallocation), and repeatedly reuse that graph and all of its associated data structures in `bliss` for finding the automorphism group. 

With this PR (in its current unfinished state):

~~~~
gap> D := CompleteDigraph(2);;
gap> for i in [1 .. 100000] do
> HomomorphismDigraphsFinder(D, D, fail, [], 1, 2, 0, [1, 2],
> [], [[1, 2]], [[1, 2]]);
> od;
gap> time;
660
~~~~

in the `stable-1.0` branch:

~~~~
gap> D := CompleteDigraph(2);;
gap> for i in [1 .. 100000] do
> HomomorphismDigraphsFinder(D, D, fail, [], 1, 2, 0, [1, 2],
> [], [[1, 2]], [[1, 2]]);
> od;
gap> time;
1205
~~~~

This PR is work in progress, I'm just pushing now to see what happens with the CI, and to ask for comments. 


