### PR TITLE
Allow user to specify automorphisms in HomomorphismDigraphsFinder

### DIFF
--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -10,7 +10,7 @@
 
 <#GAPDoc Label="HomomorphismDigraphsFinder">
 <ManSection>
-  <Func Name="HomomorphismDigraphsFinder" Arg="D1, D2, hook, user_param, max_results, hint, injective, image, partial_map, colors1, colors2[, order]"/>
+  <Func Name="HomomorphismDigraphsFinder" Arg="D1, D2, hook, user_param, max_results, hint, injective, image, partial_map, colors1, colors2[, order, aut_grp]"/>
   <Returns>The argument <A>user_param</A>.</Returns>
   <Description>
     This function finds homomorphisms from the digraph <A>D1</A> to the digraph
@@ -19,7 +19,8 @@
 
     If <C>f</C> and <C>g</C> are homomorphisms found by
     <C>HomomorphismDigraphsFinder</C>, then <C>f</C> cannot be obtained from
-    <C>g</C> by right multiplying by an automorphism of <A>D2</A>.
+    <C>g</C> by right multiplying by an automorphism of <A>D2</A> in
+    <A>aut_grp</A>.
 
     <List>
       <Mark><A>hook</A></Mark>
@@ -125,12 +126,19 @@
       </Item>
       <Mark><A>order</A></Mark>
       <Item>
-        The optional final argument <A>order</A> specifies the order the
+        The optional argument <A>order</A> specifies the order the
         vertices in <A>D1</A> appear in the search for homomorphisms. 
         The value of this parameter can have a large impact
         on the runtime of the function. It seems in many cases to be a good
         idea for this to be the <Ref Attr="DigraphWelshPowellOrder"/>, i.e.
         vertices ordered from highest to lowest degree.
+      </Item>
+      <Item>
+        The optional argument <A>aut_grp</A> should be a subgroup of the
+        automorphism group of <A>D2</A>. This function returns unique
+        representatives of the homomorphisms found up to right multiplication
+        by <A>aut_grp</A>. If this argument is not specific, it defaults to the
+        full automorphism group of <A>D2</A>, which may be costly to calculate.
       </Item>
     </List>
 
@@ -155,7 +163,18 @@ gap> HomomorphismDigraphsFinder(D, D2, func, [Transformation([2, 2])],
 [ Transformation( [ 2, 2 ] ), 
   Transformation( [ 2, 2, 2, 3, 4, 5, 6, 2, 2, 2 ] ), 
   Transformation( [ 2, 2, 2, 3, 4, 5, 6, 2, 2, 3 ] ), 
-  Transformation( [ 2, 2, 2, 3, 4, 5, 6, 2, 2, 4 ] ) ]]]></Example>
+  Transformation( [ 2, 2, 2, 3, 4, 5, 6, 2, 2, 4 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(2), NullDigraph(3), fail,
+> [], infinity, fail, 1, [1, 2, 3], fail, fail, fail, fail,
+> Group(()));
+[ IdentityTransformation, Transformation( [ 1, 3, 3 ] ), 
+  Transformation( [ 2, 1 ] ), Transformation( [ 2, 3, 3 ] ), 
+  Transformation( [ 3, 1, 3 ] ), Transformation( [ 3, 2, 3 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(2), NullDigraph(3), fail,
+> [], infinity, fail, 1, [1, 2, 3], fail, fail, fail, fail,
+> Group((1, 2)));
+[ IdentityTransformation, Transformation( [ 1, 3, 3 ] ), 
+  Transformation( [ 3, 1, 3 ] ) ]]]></Example>
   </Description>
 </ManSection>
 <#/GAPDoc>

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -565,9 +565,13 @@ gap> EmbeddingsDigraphs(D1, D2);
 <#GAPDoc Label="IsDigraphHomomorphism">
 <ManSection>
   <Oper Name="IsDigraphHomomorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphHomomorphism" Arg="src, ran, x, col1, col2"/>
   <Oper Name="IsDigraphEpimorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphEpimorphism" Arg="src, ran, x, col1, col2"/>
   <Oper Name="IsDigraphMonomorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphMonomorphism" Arg="src, ran, x, col1, col2"/>
   <Oper Name="IsDigraphEndomorphism" Arg="digraph, x"/>
+  <Oper Name="IsDigraphEndomorphism" Arg="digraph, x, col"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
     <C>IsDigraphHomomorphism</C> returns <K>true</K> if the permutation
@@ -603,6 +607,20 @@ gap> EmbeddingsDigraphs(D1, D2);
     </List>
     See also <Ref Func="GeneratorsOfEndomorphismMonoid"/>.<P/>
 
+    If <A>col1</A> and <A>col2</A>, or <A>col</A>, are given then they must
+    represent vertex colourings; see <Ref Oper="AutomorphismGroup" Label="for a
+    digraph and a homogeneous list"/> for details of the permissible values for
+    these argument. The homomorphism must then also have the property:
+  
+    <List>
+      <Item>
+        <C>col[i] = col[i ^ x]</C> for all vertices <C>i</C> of <A>digraph</A>,
+        in the case of <C>IsDigraphEndomorphism</C>.</Item>
+      <Item>
+        <C>col1[i] = col2[i ^ x]</C> for all vertices <C>i</C> of <A>src</A>,
+        in the cases of the other operations.</Item>
+    </List>
+
     <Example><![CDATA[
 gap> src := Digraph([[1], [1, 2], [1, 3]]);
 <immutable digraph with 3 vertices, 5 edges>
@@ -616,8 +634,18 @@ gap> IsDigraphHomomorphism(src, ran, Transformation([3, 3, 3]));
 false
 gap> IsDigraphHomomorphism(src, src, Transformation([3, 3, 3]));
 true
+gap> IsDigraphHomomorphism(src, ran, Transformation([1, 2, 2]),
+>                          [1, 2, 2], [1, 2]);
+true
+gap> IsDigraphHomomorphism(src, ran, Transformation([1, 2, 2]),
+>                          [2, 1, 1], [1, 2]);
+false
 gap> IsDigraphEndomorphism(src, Transformation([3, 3, 3]));
 true
+gap> IsDigraphEndomorphism(src, Transformation([3, 3, 3]), [1, 1, 1]);
+true
+gap> IsDigraphEndomorphism(src, Transformation([3, 3, 3]), [1, 1, 2]);
+false
 gap> IsDigraphEpimorphism(src, ran, Transformation([3, 3, 3]));
 false
 gap> IsDigraphMonomorphism(src, ran, Transformation([1, 2, 2]));
@@ -633,11 +661,13 @@ true]]></Example>
 <#GAPDoc Label="IsDigraphEmbedding">
 <ManSection>
   <Oper Name="IsDigraphEmbedding" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphEmbedding" Arg="src, ran, x, col1, col2"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
     <C>IsDigraphEmbedding</C> returns <K>true</K> if the permutation
     or transformation <A>x</A> is a embedding of the digraph
-    <A>src</A> into the digraph <A>ran</A>.
+    <A>src</A> into the digraph <A>ran</A>, while respecting the colourings
+    <A>col1</A> and <A>col2</A> if given.
     <P/>
 
     A permutation or transformation <A>x</A> is a <E>embedding</E> of a digraph
@@ -657,6 +687,10 @@ gap> IsDigraphMonomorphism(src, ran, ());
 true
 gap> IsDigraphEmbedding(src, ran, ());
 true
+gap> IsDigraphEmbedding(src, ran, (), [2, 1], [2, 1, 1]);
+true
+gap> IsDigraphEmbedding(src, ran, (), [2, 1], [1, 2, 1]);
+false
 gap> ran := Digraph([[1, 2], [1, 2], [1, 3]]);
 <immutable digraph with 3 vertices, 6 edges>
 gap> IsDigraphMonomorphism(src, ran, IdentityTransformation);

--- a/doc/grahom.xml
+++ b/doc/grahom.xml
@@ -626,7 +626,7 @@ gap> EmbeddingsDigraphs(D1, D2);
     </List>
     See also <Ref Func="GeneratorsOfEndomorphismMonoid"/>.<P/>
 
-    If <A>col1</A> and <A>col2</A>, or <A>col</A>, are given then they must
+    If <A>col1</A> and <A>col2</A>, or <A>col</A>, are given, then they must
     represent vertex colourings; see <Ref Oper="AutomorphismGroup" Label="for a
     digraph and a homogeneous list"/> for details of the permissible values for
     these argument. The homomorphism must then also have the property:

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -753,7 +753,9 @@ gap> OutNeighbours(canon);
 <#GAPDoc Label="IsDigraphAutomorphism">
 <ManSection>
   <Oper Name="IsDigraphIsomorphism" Arg="src, ran, x"/>
+  <Oper Name="IsDigraphIsomorphism" Arg="src, ran, x, col1, col2"/>
   <Oper Name="IsDigraphAutomorphism" Arg="digraph, x"/>
+  <Oper Name="IsDigraphAutomorphism" Arg="digraph, x, col"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
     <C>IsDigraphIsomorphism</C> returns <K>true</K> if the permutation or
@@ -783,6 +785,21 @@ gap> OutNeighbours(canon);
     </List>
     See also <Ref Attr="AutomorphismGroup" Label="for a digraph"
       />.<P/>
+    
+    
+    If <A>col1</A> and <A>col2</A>, or <A>col</A>, are given then they must
+    represent vertex colourings; see <Ref Oper="AutomorphismGroup" Label="for a
+    digraph and a homogeneous list"/> for details of the permissible values for
+    these argument. The homomorphism must then also have the property:
+  
+    <List>
+      <Item>
+        <C>col1[i] = col2[i ^ x]</C> for all vertices <C>i</C> of <A>src</A>,
+        for <C>IsDigraphIsomorphism</C>. </Item>
+      <Item>
+        <C>col[i] = col[i ^ x]</C> for all vertices <C>i</C> of <A>digraph</A>,
+        for <C>IsDigraphAutomorphism</C>. </Item>
+    </List>
 
     For some digraphs, it can be faster to use <C>IsDigraphAutomorphism</C>
     than to test membership in the automorphism group of <A>digraph</A>.
@@ -794,6 +811,10 @@ gap> IsDigraphAutomorphism(src, (1, 2, 3));
 false
 gap> IsDigraphAutomorphism(src, (2, 3));
 true
+gap> IsDigraphAutomorphism(src, (2, 3), [2, 1, 1]);
+true
+gap> IsDigraphAutomorphism(src, (2, 3), [2, 2, 1]);
+false
 gap> IsDigraphAutomorphism(src, (2, 3)(4, 5));
 false
 gap> IsDigraphAutomorphism(src, (1, 4));
@@ -809,6 +830,10 @@ true
 gap> IsDigraphIsomorphism(ran, src, (1, 2));
 true
 gap> IsDigraphIsomorphism(src, Digraph([[3], [1, 3], [2]]), (1, 2, 3));
+false
+gap> IsDigraphIsomorphism(src, ran, (1, 2), [1, 2, 3], [2, 1, 3]);
+true
+gap> IsDigraphIsomorphism(src, ran, (1, 2), [1, 2, 2], [2, 1, 3]);
 false
 ]]></Example>
   </Description>

--- a/doc/isomorph.xml
+++ b/doc/isomorph.xml
@@ -786,7 +786,6 @@ gap> OutNeighbours(canon);
     See also <Ref Attr="AutomorphismGroup" Label="for a digraph"
       />.<P/>
     
-    
     If <A>col1</A> and <A>col2</A>, or <A>col</A>, are given then they must
     represent vertex colourings; see <Ref Oper="AutomorphismGroup" Label="for a
     digraph and a homogeneous list"/> for details of the permissible values for

--- a/gap/grahom.gd
+++ b/gap/grahom.gd
@@ -43,10 +43,20 @@ DeclareOperation("IsDigraphEndomorphism", [IsDigraph, IsTransformation]);
 DeclareOperation("IsDigraphHomomorphism",
                  [IsDigraph, IsDigraph, IsTransformation]);
 
+DeclareOperation("IsDigraphEndomorphism",
+                 [IsDigraph, IsTransformation, IsList]);
+DeclareOperation("IsDigraphHomomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation, IsList, IsList]);
+
 DeclareOperation("IsDigraphEndomorphism", [IsDigraph, IsPerm]);
 DeclareOperation("IsDigraphHomomorphism",
                  [IsDigraph, IsDigraph, IsPerm]);
 
+DeclareOperation("IsDigraphEndomorphism",
+                 [IsDigraph, IsPerm, IsList]);
+DeclareOperation("IsDigraphHomomorphism",
+                 [IsDigraph, IsDigraph, IsPerm, IsList, IsList]);
+
 DeclareOperation("IsDigraphEpimorphism",
                  [IsDigraph, IsDigraph, IsTransformation]);
 DeclareOperation("IsDigraphMonomorphism",
@@ -55,11 +65,25 @@ DeclareOperation("IsDigraphEmbedding",
                  [IsDigraph, IsDigraph, IsTransformation]);
 
 DeclareOperation("IsDigraphEpimorphism",
+                 [IsDigraph, IsDigraph, IsTransformation, IsList, IsList]);
+DeclareOperation("IsDigraphMonomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation, IsList, IsList]);
+DeclareOperation("IsDigraphEmbedding",
+                 [IsDigraph, IsDigraph, IsTransformation, IsList, IsList]);
+
+DeclareOperation("IsDigraphEpimorphism",
                  [IsDigraph, IsDigraph, IsPerm]);
 DeclareOperation("IsDigraphMonomorphism",
                  [IsDigraph, IsDigraph, IsPerm]);
 DeclareOperation("IsDigraphEmbedding",
                  [IsDigraph, IsDigraph, IsPerm]);
+
+DeclareOperation("IsDigraphEpimorphism",
+                 [IsDigraph, IsDigraph, IsPerm, IsList, IsList]);
+DeclareOperation("IsDigraphMonomorphism",
+                 [IsDigraph, IsDigraph, IsPerm, IsList, IsList]);
+DeclareOperation("IsDigraphEmbedding",
+                 [IsDigraph, IsDigraph, IsPerm, IsList, IsList]);
 
 DeclareOperation("IsDigraphColouring", [IsDigraph, IsList]);
 DeclareOperation("IsDigraphColouring", [IsDigraph, IsTransformation]);

--- a/gap/isomorph.gd
+++ b/gap/isomorph.gd
@@ -57,7 +57,14 @@ DeclareGlobalFunction("DIGRAPHS_ValidateEdgeColouring");
 DeclareGlobalFunction("DIGRAPHS_CollapseMultiColouredEdges");
 
 DeclareOperation("IsDigraphAutomorphism", [IsDigraph, IsPerm]);
-DeclareOperation("IsDigraphIsomorphism", [IsDigraph, IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphAutomorphism", [IsDigraph, IsPerm, IsList]);
 DeclareOperation("IsDigraphAutomorphism", [IsDigraph, IsTransformation]);
+DeclareOperation("IsDigraphAutomorphism", [IsDigraph, IsTransformation, IsList]);
+
+DeclareOperation("IsDigraphIsomorphism", [IsDigraph, IsDigraph, IsPerm]);
+DeclareOperation("IsDigraphIsomorphism",
+                 [IsDigraph, IsDigraph, IsPerm, IsList, IsList]);
 DeclareOperation("IsDigraphIsomorphism",
                  [IsDigraph, IsDigraph, IsTransformation]);
+DeclareOperation("IsDigraphIsomorphism",
+                 [IsDigraph, IsDigraph, IsTransformation, IsList, IsList]);

--- a/gap/isomorph.gi
+++ b/gap/isomorph.gi
@@ -718,9 +718,26 @@ function(src, ran, x)
      and IsDigraphHomomorphism(ran, src, x ^ -1);
 end);
 
+InstallMethod(IsDigraphIsomorphism,
+"for digraph, digraph, permutation, list, and list",
+[IsDigraph, IsDigraph, IsPerm, IsList, IsList],
+function(src, ran, x, c1, c2)
+  if IsMultiDigraph(src) or IsMultiDigraph(ran) then
+    ErrorNoReturn("the 1st and 2nd arguments <src> and <ran> must not have ",
+                  "multiple edges,");
+  fi;
+  return IsDigraphHomomorphism(src, ran, x, c1, c2)
+     and IsDigraphHomomorphism(ran, src, x ^ -1, c1, c2);
+end);
+
 InstallMethod(IsDigraphAutomorphism, "for a digraph and a permutation",
 [IsDigraph, IsPerm],
 {D, x} -> IsDigraphIsomorphism(D, D, x));
+
+InstallMethod(IsDigraphAutomorphism,
+"for a digraph, a permutation, and a list",
+[IsDigraph, IsPerm, IsList],
+{D, x, c} -> IsDigraphIsomorphism(D, D, x, c, c));
 
 InstallMethod(IsDigraphIsomorphism, "for digraph, digraph, and transformation",
 [IsDigraph, IsDigraph, IsTransformation],
@@ -733,6 +750,23 @@ function(src, ran, x)
   return IsDigraphIsomorphism(src, ran, y);
 end);
 
+InstallMethod(IsDigraphIsomorphism,
+"for digraph, digraph, transformation, list, and list",
+[IsDigraph, IsDigraph, IsTransformation, IsList, IsList],
+function(src, ran, x, c1, c2)
+  local y;
+  y := AsPermutation(RestrictedTransformation(x, DigraphVertices(src)));
+  if y = fail then
+    return false;
+  fi;
+  return IsDigraphIsomorphism(src, ran, y, c1, c2);
+end);
+
 InstallMethod(IsDigraphAutomorphism, "for a digraph and a transformation",
 [IsDigraph, IsTransformation],
 {D, x} -> IsDigraphIsomorphism(D, D, x));
+
+InstallMethod(IsDigraphAutomorphism,
+"for a digraph, a transformation, and a list",
+[IsDigraph, IsTransformation, IsList],
+{D, x, c} -> IsDigraphIsomorphism(D, D, x, c, c));

--- a/src/digraphs.c
+++ b/src/digraphs.c
@@ -51,6 +51,9 @@ Obj IsSymmetricDigraph;
 Obj GeneratorsOfGroup;
 Obj AutomorphismGroup;
 Obj IsAttributeStoringRepObj;
+Obj IsPermGroup;
+Obj IsDigraphAutomorphism;
+Obj LargestMovedPointPerms;
 
 #if !defined(GAP_KERNEL_MAJOR_VERSION) || GAP_KERNEL_MAJOR_VERSION < 3
 // compatibility with GAP <= 4.9
@@ -2280,6 +2283,9 @@ static Int InitKernel(StructInitInfo* module) {
   ImportGVarFromLibrary("AutomorphismGroup", &AutomorphismGroup);
   ImportGVarFromLibrary("GeneratorsOfGroup", &GeneratorsOfGroup);
   ImportGVarFromLibrary("IsAttributeStoringRep", &IsAttributeStoringRepObj);
+  ImportGVarFromLibrary("IsPermGroup", &IsPermGroup);
+  ImportGVarFromLibrary("IsDigraphAutomorphism", &IsDigraphAutomorphism);
+  ImportGVarFromLibrary("LargestMovedPointPerms", &LargestMovedPointPerms);
   /* return success                                                      */
   return 0;
 }

--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -34,6 +34,8 @@
 #define bliss_digraphs_find_automorphisms       bliss_find_automorphisms
 #endif
 
+extern Obj GeneratorsOfGroup;
+
 Digraph* new_digraph(uint16_t const nr_verts) {
   DIGRAPHS_ASSERT(nr_verts <= MAXVERTS);
   Digraph* digraph        = malloc(sizeof(Digraph));

--- a/src/homos-graphs.h
+++ b/src/homos-graphs.h
@@ -78,5 +78,4 @@ static inline bool is_adjacent_graph(Graph const* const graph,
 }
 
 void automorphisms_graph(Graph const* const, uint16_t const* const, PermColl*);
-
 #endif  // DIGRAPHS_SRC_HOMOS_GRAPHS_H_

--- a/src/perms.c
+++ b/src/perms.c
@@ -25,6 +25,41 @@ Perm new_perm(uint16_t const degree) {
   return malloc(degree * sizeof(uint16_t));
 }
 
+Perm new_perm_from_gap(Obj gap_perm_obj, uint16_t const degree) {
+  UInt lmp = LargestMovedPointPerm(gap_perm_obj);
+  DIGRAPHS_ASSERT(lmp <= MAXVERTS);
+  if (lmp > MAXVERTS) {
+    ErrorQuit("expected permutations of degree at most %d, but got a "
+              "permutation of degree %d",
+              MAXVERTS,
+              lmp);
+  }
+
+  DIGRAPHS_ASSERT(lmp <= degree);
+
+  Perm p = new_perm(degree > 0 ? degree : 1);
+
+  if (IS_PERM2(gap_perm_obj)) {
+    UInt2* gap_perm_ptr = ADDR_PERM2(gap_perm_obj);
+    for (UInt i = 0; i < lmp; ++i) {
+      p[i] = gap_perm_ptr[i];
+    }
+    for (UInt i = lmp; i < degree; ++i) {
+      p[i] = i;
+    }
+  } else {
+    DIGRAPHS_ASSERT(IS_PERM4(gap_perm_obj));
+    UInt4* gap_perm_ptr = ADDR_PERM4(gap_perm_obj);
+    for (UInt i = 0; i < lmp; ++i) {
+      p[i] = gap_perm_ptr[i];
+    }
+    for (UInt i = lmp; i < degree; ++i) {
+      p[i] = i;
+    }
+  }
+  return p;
+}
+
 PermColl* new_perm_coll(uint16_t const capacity, uint16_t const degree) {
   PermColl* coll = malloc(sizeof(PermColl));
   coll->perms    = malloc(capacity * sizeof(Perm));

--- a/src/perms.h
+++ b/src/perms.h
@@ -21,6 +21,10 @@
 
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT
 
+// GAP headers
+#include "src/compiled.h"  // for Obj, Int
+#include "src/permutat.h"  // for ADDR_PERM, IS_PERM 
+
 #define MAXVERTS 512
 #define UNDEFINED MAXVERTS + 1
 
@@ -33,6 +37,8 @@
 typedef uint16_t* Perm;
 
 Perm new_perm(uint16_t const);
+
+Perm new_perm_from_gap(Obj, uint16_t const);
 
 static inline void id_perm(Perm x, uint16_t const degree) {
   DIGRAPHS_ASSERT(degree <= MAXVERTS);

--- a/src/perms.h
+++ b/src/perms.h
@@ -23,7 +23,7 @@
 
 // GAP headers
 #include "src/compiled.h"  // for Obj, Int
-#include "src/permutat.h"  // for ADDR_PERM, IS_PERM 
+#include "src/permutat.h"  // for ADDR_PERM, IS_PERM
 
 #define MAXVERTS 512
 #define UNDEFINED MAXVERTS + 1

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2193,13 +2193,13 @@ gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
 Error, the 12th argument <order> must be duplicate-free, but the value 1 in po\
 sition 2 is a duplicate,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
-> fail, true, [1, 2, 3], [1], fail, fail, FreeGroup(3));
+> fail, true, [1, 2, 3], [1], fail, fail, 12);
 Error, the 12th or 13th argument <aut_grp> must be a permutation group or fail\
-, not object (component),
+, not integer,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
-> fail, true, [1, 2, 3], [1], fail, fail, Semigroup(Transformation([1, 1])));
+> fail, true, [1, 2, 3], [1], fail, fail, true);
 Error, the 12th or 13th argument <aut_grp> must be a permutation group or fail\
-, not object (component),
+, not boolean or fail,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
 > fail, true, [1, 2, 3], [1], fail, fail, Group(CycleFromList([1 .. 1000])));
 Error, expected group of automorphisms, but found a non-automorphism in positi\

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2191,25 +2191,25 @@ gap> IsDigraphAutomorphism(gr1, x, [1, 1, 1, 1, 1, 1]);
 true
 gap> IsDigraphAutomorphism(gr1, x, [1, 1, 2, 2, 3, 3]); 
 false
-gap> IsDigraphAutomorphism(gr1, x^2, [1, 1, 2, 2, 3, 3]);
+gap> IsDigraphAutomorphism(gr1, x ^ 2, [1, 1, 2, 2, 3, 3]);
 false
-gap> IsDigraphAutomorphism(gr1, x^2, [1, 2, 2, 3, 4, 4]);
+gap> IsDigraphAutomorphism(gr1, x ^ 2, [1, 2, 2, 3, 4, 4]);
 false
-gap> IsDigraphAutomorphism(gr1, x^2, [1, 1, 1, 1, 1, 1]);
+gap> IsDigraphAutomorphism(gr1, x ^ 2, [1, 1, 1, 1, 1, 1]);
 true
-gap> IsDigraphAutomorphism(gr1, x^3, [1, 2, 2, 3, 4, 4]);
+gap> IsDigraphAutomorphism(gr1, x ^ 3, [1, 2, 2, 3, 4, 4]);
 false
-gap> IsDigraphAutomorphism(gr1, x^3, [1, 1, 1, 1, 1, 1]);
+gap> IsDigraphAutomorphism(gr1, x ^ 3, [1, 1, 1, 1, 1, 1]);
 true
 gap> IsDigraphAutomorphism(gr1, t, [1 .. 6]);            
 false
 gap> IsDigraphAutomorphism(gr1, t, [1, 1, 2, 2, 3, 3]);
 false
-gap> IsDigraphAutomorphism(gr1, t^2, [1, 1, 2, 2, 3, 3]);
+gap> IsDigraphAutomorphism(gr1, t ^ 2, [1, 1, 2, 2, 3, 3]);
 false
-gap> IsDigraphAutomorphism(gr1, t^2, [1, 2, 2, 3, 4, 4]);
+gap> IsDigraphAutomorphism(gr1, t ^ 2, [1, 2, 2, 3, 4, 4]);
 false
-gap> IsDigraphAutomorphism(gr1, t^3, [1, 2, 2, 3, 4, 4]);
+gap> IsDigraphAutomorphism(gr1, t ^ 3, [1, 2, 2, 3, 4, 4]);
 false
 gap> gr1 := DigraphFromDigraph6String("&D~~~~_");
 <immutable digraph with 5 vertices, 25 edges>
@@ -2258,10 +2258,10 @@ true
 gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]), [1, 2, 3], [1, 2]);
 false
 gap> IsDigraphEpimorphism(src, src, Transformation([1, 2, 3]),
->                         [1, 1, 2], [1, 1,2]);
+>                         [1, 1, 2], [1, 1, 2]);
 true
 gap> IsDigraphEpimorphism(src, src, Transformation([1, 2, 3]),
->                         [1, 2, 3], [1, 1,2]);
+>                         [1, 2, 3], [1, 1, 2]);
 false
 gap> IsDigraphEpimorphism(src, src, (), [1, 2, 2], [1, 2, 2]);
 true

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2140,6 +2140,197 @@ gap> GeneratorsOfEndomorphismMonoid(gr);
 [ Transformation( [ 2, 3, 4, 5, 1 ] ), Transformation( [ 2, 1 ] ), 
   IdentityTransformation ]
 
+# IsHomomorphism etc. for vertex-coloured digraphs
+gap> gr1 := Digraph([[], []]);
+<immutable empty digraph with 2 vertices>
+gap> gr2 := Digraph([[], [1]]);
+<immutable digraph with 2 vertices, 1 edge>
+gap> IsDigraphAutomorphism(gr1, Transformation([1, 2]));
+true
+gap> IsDigraphAutomorphism(gr1, Transformation([1, 2]), [1, 2]);
+true
+gap> IsDigraphAutomorphism(gr2, Transformation([1, 2]), [1, 1]);
+true
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2]));
+true
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2]), [1, 2], [1, 1]);
+false
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2]), [1, 1], [1, 1]);
+true
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2]), [1, 1], [1, 2]);
+false
+gap> gr1 := Digraph([[], []]);
+<immutable empty digraph with 2 vertices>
+gap> gr1 := ChainDigraph(3);   
+<immutable chain digraph with 3 vertices>
+gap> gr2 := ChainDigraph(6);
+<immutable chain digraph with 6 vertices>
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]), [1 .. 3], [1 .. 6]);
+true
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]), [1 .. 3], [1, 1, 2, 3, 4, 5]);   
+false
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]),
+> [2, 2, 1], [2, 2, 1, 3, 4, 5]);
+true
+gap> IsDigraphHomomorphism(gr1, gr2, Transformation([1, 2, 3]),
+> [2, 2, 1], [1, 1, 2, 3, 4, 5]);
+false
+gap> IsDigraphAutomorphism(gr1, Transformation([3, 2, 1]), [1, 2, 3]);
+false
+gap> gr1 := CycleDigraph(6);
+<immutable cycle digraph with 6 vertices>
+gap> x := (1, 2, 3, 4, 5, 6);                                                
+(1,2,3,4,5,6)
+gap> t := AsTransformation(x);
+Transformation( [ 2, 3, 4, 5, 6, 1 ] )
+gap> IsDigraphAutomorphism(gr1, x, [1 .. 6]);
+false
+gap> IsDigraphAutomorphism(gr1, x, [1, 1, 2, 2, 3, 3]); 
+false
+gap> IsDigraphAutomorphism(gr1, x, [1, 1, 1, 1, 1, 1]);
+true
+gap> IsDigraphAutomorphism(gr1, x, [1, 1, 2, 2, 3, 3]); 
+false
+gap> IsDigraphAutomorphism(gr1, x^2, [1, 1, 2, 2, 3, 3]);
+false
+gap> IsDigraphAutomorphism(gr1, x^2, [1, 2, 2, 3, 4, 4]);
+false
+gap> IsDigraphAutomorphism(gr1, x^2, [1, 1, 1, 1, 1, 1]);
+true
+gap> IsDigraphAutomorphism(gr1, x^3, [1, 2, 2, 3, 4, 4]);
+false
+gap> IsDigraphAutomorphism(gr1, x^3, [1, 1, 1, 1, 1, 1]);
+true
+gap> IsDigraphAutomorphism(gr1, t, [1 .. 6]);            
+false
+gap> IsDigraphAutomorphism(gr1, t, [1, 1, 2, 2, 3, 3]);
+false
+gap> IsDigraphAutomorphism(gr1, t^2, [1, 1, 2, 2, 3, 3]);
+false
+gap> IsDigraphAutomorphism(gr1, t^2, [1, 2, 2, 3, 4, 4]);
+false
+gap> IsDigraphAutomorphism(gr1, t^3, [1, 2, 2, 3, 4, 4]);
+false
+gap> gr1 := DigraphFromDigraph6String("&D~~~~_");
+<immutable digraph with 5 vertices, 25 edges>
+gap> ForAll(AutomorphismGroup(gr1),
+>           x -> x = () or not IsDigraphAutomorphism(gr1, x, [1 .. 5]));
+true
+gap> ForAll(AutomorphismGroup(gr1),
+>           x -> IsDigraphAutomorphism(gr1, x, [1, 1, 1, 1, 1]));
+true
+
+# IsDigraphEndomorphism, for vertex-coloured digraphs 
+gap> gr1 := DigraphTransitiveClosure(CompleteDigraph(2));   
+<immutable transitive digraph with 2 vertices, 4 edges>
+gap> IsDigraphEndomorphism(gr1, (1, 2), [1, 2]);
+false
+gap> IsDigraphEndomorphism(gr1, (1, 2), [1, 1]);
+true
+gap> IsDigraphEndomorphism(gr1, Transformation([1, 1]), [1, 2]);
+false
+gap> IsDigraphEndomorphism(gr1, Transformation([1, 1]), [1, 1]);
+true
+gap> ForAll(GeneratorsOfEndomorphismMonoid(gr1),           
+>           x -> IsDigraphEndomorphism(gr1, x, [1, 1]));
+true
+gap> gr2 := Digraph([[3, 4], [1, 3], [4], [1, 2, 3, 5], [2]]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> ForAll(GeneratorsOfEndomorphismMonoid(gr2),             
+>           x -> IsDigraphEndomorphism(gr2, x, [1, 1, 1, 1, 1]));
+true
+gap> gr1 := DigraphFromDigraph6String("&D~~~~_");
+<immutable digraph with 5 vertices, 25 edges>
+gap> ForAll(GeneratorsOfEndomorphismMonoid(gr1),
+>           x -> IsDigraphEndomorphism(gr1, x, [1, 1, 1, 1, 1]));
+true
+gap> ForAll(AutomorphismGroup(gr1),
+>           x -> IsDigraphEndomorphism(gr1, x, [1, 1, 1, 1, 1]));
+true
+
+# IsDigraphEpimorphism, for vertex-coloured digraphs
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<immutable digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<immutable digraph with 2 vertices, 3 edges>
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]), [1, 2, 2], [1, 2]);
+true
+gap> IsDigraphEpimorphism(src, ran, Transformation([1, 2, 2]), [1, 2, 3], [1, 2]);
+false
+gap> IsDigraphEpimorphism(src, src, Transformation([1, 2, 3]),
+>                         [1, 1, 2], [1, 1,2]);
+true
+gap> IsDigraphEpimorphism(src, src, Transformation([1, 2, 3]),
+>                         [1, 2, 3], [1, 1,2]);
+false
+gap> IsDigraphEpimorphism(src, src, (), [1, 2, 2], [1, 2, 2]);
+true
+gap> IsDigraphEpimorphism(src, src, (2, 3), [1, 2, 3], [2, 3, 1]);
+false
+gap> IsDigraphEpimorphism(src, src, (2, 3), [2, 1, 3], [2, 3, 1]);
+true
+
+# IsDigraphMonomorphism, for vertex-coloured digraphs
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<immutable digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<immutable digraph with 2 vertices, 3 edges>
+gap> IsDigraphMonomorphism(src, src, Transformation([1, 3, 2]),
+>                          [2, 3, 1], [2, 1, 3]);
+true
+gap> IsDigraphMonomorphism(src, src, Transformation([1, 3, 2]),
+>                          [2, 3, 1], [2, 3, 1]);
+false
+gap> IsDigraphMonomorphism(src, src, Transformation([1, 2, 3]),
+>                          [2, 1, 1], [1, 2, 2]);
+false
+gap> IsDigraphMonomorphism(src, src, Transformation([1, 2, 3]),
+>                          [1, 2, 2], [1, 2, 2]);
+true
+gap> IsDigraphMonomorphism(ran, src, Transformation([1, 2]),
+>                          [2, 1], [1, 2, 1]);
+false
+gap> IsDigraphMonomorphism(ran, src, Transformation([1, 2]),
+>                          [2, 1], [1, 1, 1]);
+false
+gap> IsDigraphMonomorphism(ran, src, Transformation([1, 2]),
+>                          [1, 1], [1, 1, 2]);
+true
+gap> IsDigraphMonomorphism(src, src, (), [1, 2, 2], [1, 2, 2]);
+true
+gap> IsDigraphMonomorphism(src, src, (), [1, 1, 2], [1, 2, 2]);
+false
+gap> IsDigraphMonomorphism(ran, src, (), [1, 1], [1, 1, 2]);
+true
+gap> IsDigraphMonomorphism(ran, src, (), [1, 1], [2, 2, 1]);
+false
+gap> IsDigraphMonomorphism(ran, src, (), [1, 2], [1, 2, 1]);
+true
+
+# IsDigraphEmbedding, for vertex-coloured digraphs
+gap> src := Digraph([[1], [1, 2], [1, 3]]);
+<immutable digraph with 3 vertices, 5 edges>
+gap> ran := Digraph([[1], [1, 2]]);
+<immutable digraph with 2 vertices, 3 edges>
+gap> IsDigraphEmbedding(src, src, Transformation([1, 2, 3]),
+>                       [1, 1, 1], [1, 1, 1]);
+true
+gap> IsDigraphEmbedding(src, src, Transformation([1, 2, 3]),
+>                       [1, 1, 2], [1, 1, 2]);
+true
+gap> IsDigraphEmbedding(ran, src, Transformation([1, 2]));
+true
+gap> IsDigraphEmbedding(src, src, (), [1, 1, 1], [1, 1, 1]);
+true
+gap> IsDigraphEmbedding(src, src, (), [2, 1, 1], [1, 1, 1]);
+false
+gap> IsDigraphEmbedding(ran, src, (), [1, 1], [1, 1, 2]);
+true
+gap> IsDigraphEmbedding(ran, src, (), [2, 1], [1, 2, 2]);
+false
+gap> IsDigraphEmbedding(ran, src, (), [2, 1], [1, 1, 2]);
+false
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(edges);
 gap> Unbind(epis);

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -2201,12 +2201,13 @@ gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
 Error, the 12th or 13th argument <aut_grp> must be a permutation group or fail\
 , not boolean or fail,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
-> fail, true, [1, 2, 3], [1], fail, fail, Group(CycleFromList([1 .. 1000])));
+> fail, true, [1, 2, 3], [1], fail, fail,
+> Group(MappingPermListList([1 .. 1000], [5 .. 1004])));
 Error, expected group of automorphisms, but found a non-automorphism in positi\
 on 1 of the group generators,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
 > fail, true, [1, 2, 3], [1], fail, fail, 
-> Group((1, 2), CycleFromList([1 .. 1000])));
+> Group((1, 2), MappingPermListList([1 .. 1000], [5 .. 1004])));
 Error, expected group of automorphisms, but found a non-automorphism in positi\
 on 2 of the group generators,
 gap> HomomorphismDigraphsFinder(NullDigraph(3), ChainDigraph(3), fail, [], 1,

--- a/tst/standard/grahom.tst
+++ b/tst/standard/grahom.tst
@@ -902,6 +902,97 @@ gap> HomomorphismDigraphsFinder(gr1, gr2, fail, [], infinity, fail, 1,
 [ IdentityTransformation, Transformation( [ 1, 3, 3 ] ), 
   Transformation( [ 2, 1 ] ), Transformation( [ 3, 1, 3 ] ) ]
 
+# HomomorphismDigraphsFinder: using a subgroup of automorphisms
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 1, [1 .. 4], [], fail, fail,
+> Group(()));
+[ IdentityTransformation, Transformation( [ 1, 2, 4, 3 ] ), 
+  Transformation( [ 1, 3, 2 ] ), Transformation( [ 1, 3, 4, 2 ] ), 
+  Transformation( [ 1, 4, 2, 3 ] ), Transformation( [ 1, 4, 3, 2 ] ), 
+  Transformation( [ 2, 1 ] ), Transformation( [ 2, 1, 4, 3 ] ), 
+  Transformation( [ 2, 3, 1 ] ), Transformation( [ 2, 3, 4, 1 ] ), 
+  Transformation( [ 2, 4, 1, 3 ] ), Transformation( [ 2, 4, 3, 1 ] ), 
+  Transformation( [ 3, 1, 2 ] ), Transformation( [ 3, 1, 4, 2 ] ), 
+  Transformation( [ 3, 2, 1 ] ), Transformation( [ 3, 2, 4, 1 ] ), 
+  Transformation( [ 3, 4, 1, 2 ] ), Transformation( [ 3, 4, 2, 1 ] ), 
+  Transformation( [ 4, 1, 2, 3 ] ), Transformation( [ 4, 1, 3, 2 ] ), 
+  Transformation( [ 4, 2, 1, 3 ] ), Transformation( [ 4, 2, 3, 1 ] ), 
+  Transformation( [ 4, 3, 1, 2 ] ), Transformation( [ 4, 3, 2, 1 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 1, [1 .. 4], [], fail, fail,
+> Group((2, 3)));
+[ IdentityTransformation, Transformation( [ 1, 2, 4, 3 ] ), 
+  Transformation( [ 1, 4, 2, 3 ] ), Transformation( [ 2, 1 ] ), 
+  Transformation( [ 2, 1, 4, 3 ] ), Transformation( [ 2, 3, 1 ] ), 
+  Transformation( [ 2, 3, 4, 1 ] ), Transformation( [ 2, 4, 1, 3 ] ), 
+  Transformation( [ 2, 4, 3, 1 ] ), Transformation( [ 4, 1, 2, 3 ] ), 
+  Transformation( [ 4, 2, 1, 3 ] ), Transformation( [ 4, 2, 3, 1 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 1, [1 .. 4], [], fail, fail,
+> Group((1, 2, 3)));
+[ IdentityTransformation, Transformation( [ 1, 2, 4, 3 ] ), 
+  Transformation( [ 1, 3, 2 ] ), Transformation( [ 1, 3, 4, 2 ] ), 
+  Transformation( [ 1, 4, 2, 3 ] ), Transformation( [ 1, 4, 3, 2 ] ), 
+  Transformation( [ 4, 1, 2, 3 ] ), Transformation( [ 4, 1, 3, 2 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 2, [1 .. 4], [], fail, fail,
+> Group((2, 3)));
+[  ]
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 0, [1 .. 4], [], fail, fail, 
+> Group((1, 2), (2, 3)));
+[ IdentityTransformation, Transformation( [ 1, 2, 3, 1 ] ), 
+  Transformation( [ 1, 2, 3, 2 ] ), Transformation( [ 1, 2, 3, 3 ] ), 
+  Transformation( [ 1, 2, 4, 3 ] ), Transformation( [ 1, 2, 4, 1 ] ), 
+  Transformation( [ 1, 2, 4, 2 ] ), Transformation( [ 1, 2, 4, 4 ] ), 
+  Transformation( [ 1, 2, 1, 3 ] ), Transformation( [ 1, 2, 1 ] ), 
+  Transformation( [ 1, 2, 1, 1 ] ), Transformation( [ 1, 2, 1, 2 ] ), 
+  Transformation( [ 1, 2, 2, 3 ] ), Transformation( [ 1, 2, 2 ] ), 
+  Transformation( [ 1, 2, 2, 1 ] ), Transformation( [ 1, 2, 2, 2 ] ), 
+  Transformation( [ 1, 4, 2, 3 ] ), Transformation( [ 1, 4, 2, 1 ] ), 
+  Transformation( [ 1, 4, 2, 2 ] ), Transformation( [ 1, 4, 2, 4 ] ), 
+  Transformation( [ 1, 4, 1, 2 ] ), Transformation( [ 1, 4, 1, 1 ] ), 
+  Transformation( [ 1, 4, 1, 4 ] ), Transformation( [ 1, 4, 4, 2 ] ), 
+  Transformation( [ 1, 4, 4, 1 ] ), Transformation( [ 1, 4, 4, 4 ] ), 
+  Transformation( [ 1, 1, 2, 3 ] ), Transformation( [ 1, 1, 2 ] ), 
+  Transformation( [ 1, 1, 2, 1 ] ), Transformation( [ 1, 1, 2, 2 ] ), 
+  Transformation( [ 1, 1, 4, 2 ] ), Transformation( [ 1, 1, 4, 1 ] ), 
+  Transformation( [ 1, 1, 4, 4 ] ), Transformation( [ 1, 1, 1, 2 ] ), 
+  Transformation( [ 1, 1, 1 ] ), Transformation( [ 1, 1, 1, 1 ] ), 
+  Transformation( [ 4, 1, 2, 3 ] ), Transformation( [ 4, 1, 2, 1 ] ), 
+  Transformation( [ 4, 1, 2, 2 ] ), Transformation( [ 4, 1, 2, 4 ] ), 
+  Transformation( [ 4, 1, 1, 2 ] ), Transformation( [ 4, 1, 1, 1 ] ), 
+  Transformation( [ 4, 1, 1, 4 ] ), Transformation( [ 4, 1, 4, 2 ] ), 
+  Transformation( [ 4, 1, 4, 1 ] ), Transformation( [ 4, 1, 4, 4 ] ), 
+  Transformation( [ 4, 4, 1, 2 ] ), Transformation( [ 4, 4, 1, 1 ] ), 
+  Transformation( [ 4, 4, 1, 4 ] ), Transformation( [ 4, 4, 4, 1 ] ), 
+  Transformation( [ 4, 4, 4, 4 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 0, [1 .. 4], [], fail, fail,
+> Group((1, 2, 3, 4), (1, 2)));
+[ IdentityTransformation, Transformation( [ 1, 2, 3, 1 ] ), 
+  Transformation( [ 1, 2, 3, 2 ] ), Transformation( [ 1, 2, 3, 3 ] ), 
+  Transformation( [ 1, 2, 1, 3 ] ), Transformation( [ 1, 2, 1, 1 ] ), 
+  Transformation( [ 1, 2, 1, 2 ] ), Transformation( [ 1, 2, 2, 3 ] ), 
+  Transformation( [ 1, 2, 2, 1 ] ), Transformation( [ 1, 2, 2, 2 ] ), 
+  Transformation( [ 1, 1, 2, 3 ] ), Transformation( [ 1, 1, 2, 1 ] ), 
+  Transformation( [ 1, 1, 2, 2 ] ), Transformation( [ 1, 1, 1, 2 ] ), 
+  Transformation( [ 1, 1, 1, 1 ] ) ]
+gap> HomomorphismDigraphsFinder(NullDigraph(4), CompleteDigraph(4),
+> fail, [], infinity, fail, 0, [1 .. 4], [], fail, fail);
+[ IdentityTransformation, Transformation( [ 1, 2, 3, 1 ] ), 
+  Transformation( [ 1, 2, 3, 2 ] ), Transformation( [ 1, 2, 3, 3 ] ), 
+  Transformation( [ 1, 2, 1, 3 ] ), Transformation( [ 1, 2, 1, 1 ] ), 
+  Transformation( [ 1, 2, 1, 2 ] ), Transformation( [ 1, 2, 2, 3 ] ), 
+  Transformation( [ 1, 2, 2, 1 ] ), Transformation( [ 1, 2, 2, 2 ] ), 
+  Transformation( [ 1, 1, 2, 3 ] ), Transformation( [ 1, 1, 2, 1 ] ), 
+  Transformation( [ 1, 1, 2, 2 ] ), Transformation( [ 1, 1, 1, 2 ] ), 
+  Transformation( [ 1, 1, 1, 1 ] ) ]
+gap> HomomorphismDigraphsFinder(CompleteDigraph(3), CompleteDigraph(3),
+> fail, [], infinity, fail, 1, [1 .. 3], [], fail, fail, 
+> Group((1, 2, 3)));
+[ IdentityTransformation, Transformation( [ 1, 3, 2 ] ) ]
+
 #  DigraphHomomorphism
 gap> gr1 := Digraph([[], [3], []]);;
 gap> gr2 := EmptyDigraph(10);;
@@ -2080,7 +2171,8 @@ Error, the 11th argument <colors2> must be a list or fail, not boolean or fail\
 ,
 gap> HomomorphismDigraphsFinder(NullDigraph(1), NullDigraph(510), fail, [], 1,
 > fail, true, [1, 2, 3], [1], fail, fail, true);
-Error, the 12th argument <order> must be a list or fail, not boolean or fail,
+Error, the 12th or 13th argument <aut_grp> must be a permutation group or fail\
+, not boolean or fail,
 gap> HomomorphismDigraphsFinder(NullDigraph(10), NullDigraph(510), fail, [], 1,
 > fail, true, [1, 2, 3], [1], fail, fail, [1]);
 Error, the 12th argument <order> must be a list of length 10, not 1,
@@ -2100,6 +2192,35 @@ gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
 > fail, true, [1, 2, 3], [1], fail, fail, [1, 1, 3]);
 Error, the 12th argument <order> must be duplicate-free, but the value 1 in po\
 sition 2 is a duplicate,
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail, FreeGroup(3));
+Error, the 12th or 13th argument <aut_grp> must be a permutation group or fail\
+, not object (component),
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail, Semigroup(Transformation([1, 1])));
+Error, the 12th or 13th argument <aut_grp> must be a permutation group or fail\
+, not object (component),
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail, Group(CycleFromList([1 .. 1000])));
+Error, expected group of automorphisms, but found a non-automorphism in positi\
+on 1 of the group generators,
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(510), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail, 
+> Group((1, 2), CycleFromList([1 .. 1000])));
+Error, expected group of automorphisms, but found a non-automorphism in positi\
+on 2 of the group generators,
+gap> HomomorphismDigraphsFinder(NullDigraph(3), ChainDigraph(3), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail, Group((1, 2, 3)));
+Error, expected group of automorphisms, but found a non-automorphism in positi\
+on 1 of the group generators,
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(3), fail, [], 1,
+> fail, true, [1, 2, 3], [1], [1, 1, 1], [1, 2, 3], Group((1, 2, 3)));
+Error, expected group of automorphisms, but found a non-automorphism in positi\
+on 1 of the group generators,
+gap> HomomorphismDigraphsFinder(NullDigraph(3), NullDigraph(3), fail, [], 1,
+> fail, true, [1, 2, 3], [1], fail, fail,
+> Group((1, 2, 3), (1, 2), (1, 3)));
+Error, expected at most 2 generators in the 12th or 13th argument but got 3,
 
 #
 gap> D1 := DigraphSymmetricClosure(Digraph([[2], [3], []]));;

--- a/tst/standard/isomorph.tst
+++ b/tst/standard/isomorph.tst
@@ -950,6 +950,53 @@ h), where graph is the 1st argument,
 gap> BlissAutomorphismGroup(gr, fail, [[1], [1, 1], [1]]) = Group([(1, 3)]);
 true
 
+# IsDigraphIsomorphism
+gap> gr1 := Digraph([[2, 3, 4], [1, 3, 4], [1, 2], [1, 2]]);
+<immutable digraph with 4 vertices, 10 edges>
+gap> IsDigraphIsomorphism(gr1, gr1, (1, 2));
+true
+gap> IsDigraphIsomorphism(gr1, gr1, (1, 2)(3, 4));
+true
+gap> gr2 := Digraph([[2, 3, 4, 4], [1, 3, 4], [1, 2], [1, 2]]);
+<immutable multidigraph with 4 vertices, 11 edges>
+gap> IsDigraphIsomorphism(gr1, gr2, (1, 2));
+Error, the 1st and 2nd arguments <src> and <ran> must not have multiple edges,
+gap> IsDigraphIsomorphism(gr2, gr1, (1, 2));
+Error, the 1st and 2nd arguments <src> and <ran> must not have multiple edges,
+gap> IsDigraphIsomorphism(gr1, gr1, Transformation([2, 1, 4, 3, 6, 5]));
+true
+gap> IsDigraphIsomorphism(gr1, gr1, Transformation([2, 1, 3, 5, 4, 6]));
+false
+gap> gr := NullDigraph(5);; 
+gap> ForAll(AutomorphismGroup(gr),        
+>           x -> IsDigraphAutomorphism(gr, x, [1, 1, 1, 1, 1]));
+true
+gap> Number(AutomorphismGroup(gr),                              
+>           x -> IsDigraphAutomorphism(gr, x, [1, 2, 3, 4, 5]));
+1
+gap> gr2 := CycleDigraph(6);
+<immutable cycle digraph with 6 vertices>
+gap> t := Transformation([2, 3, 4, 5, 6, 1, 8, 7]);
+Transformation( [ 2, 3, 4, 5, 6, 1, 8, 7 ] )
+gap> ForAll([1 .. 6],
+>            i -> IsDigraphAutomorphism(gr2,
+>                                       t ^ i,  
+>                                       [1, 1, 1, 1, 1, 1]));
+true
+gap> ForAll([2, 4, 6],
+>            i -> IsDigraphAutomorphism(gr2,
+>                                       t ^ i,
+>                                       [1, 2, 1, 2, 1, 2]));
+true
+gap> IsDigraphAutomorphism(gr2, t ^ 3, [1, 2, 3, 1, 2, 3]);
+true
+gap> gr3 := CycleDigraph(5);;
+gap> Number(FullTransformationMonoid(5),
+>           t -> IsDigraphAutomorphism(gr3,
+>                                      t,
+>                                      [1, 1, 1, 1, 1]));   
+5
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(canon);
 gap> Unbind(D);


### PR DESCRIPTION
This PR allows the user to specify a subgroup of the automorphism group to `HomomorphismDigraphsFinder`. Representatives of homomorphisms are then returned up to right multiplication by elements of the automorphism subgroup.

This PR also fixes a bug where non-embeddings could be returned when the embedding option was chosen.


This PR deals with #279 and is based on #283 

