### PR TITLE
Add DigraphMaximumMatching

### DIFF
--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -2218,7 +2218,7 @@ true
     For the definition of a maximum matching, see <Ref Oper="IsMaximumMatching"/>.
     If <A>digraph</A> is bipartite (see <Ref Oper="IsBipartiteDigraph"/>), then 
     the algorithm used has complexity <C>O(m*sqrt(n))</C>. Otherwise for general 
-    graphs the complexity is <C>O(m*n)</C>. Here <C>n</C> is the number of vertices 
+    graphs the complexity is <C>O(m*n*log(n))</C>. Here <C>n</C> is the number of vertices 
     and <C>m</C> is the number of edges.
 
     <Example><![CDATA[
@@ -2228,12 +2228,14 @@ gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
 true
 gap> Length(M);
 5
-gap> D := Digraph([[5, 6, 7, 8], [6, 7, 8], [7, 8], [8], [], [], [], []]);;
+gap> D := Digraph([[5, 6, 7, 8], [6, 7, 8], [7, 8], [8], 
+>                  [], [], [], []]);;
 gap> M := DigraphMaximumMatching(D);
 [ [ 1, 5 ], [ 2, 6 ], [ 3, 7 ], [ 4, 8 ] ]
 gap> D := GeneralisedPetersenGraph(IsMutableDigraph, 9, 2);
 <mutable digraph with 18 vertices, 54 edges>
-gap> IsMaximalMatching(D, DigraphMaximumMatching(D));
+gap> M := DigraphMaximumMatching(D);;
+gap> IsMaximalMatching(D, M);
 true
 gap> Length(M);
 9

--- a/doc/attr.xml
+++ b/doc/attr.xml
@@ -2179,3 +2179,65 @@ true
   </Description>
 </ManSection>
 <#/GAPDoc>
+
+<#GAPDoc Label="DigraphMaximalMatching">
+<ManSection>
+  <Attr Name="DigraphMaximalMatching" Arg="digraph"/>
+  <Returns>A list of pairs of vertices.</Returns>
+  <Description>
+    This function returns a maximal matching of the digraph <A>digraph</A>.
+    <P/>
+
+    For the definition of a maximal matching, see <Ref Oper="IsMaximalMatching"/>. 
+
+    <Example><![CDATA[
+gap> D := DigraphFromDiSparse6String(".IeAoXCJU@|SHAe?d");
+<immutable digraph with 10 vertices, 13 edges>
+gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
+true
+gap> D := RandomDigraph(100);;
+gap> IsMaximalMatching(D, DigraphMaximalMatching(D));
+true
+gap> D := GeneralisedPetersenGraph(IsMutableDigraph, 9, 2);
+<mutable digraph with 18 vertices, 54 edges>
+gap> IsMaximalMatching(D, DigraphMaximalMatching(D));
+true
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>
+
+<#GAPDoc Label="DigraphMaximumMatching">
+<ManSection>
+  <Attr Name="DigraphMaximumMatching" Arg="digraph"/>
+  <Returns>A list of pairs of vertices.</Returns>
+  <Description>
+    This function returns a maximum matching of the digraph <A>digraph</A>.
+    <P/>
+
+    For the definition of a maximum matching, see <Ref Oper="IsMaximumMatching"/>.
+    If <A>digraph</A> is bipartite (see <Ref Oper="IsBipartiteDigraph"/>), then 
+    the algorithm used has complexity <C>O(m*sqrt(n))</C>. Otherwise for general 
+    graphs the complexity is <C>O(m*n)</C>. Here <C>n</C> is the number of vertices 
+    and <C>m</C> is the number of edges.
+
+    <Example><![CDATA[
+gap> D := DigraphFromDigraph6String("&I@EA_A?AdDp[_c??OO");
+<immutable digraph with 10 vertices, 23 edges>
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+5
+gap> D := Digraph([[5, 6, 7, 8], [6, 7, 8], [7, 8], [8], [], [], [], []]);;
+gap> M := DigraphMaximumMatching(D);
+[ [ 1, 5 ], [ 2, 6 ], [ 3, 7 ], [ 4, 8 ] ]
+gap> D := GeneralisedPetersenGraph(IsMutableDigraph, 9, 2);
+<mutable digraph with 18 vertices, 54 edges>
+gap> IsMaximalMatching(D, DigraphMaximumMatching(D));
+true
+gap> Length(M);
+9
+]]></Example>
+  </Description>
+</ManSection>
+<#/GAPDoc>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1665,13 +1665,13 @@ true
     of <A>digraph</A>.  Note that this definition allows a matching to contain
     loops.  See <Ref Prop="DigraphHasLoops" />.  The matching <C>M</C> is
     <E>maximal</E> if it is contained in no larger matching of the digraph,
-    is <E>maximum</E> if it has the greatest cardinality among all mathings and
+    is <E>maximum</E> if it has the greatest cardinality among all matchings and
     is <E>perfect</E> if every vertex of the digraph is incident to an edge in
     the matching.  Every maximum or perfect matching is maximal. Note however
     that for digraphs with loops, not every perfect matching will be maximum.
 
     <Example><![CDATA[
-gap> D := Digraph([[2], [1], [2, 3, 4], [3, 5], [1]]);
+gap> D := Digraph([[1, 2], [1, 2], [2, 3, 4], [3, 5], [1]]);
 <immutable digraph with 5 vertices, 8 edges>
 gap> IsMatching(D, [[2, 1], [3, 2]]);
 false
@@ -1680,13 +1680,18 @@ gap> IsMatching(D, edges);
 true
 gap> IsMaximalMatching(D, edges);
 false
-gap> edges := [[5, 1], [3, 3]];;
+gap> edges := [[2, 1], [3, 4]];;
 gap> IsMaximalMatching(D, edges);
 true
 gap> IsPerfectMatching(D, edges);
 false
 gap> edges := [[1, 2], [3, 3], [4, 5]];;
 gap> IsPerfectMatching(D, edges);
+true
+gap> IsMaximumMatching(D, edges);
+false
+gap> edges := [[1, 1], [2, 2], [3, 3], [4, 5]];;
+gap> IsMaximumMatching(D, edges);
 true
 ]]></Example>
   </Description>

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1653,10 +1653,12 @@ true
   <Description>
     If <A>digraph</A> is a digraph and <A>list</A> is a list of pairs of
     vertices of <A>digraph</A>, then <C>IsMatching</C> returns <K>true</K> if
-    <A>list</A> is a matching of <A>digraph</A>.  The operations
-    <C>IsMaximalMatching</C>, <C>IsMaximumMatching</C> and <C>IsPerfectMatching</C> 
-    return <K>true</K> if <A>list</A> is a maximal, maximum or perfect, matching 
-    of <A>digraph</A>, respectively.  Otherwise, these operations return <K>false</K>.
+    <A>list</A> is a matching of <A>digraph</A>.  The operation
+    <C>IsMaximalMatching</C> returns <K>true</K> if <A>list</A> is a maximal 
+    matching, <C>IsMaximumMatching</C> returns <K>true</K> if <A>list</A> is a
+    maximum matching and <C>IsPerfectMatching</C> returns <K>true</K> if 
+    <A>list</A> is a perfect, matching of <A>digraph</A>, respectively.  
+    Otherwise, each of these operations return <K>false</K>.
     <P/>
 
     A <E>matching</E> <C>M</C> of a digraph <A>digraph</A> is a subset of the
@@ -1667,8 +1669,8 @@ true
     <E>maximal</E> if it is contained in no larger matching of the digraph,
     is <E>maximum</E> if it has the greatest cardinality among all matchings and
     is <E>perfect</E> if every vertex of the digraph is incident to an edge in
-    the matching.  Every maximum or perfect matching is maximal. Note however
-    that for digraphs with loops, not every perfect matching will be maximum.
+    the matching.  Every maximum or perfect matching is maximal. Note, however,
+    that that not every perfect matching of digraphs with loops is maximum.
 
     <Example><![CDATA[
 gap> D := Digraph([[1, 2], [1, 2], [2, 3, 4], [3, 5], [1]]);

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1672,7 +1672,7 @@ true
 
     <Example><![CDATA[
 gap> D := Digraph([[1, 2], [1, 2], [2, 3, 4], [3, 5], [1]]);
-<immutable digraph with 5 vertices, 8 edges>
+<immutable digraph with 5 vertices, 10 edges>
 gap> IsMatching(D, [[2, 1], [3, 2]]);
 false
 gap> edges := [[3, 2]];;

--- a/doc/oper.xml
+++ b/doc/oper.xml
@@ -1647,24 +1647,28 @@ true
 <ManSection>
   <Oper Name="IsMatching" Arg="digraph, list"/>
   <Oper Name="IsMaximalMatching" Arg="digraph, list"/>
+  <Oper Name="IsMaximumMatching" Arg="digraph, list"/>
   <Oper Name="IsPerfectMatching" Arg="digraph, list"/>
   <Returns><K>true</K> or <K>false</K>.</Returns>
   <Description>
     If <A>digraph</A> is a digraph and <A>list</A> is a list of pairs of
     vertices of <A>digraph</A>, then <C>IsMatching</C> returns <K>true</K> if
     <A>list</A> is a matching of <A>digraph</A>.  The operations
-    <C>IsMaximalMatching</C> and <C>IsPerfectMatching</C> return <K>true</K> if
-    <A>list</A> is a maximal, or perfect, matching of <A>digraph</A>,
-    respectively.  Otherwise, these operations return <K>false</K>. <P/>
+    <C>IsMaximalMatching</C>, <C>IsMaximumMatching</C> and <C>IsPerfectMatching</C> 
+    return <K>true</K> if <A>list</A> is a maximal, maximum or perfect, matching 
+    of <A>digraph</A>, respectively.  Otherwise, these operations return <K>false</K>.
+    <P/>
 
     A <E>matching</E> <C>M</C> of a digraph <A>digraph</A> is a subset of the
     edges of <A>digraph</A>, i.e. <C>DigraphEdges(<A>digraph</A>)</C>, such
     that no pair of distinct edges in <C>M</C> are incident to the same vertex
     of <A>digraph</A>.  Note that this definition allows a matching to contain
     loops.  See <Ref Prop="DigraphHasLoops" />.  The matching <C>M</C> is
-    <E>maximal</E> if it is contained in no larger matching of the digraph, and
+    <E>maximal</E> if it is contained in no larger matching of the digraph,
+    is <E>maximum</E> if it has the greatest cardinality among all mathings and
     is <E>perfect</E> if every vertex of the digraph is incident to an edge in
-    the matching.  Every perfect matching is maximal.
+    the matching.  Every maximum or perfect matching is maximal. Note however
+    that for digraphs with loops, not every perfect matching will be maximum.
 
     <Example><![CDATA[
 gap> D := Digraph([[2], [1], [2, 3, 4], [3, 5], [1]]);

--- a/doc/z-chap4.xml
+++ b/doc/z-chap4.xml
@@ -15,6 +15,8 @@
     <#Include Label="DigraphOutEdges">
     <#Include Label="IsDigraphEdge">
     <#Include Label="IsMatching">
+    <#Include Label="DigraphMaximalMatching">
+    <#Include Label="DigraphMaximumMatching">
   </Section>
 
   <Section><Heading>Neighbours and degree</Heading>

--- a/gap/attr.gd
+++ b/gap/attr.gd
@@ -114,3 +114,6 @@ DeclareAttribute("DigraphMycielskianAttr", IsDigraph);
 
 DeclareAttribute("DigraphCartesianProductProjections", IsDigraph);
 DeclareAttribute("DigraphDirectProductProjections", IsDigraph);
+
+DeclareAttribute("DigraphMaximalMatching", IsDigraph);
+DeclareAttribute("DigraphMaximumMatching", IsDigraph);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2045,10 +2045,11 @@ InstallMethod(DigraphMycielskian,
 InstallMethod(DigraphMycielskianAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphMycielskian);
 
+# Uses a simple greedy algorithm.
 BindGlobal("DIGRAPHS_MaximalMatching",
 function(D)
   local mate, u, v;
-  mate := List(DigraphVertices(D), x -> 0);
+  mate := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
   for v in DigraphVertices(D) do
     if mate[v] = 0 then
       for u in OutNeighboursOfVertex(D, v) do
@@ -2063,6 +2064,8 @@ function(D)
   return mate;
 end);
 
+# For bipartite digraphs implements the Hopcroft-Karp matching algorithm,
+# complexity O(m*sqrt(n))
 BindGlobal("DIGRAPHS_BipartiteMatching",
 function(D, mate)
   local U, dist, inf, dfs, bfs, u;
@@ -2115,7 +2118,7 @@ function(D, mate)
   end;
 
   inf  := DigraphNrVertices(D) + 1;
-  dist := List([1 .. inf], x -> inf);
+  dist := ListWithIdenticalEntries(inf, inf);
   for u in [1 .. Length(mate)] do
     if mate[u] = 0 then
       mate[u] := inf;
@@ -2138,6 +2141,8 @@ function(D, mate)
   return mate;
 end);
 
+# For general digraphs implements a modified version of Gabow's maximum matching
+# algorithm, complexity O(m*n*log(n)).
 BindGlobal("DIGRAPHS_GeneralMatching",
 function(D, mate)
   local blos, pred, time, t, tj, u, dfs, mark, blosfind;
@@ -2213,18 +2218,18 @@ function(D, mate)
     return false;
   end;
 
-  time := List(DigraphVertices(D), x -> 0);
-  blos := ShallowCopy(DigraphVertices(D));
-  pred := List(DigraphVertices(D), x -> 0);
+  time := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
+  blos := [1 .. DigraphNrVertices(D)];
+  pred := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
   t    := 0;
   for u in DigraphVertices(D) do
     if mate[u] = 0 then
       t       := t + 1;
       time[u] := t;
       if dfs(u) then
-        time := List(DigraphVertices(D), x -> 0);
-        pred := List(DigraphVertices(D), x -> 0);
-        blos := ShallowCopy(DigraphVertices(D));
+        time := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
+        blos := [1 .. DigraphNrVertices(D)];
+        pred := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
       fi;
     fi;
   od;
@@ -2238,12 +2243,14 @@ function(D, mate)
   M := [];
   for u in DigraphVertices(D) do
     if u <= mate[u] then
-      if IsDigraphEdge(D, u, mate[u]) then Add(M, [u, mate[u]]);
-      elif IsDigraphEdge(D, mate[u], u) then Add(M, [mate[u], u]);
+      if IsDigraphEdge(D, u, mate[u]) then
+        Add(M, [u, mate[u]]);
+      elif IsDigraphEdge(D, mate[u], u) then
+        Add(M, [mate[u], u]);
       fi;
     fi;
   od;
-  return Unique(M);
+  return Set(M);
 end);
 
 InstallMethod(DigraphMaximalMatching, "for a digraph", [IsDigraph],
@@ -2262,7 +2269,7 @@ function(D)
   else
     mateG := DIGRAPHS_GeneralMatching(G, mateG);
   fi;
-  mateD := List(DigraphVertices(D), x -> 0);
+  mateD := ListWithIdenticalEntries(DigraphNrVertices(D), 0);
   for i in DigraphVertices(G) do
     if mateG[i] <> 0 then
       mateD[lab[i]] := lab[mateG[i]];

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2251,9 +2251,10 @@ D -> DIGRAPHS_MateToMatching(D, DIGRAPHS_MaximalMatching(D)));
 
 InstallMethod(DigraphMaximumMatching, "for a digraph", [IsDigraph],
 function(D)
-  local mateG, mateD, G, M, i;
+  local mateG, mateD, G, M, i, lab;
   G     := DigraphImmutableCopy(D);
   G     := InducedSubdigraph(G, Difference(DigraphVertices(G), DigraphLoops(G)));
+  lab   := DigraphVertexLabels(G);
   G     := DigraphSymmetricClosure(G);
   mateG := DIGRAPHS_MaximalMatching(G);
   if IsBipartiteDigraph(G) then
@@ -2264,7 +2265,7 @@ function(D)
   mateD := List(DigraphVertices(D), x -> 0);
   for i in DigraphVertices(G) do
     if mateG[i] <> 0 then
-      mateD[DigraphVertexLabel(G, i)] := DigraphVertexLabel(G, mateG[i]);
+      mateD[lab[i]] := lab[mateG[i]];
     fi;
   od;
   M := List(DigraphLoops(D), x -> [x, x]);

--- a/gap/attr.gi
+++ b/gap/attr.gi
@@ -2044,3 +2044,229 @@ InstallMethod(DigraphMycielskian,
 
 InstallMethod(DigraphMycielskianAttr, "for an immutable digraph",
 [IsImmutableDigraph], DigraphMycielskian);
+
+BindGlobal("DIGRAPHS_MaximalMatching",
+function(D)
+  local mate, u, v;
+  mate := List(DigraphVertices(D), x -> 0);
+  for v in DigraphVertices(D) do
+    if mate[v] = 0 then
+      for u in OutNeighboursOfVertex(D, v) do
+        if mate[u] = 0 then
+          mate[u] := v;
+          mate[v] := u;
+          break;
+        fi;
+      od;
+    fi;
+  od;
+  return mate;
+end);
+
+BindGlobal("DIGRAPHS_BipartiteMatching",
+function(D, mate)
+  local U, dist, inf, dfs, bfs, u;
+
+  U := DigraphBicomponents(D);
+  U := U[PositionMinimum(U, Length)];
+
+  bfs := function()
+    local v, que, q;
+    que := [];
+    for v in U do
+      if mate[v] = inf then
+        dist[v] := 0;
+        Add(que, v);
+      else
+        dist[v] := inf;
+      fi;
+    od;
+    dist[inf] := inf;
+
+    q := 1;
+    while q <= Length(que) do
+      if dist[que[q]] < dist[inf] then
+        for v in OutNeighborsOfVertex(D, que[q]) do
+          if dist[mate[v]] = inf then
+            dist[mate[v]] := dist[que[q]] + 1;
+            Add(que, mate[v]);
+          fi;
+        od;
+      fi;
+      q := q + 1;
+    od;
+    return dist[inf] <> inf;
+  end;
+
+  dfs := function(u)
+    local v;
+    if u = inf then
+      return true;
+    fi;
+    for v in OutNeighborsOfVertex(D, u) do
+      if dist[mate[v]] = dist[u] + 1 and dfs(mate[v]) then
+        mate[v] := u;
+        mate[u] := v;
+        return true;
+      fi;
+    od;
+    dist[u] := inf;
+    return false;
+  end;
+
+  inf  := DigraphNrVertices(D) + 1;
+  dist := List([1 .. inf], x -> inf);
+  for u in [1 .. Length(mate)] do
+    if mate[u] = 0 then
+      mate[u] := inf;
+    fi;
+  od;
+
+  while bfs() do
+    for u in U do
+      if mate[u] = inf then dfs(u);
+      fi;
+    od;
+  od;
+
+  for u in [1 .. DigraphNrVertices(D)] do
+    if mate[u] = inf then
+      mate[u] := 0;
+    fi;
+  od;
+
+  return mate;
+end);
+
+BindGlobal("DIGRAPHS_GeneralMatching",
+function(D, mate)
+  local blos, pred, time, t, tj, u, dfs, mark, blosfind;
+
+  blosfind := function(x)
+    if x <> blos[x] then
+      blos[x] := blosfind(blos[x]);
+    fi;
+    return blos[x];
+  end;
+
+  mark := function(v, x, b, path)
+    while blosfind(v) <> b do
+      pred[v] := x;
+      x       := mate[v];
+      Add(tj, v);
+      Add(tj, x);
+      if time[x] = 0 then
+        t       := t + 1;
+        time[x] := t;
+        Add(path, x);
+      fi;
+      v := pred[x];
+    od;
+  end;
+
+  dfs := function(v)
+    local x, bx, bv, b, y, z, path;
+    for x in OutNeighboursOfVertex(D, v) do
+      bv := blosfind(v);
+      bx := blosfind(x);
+      if bx <> bv then
+        if time[x] > 0 then
+          path := [];
+          tj   := [];
+          if time[bx] < time[bv] then
+            b := bx;
+            mark(v, x, b, path);
+          else
+            b := bv;
+            mark(x, v, b, path);
+          fi;
+          for z in tj do
+            blos[z] := b;
+          od;
+          for z in path do
+            if dfs(z) then
+              return true;
+            fi;
+          od;
+        elif pred[x] = 0 then
+          pred[x] := v;
+          if mate[x] = 0 then
+            while x <> 0 do
+              y       := pred[x];
+              v       := mate[y];
+              mate[y] := x;
+              mate[x] := y;
+              x       := v;
+            od;
+            return true;
+          fi;
+          if time[mate[x]] = 0 then
+            t             := t + 1;
+            time[mate[x]] := t;
+            if dfs(mate[x]) then
+              return true;
+            fi;
+          fi;
+        fi;
+      fi;
+    od;
+    return false;
+  end;
+
+  time := List(DigraphVertices(D), x -> 0);
+  blos := ShallowCopy(DigraphVertices(D));
+  pred := List(DigraphVertices(D), x -> 0);
+  t    := 0;
+  for u in DigraphVertices(D) do
+    if mate[u] = 0 then
+      t       := t + 1;
+      time[u] := t;
+      if dfs(u) then
+        time := List(DigraphVertices(D), x -> 0);
+        pred := List(DigraphVertices(D), x -> 0);
+        blos := ShallowCopy(DigraphVertices(D));
+      fi;
+    fi;
+  od;
+
+  return mate;
+end);
+
+BindGlobal("DIGRAPHS_MateToMatching",
+function(D, mate)
+  local u, M;
+  M := [];
+  for u in DigraphVertices(D) do
+    if u <= mate[u] then
+      if IsDigraphEdge(D, u, mate[u]) then Add(M, [u, mate[u]]);
+      elif IsDigraphEdge(D, mate[u], u) then Add(M, [mate[u], u]);
+      fi;
+    fi;
+  od;
+  return Unique(M);
+end);
+
+InstallMethod(DigraphMaximalMatching, "for a digraph", [IsDigraph],
+D -> DIGRAPHS_MateToMatching(D, DIGRAPHS_MaximalMatching(D)));
+
+InstallMethod(DigraphMaximumMatching, "for a digraph", [IsDigraph],
+function(D)
+  local mateG, mateD, G, M, i;
+  G     := DigraphImmutableCopy(D);
+  G     := InducedSubdigraph(G, Difference(DigraphVertices(G), DigraphLoops(G)));
+  G     := DigraphSymmetricClosure(G);
+  mateG := DIGRAPHS_MaximalMatching(G);
+  if IsBipartiteDigraph(G) then
+    mateG := DIGRAPHS_BipartiteMatching(G, mateG);
+  else
+    mateG := DIGRAPHS_GeneralMatching(G, mateG);
+  fi;
+  mateD := List(DigraphVertices(D), x -> 0);
+  for i in DigraphVertices(G) do
+    if mateG[i] <> 0 then
+      mateD[DigraphVertexLabel(G, i)] := DigraphVertexLabel(G, mateG[i]);
+    fi;
+  od;
+  M := List(DigraphLoops(D), x -> [x, x]);
+  return Union(M, DIGRAPHS_MateToMatching(D, mateD));
+end);

--- a/gap/oper.gd
+++ b/gap/oper.gd
@@ -88,6 +88,7 @@ DeclareOperation("IsUndirectedSpanningForest", [IsDigraph, IsDigraph]);
 
 DeclareOperation("IsMatching", [IsDigraph, IsHomogeneousList]);
 DeclareOperation("IsMaximalMatching", [IsDigraph, IsHomogeneousList]);
+DeclareOperation("IsMaximumMatching", [IsDigraph, IsHomogeneousList]);
 DeclareOperation("IsPerfectMatching", [IsDigraph, IsHomogeneousList]);
 
 # 9. Connectivity . . .

--- a/gap/oper.gi
+++ b/gap/oper.gi
@@ -1108,6 +1108,13 @@ function(D, edges)
   return SizeBlist(seen) = DigraphNrVertices(D);
 end);
 
+InstallMethod(IsMaximumMatching, "for a digraph and a list",
+[IsDigraph, IsHomogeneousList],
+function(D, edges)
+  return IsMatching(D, edges)
+          and Length(edges) = Length(DigraphMaximumMatching(D));
+end);
+
 InstallMethod(IsMaximalMatching, "for a digraph and a list",
 [IsDigraphByOutNeighboursRep, IsHomogeneousList],
 function(D, edges)

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2211,32 +2211,14 @@ gap> IsIsomorphicDigraph(H, P);
 true
 
 # DigraphMaximalMatching
-gap> D := DigraphFromDigraph6String("\
-> &~?@c~Bn^F~]bj\\[~~FOqv^~z^IJrzN~^nn|l|\\^n]{|]}vp~ZVdt^k~z~~H]]r|mz`\\r{tv}jvu\  
-> }{^trz~smXZxz~xr|jm~}~Z~|z~[y^~zzf^Lx~tHuu|^~y|}txZec~\\uen|t|v~~~L}vvlnvZK^^~~M\  
-> N~^}}~n^b~~}~Zl~tWj|vn^}r~x_}n]}n~}]}h\\^}vvzv]^vzn^UI}h~xM^hn~~~n~_{vYvz|~n~z~]\  
-> {~j~nN|^V}nu\\vv}t~z\\}rt}vuy~|nL^~^}z~|{}^~Nlvn}N~b~z^hn|l||^~|evM~rzz^U^N~}^}S\  
-> xMf|k^uD~e^k~\\~R~ylrFkzxzb~xvl{~~XtU~MN}n~n~s~\\~rj\\}~xLvsjDzk}~M^vjqfr]~Unynk\  
-> ~Mny~~jql}tH\\}\\nj^Pvc~|^|v~~f}`XL~XvU~VjKy^Ln~qkT|U}~z^zV|yV~vxovYr~^~|zVz}AX}\  
-> nr^gNnx|}^~Zzvnkz}j^Vi~~}Z~qz~|mUMz~~~nnnrn|~|V\\n~}|^N]}np}t}nnyte^y]^~~xj[~x|}\  
-> ~f~]^t^tvNiD|~sc}zk~s}z|ZU~t~znwj^~_lN|z]~vUn~~~zD}]f^f}vjC^}~b|u~z]}Ny}zX}Zmzpr\  
-> ~Z^|{Vh^Grf~z~~~vtuZvnzvyjJzpz^~}~VZny^mzjnz~|w^~Vxozb~n~f|}[Fx}]FSvruoz~xz}x~Nv\  
-> vZ|\\U~{~|wv|^~N~yv|m]l~^yx~Vhv]jwN~udz|vp^~x~{ul{~Z~XnbT}tT^}]vzX|vz^|^~zwfFy~z\  
-> t^z~\\v^uV}v~tK}kT}zN|~m~ld}V|nv{r~^}n\\lcNwfqv~~ezvW^{^~e}u[|^{}~~|n~{vvHk]H\\r\  
-> ZVvt~lwJZz~d|n}]~~~kw^r|v~}}Zm~hzZzvx~|\\yuZNntXVx~m~~|n|nzT}~^v|^|Zn^}{N^n|~vx\   
-> \\T[}Sf~ub{~]^j|ZVN~z~}vvz~hrT~vnyij~z}RNX|njzy\\xNjn~nx{}v~fene~^~|^nv~}th^v|~M\  
-> ngD{||~zy}y{Nv\\Z}nSk~}r^nc~}ldZkh~z~V|qtv~~~N\\FVN~|~z|zXyvz{}R~]}{S^zJv~vblL~l\  
-> z~~zMXNJVz~z^^YnB~kzu~oL]}|vfo|nQN[}iz}v}jn}psmm\\Rrd}^x]||~\\\\YT]vvnZtzuVm{j~y\  
-> ^l|t[~jzzt~uGg|]rk}Zhn~ZL^^z^[T~nzznjzzjrf^L|{}~}z}~~]znM^nvZAt|EzyvRz}VAnV{agZr\  
-> uXxy\\}ovv~y~}~^H~XHnnQ}j|}zr]ku[~^\\}~~}nx{|Mzv~j~by^|n}zzlZc~}~z`n^Lx^|}vy]^x^\  
-> M{kzUiu\\sNV^}vN~panv||g^b~zIl}FbaZWDn[z|^txkvvUuD~~w~~~nzU}Mt|~xMnz]w^vw^[f~z@|\  
-> ZyN~^j^~f^~kZ~zvy~Nn^{~N|v^~~|j}znv^flyzvizyj|^M~J^Nazi~yxnjpyxz}}va~MdFmrLE~\\w\  
-> nzn|lsv|~vz[m|v~~\\|U}~j~Y||v}NnnZl}|~E~v~J}fT~|vy|v{|ifJNef^[V{vnm~^xvw^Tvl^wmx\  
-> dnl~ynl~y~{nZ~^v~n}F}~bVJvNzZ~x|~vT^n|n^m}^[NF\\v~~~zxRlY^Znl|x}[zm^vz|Zv{^Nzv[b\  
-> l~^Z^^m~}N~ZYuzM}|lzVYS~s");
+gap> D := DigraphFromDigraph6String("&Sq_MN|bDCLy~Xj}u}GxOLlGfqJtnSQ|l\
+> Q?lYvjbqN~XNNAQYDJE[UHOhyGOqtsjCWJy[");
+<immutable digraph with 20 vertices, 205 edges>
 gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
 true
-gap> D := RandomDigraph(IsMutable, 100);;
+gap> D := DigraphFromDigraph6String(IsMutable, "&Sq_MN|bDCLy~Xj}u}GxOLlGfqJtnSQ|l\
+> Q?lYvjbqN~XNNAQYDJE[UHOhyGOqtsjCWJy[");
+<mutable digraph with 20 vertices, 205 edges>
 gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
 true
 gap> D := Digraph(IsMutable, [[2], [3], [4], [1]]);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2211,7 +2211,29 @@ gap> IsIsomorphicDigraph(H, P);
 true
 
 # DigraphMaximalMatching
-gap> D := RandomDigraph(100);;
+gap> D := DigraphFromDigraph6String("\
+> &~?@c~Bn^F~]bj\\[~~FOqv^~z^IJrzN~^nn|l|\\^n]{|]}vp~ZVdt^k~z~~H]]r|mz`\\r{tv}jvu\  
+> }{^trz~smXZxz~xr|jm~}~Z~|z~[y^~zzf^Lx~tHuu|^~y|}txZec~\\uen|t|v~~~L}vvlnvZK^^~~M\  
+> N~^}}~n^b~~}~Zl~tWj|vn^}r~x_}n]}n~}]}h\\^}vvzv]^vzn^UI}h~xM^hn~~~n~_{vYvz|~n~z~]\  
+> {~j~nN|^V}nu\\vv}t~z\\}rt}vuy~|nL^~^}z~|{}^~Nlvn}N~b~z^hn|l||^~|evM~rzz^U^N~}^}S\  
+> xMf|k^uD~e^k~\\~R~ylrFkzxzb~xvl{~~XtU~MN}n~n~s~\\~rj\\}~xLvsjDzk}~M^vjqfr]~Unynk\  
+> ~Mny~~jql}tH\\}\\nj^Pvc~|^|v~~f}`XL~XvU~VjKy^Ln~qkT|U}~z^zV|yV~vxovYr~^~|zVz}AX}\  
+> nr^gNnx|}^~Zzvnkz}j^Vi~~}Z~qz~|mUMz~~~nnnrn|~|V\\n~}|^N]}np}t}nnyte^y]^~~xj[~x|}\  
+> ~f~]^t^tvNiD|~sc}zk~s}z|ZU~t~znwj^~_lN|z]~vUn~~~zD}]f^f}vjC^}~b|u~z]}Ny}zX}Zmzpr\  
+> ~Z^|{Vh^Grf~z~~~vtuZvnzvyjJzpz^~}~VZny^mzjnz~|w^~Vxozb~n~f|}[Fx}]FSvruoz~xz}x~Nv\  
+> vZ|\\U~{~|wv|^~N~yv|m]l~^yx~Vhv]jwN~udz|vp^~x~{ul{~Z~XnbT}tT^}]vzX|vz^|^~zwfFy~z\  
+> t^z~\\v^uV}v~tK}kT}zN|~m~ld}V|nv{r~^}n\\lcNwfqv~~ezvW^{^~e}u[|^{}~~|n~{vvHk]H\\r\  
+> ZVvt~lwJZz~d|n}]~~~kw^r|v~}}Zm~hzZzvx~|\\yuZNntXVx~m~~|n|nzT}~^v|^|Zn^}{N^n|~vx\   
+> \\T[}Sf~ub{~]^j|ZVN~z~}vvz~hrT~vnyij~z}RNX|njzy\\xNjn~nx{}v~fene~^~|^nv~}th^v|~M\  
+> ngD{||~zy}y{Nv\\Z}nSk~}r^nc~}ldZkh~z~V|qtv~~~N\\FVN~|~z|zXyvz{}R~]}{S^zJv~vblL~l\  
+> z~~zMXNJVz~z^^YnB~kzu~oL]}|vfo|nQN[}iz}v}jn}psmm\\Rrd}^x]||~\\\\YT]vvnZtzuVm{j~y\  
+> ^l|t[~jzzt~uGg|]rk}Zhn~ZL^^z^[T~nzznjzzjrf^L|{}~}z}~~]znM^nvZAt|EzyvRz}VAnV{agZr\  
+> uXxy\\}ovv~y~}~^H~XHnnQ}j|}zr]ku[~^\\}~~}nx{|Mzv~j~by^|n}zzlZc~}~z`n^Lx^|}vy]^x^\  
+> M{kzUiu\\sNV^}vN~panv||g^b~zIl}FbaZWDn[z|^txkvvUuD~~w~~~nzU}Mt|~xMnz]w^vw^[f~z@|\  
+> ZyN~^j^~f^~kZ~zvy~Nn^{~N|v^~~|j}znv^flyzvizyj|^M~J^Nazi~yxnjpyxz}}va~MdFmrLE~\\w\  
+> nzn|lsv|~vz[m|v~~\\|U}~j~Y||v}NnnZl}|~E~v~J}fT~|vy|v{|ifJNef^[V{vnm~^xvw^Tvl^wmx\  
+> dnl~ynl~y~{nZ~^v~n}F}~bVJvNzZ~x|~vT^n|n^m}^[NF\\v~~~zxRlY^Znl|x}[zm^vz|Zv{^Nzv[b\  
+> l~^Z^^m~}N~ZYuzM}|lzVYS~s");
 gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
 true
 gap> D := RandomDigraph(IsMutable, 100);;
@@ -2226,9 +2248,6 @@ gap> D;
 <mutable digraph with 4 vertices, 4 edges>
 
 # DigraphMaximumMatching
-gap> D := RandomDigraph(100);;
-gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
-true
 gap> D := DigraphFromDiSparse6String(".]cBn@kqAlt?EpclQp|M}bAgFjHkoDsIuACyCM_Hj");
 <immutable digraph with 30 vertices, 26 edges>
 gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2245,6 +2245,181 @@ gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
 true
 gap> Length(M);
 3
+gap> D := DigraphFromDiSparse6String("\
+> .~?B]zsE?cB?kH?cK?{M?{O?SIaWHaoQ_{X??@?wJ@gT`{[BKF@s^BG[_OOAca?{@@gXB_^bK?A\
+> gXbGc_gF@o\\dGG`gXC[X`K__OC?oG@GI@wOAGQAWSAoWBOZBo_CGgDGkDk?BGd_wMBgfdsFC{Q\
+> Ao]CGmdsJBGbC_ebGdD{ZDsXCgnEsC?oHAWkDsFbK@BGb`?PDsD?wfcGmE[Fb?ZD?mEWsE{LBGb\
+> DSmEW~aOmE[XB_^C[XbKmEW~G[gDp@_x?dop_wfdosGKWDp@dsJBGt`wYDopFHJH{FA{F_waG@I\
+> I[OC?mbGtdsUDor`?IAG_DGmFhVbWgDovGHH_GXBwbFcFCwqdpVJKXG{XGx]_wVISC?omFKXF[X\
+> CkFCP?IXSaOmEXCbGtIsXGs?BGddpP_xS_wKAwfIP_dpVJH\\_?TBGdDWnEowFXEGx]JxaKXfLC\
+> mEHJIKUDorJCFL[XDXfLkWDosGHLHpY`GkDox`WXEhOIsmEW~dorFxtbGjLhpcGmEW~MkA?_E@?\
+> H@ONA?PAWSBO_DGkDgmEGxFhJHxPIhVJH\\KHhL`mM[A@?IA?PA__DGlDo|IhVJH\\L`x_WF`wY\
+> DpPNKQAo]DorFxCJ@dL{IAGmJHkNHydopHxPNKUDorNkgDp@JS?BGdL@lbGeEk@@WLBG[BwbC_e\
+> DOtF`AGhOIpZKplMaBcGmEW~c?lDpxNSFdorFxBHCFL[mIHhNKmFHx_wfEP[aOUB?ZBo`D?mEWs\
+> Ew~GHBG`GHHLHpWJPdLxqMhuN@xNi?OIDPCSC?mNHybGbDPDOcFNYFbGbOaN_waIcF_wyQ[FLYH\
+> do|JHxNSFHPSLSmEW~OiLbOmIHhLpxPSF@`jaWmFHx__E@GNAWYD_mEGxHXNIH`LHmMXxNP{NyI\
+> PYXR[XChbLkXCgnKXlRkmGHMMQLdo|JHxNQUaWmFHxPY[dp@JQLbWmEx@HHYPkmFHxPY[SKFAxj\
+> PITdp@HhqPi^a?_DpTNHydp@JQLSSXEhUKqC_WFFQS_yFQCB?waFP?HPRI`cLPzOyOQQRQaVTQj\
+> dp@JQLSQbTCD?wK@oVBgfE?qFpKIP[K@jMAHPaTRQdTcFCxKJam_xSLQVTc_DgmNHyOsmGHMMQL\
+> dorNi?PkXCotOYCbHEKPfLk]DorNi?PkgDp@HHYPkFCw}HamT{FQYkdorFyDPiWdosGHLMQL_WF\
+> NYkdp@JQ@PkRDoxNIZRcAC?lDpxNSmGHqPi^SsWDp@MQLbGzJpaLkXC_tKqCagXChl_?TBGdLjC\
+> cGmEW~NALbGcEiCW[FIXSKak_WFFPSNYFQARQaiTYkVI{_gFCwoFqmb?mGHqPj@dp@JQ@Pi|a__\
+> DpTNHyPsmHxPNH~RcmEW~GXtMqLbGdDWzGpFJp^KPfLhpMytWSXCYCPyP_waIaQTcFLXoQimdor\
+> Ni?Pir_yRTaxXKF@`jRQm_x?HPSTc??GB?gF@WK@gMAgVBG[Bg^CObC_dCofDOjDonE?qEguF?y\
+> FW{Fp?GPDGpFHPKI@QIXSIpZJ`]Jx_KPbK`eKxgLPjLhoMHsMxzOQBOaFPIKPyOQIQQYSQiVRQ\\
+> \RqdTIiTYkTqnUAsUiwVI{WRBWbDWzGXJIYBPYRRYjUY{GDGmJHxNSAC?mNHyV{mGHMMQLUS]Do\
+> rNiLUsFLXoTrRYrW");;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+111
+gap> M1 := [
+> [1, 198], [2, 61], [3, 219], [4, 189], [5, 10], [6, 63], [7, 98], [8, 26], 
+> [9, 62], [11, 18], [12, 81], [13, 155], [14, 67], [15, 30], [16, 125], 
+> [17, 168], [19, 23], [20, 162], [21, 143], [22, 197], [24, 166], [25, 79], 
+> [27, 154], [28, 56], [29, 70], [31, 221], [32, 92], [33, 90], [34, 134], 
+> [35, 101], [36, 54], [37, 39], [38, 209], [40, 108], [41, 130], [42, 218], 
+> [43, 144], [44, 120], [45, 116], [46, 192], [47, 217], [48, 159], [49, 203], 
+> [50, 128], [51, 141], [52, 66], [53, 188], [55, 57], [58, 82], [59, 171], 
+> [60, 99], [64, 126], [65, 216], [68, 208], [69, 102], [71, 182], [72, 96], 
+> [73, 137], [74, 184], [75, 152], [76, 111], [77, 185], [78, 167], [80, 207], 
+> [83, 97], [84, 201], [85, 202], [86, 206], [87, 117], [88, 94], [89, 112], 
+> [91, 115], [93, 176], [95, 195], [100, 158], [103, 170], [104, 114], 
+> [105, 131], [106, 139], [107, 177], [109, 127], [110, 133], [113, 212], 
+> [118, 119], [121, 199], [122, 142], [123, 157], [124, 145], [129, 183], 
+> [132, 181], [135, 178], [136, 172], [138, 150], [140, 165], [146, 210], 
+> [147, 211], [148, 149], [151, 161], [153, 187], [156, 191], [160, 193], 
+> [163, 169], [164, 174], [173, 175], [179, 220], [180, 213], [186, 214],
+> [190, 205], [194, 204], [196, 200], [215, 222]];;
+gap> M = M1;
+true
+gap> D := DigraphFromDiSparse6String("\
+> .~?@}~ggEb?eM@X?@_?CC@OWIAowO_PEPdOOPcX_HBHaPDgWICW[GAOoLE@e?@`ESbp]PfG_[cP\
+> M?@_gMCPk\\_OOJC@CQDPWYd@yHB@_[`pqPD`gdcQA[IH_XFHCUEaShapCd_?SEA_wPCpk\\GAK\
+> cHQiPJwMPHQeGFAE^frQPCqKn_OOJCPSUEaShJQwq__MA?o[GAOoLBpCSDp_XF@w^GQGeHq_jJB\
+> CrLBSwfrOtMWSMCQ}@CPGdfBePDaShKb]PCq{u_?SEA_wPEpscJrm]MW{^MXCdIRGvNgCPCaS{`\
+> os[IAkxNXCiJrAFFA_xPXCRGAgnKCYPGAgnQGOJCPSdIQwv_@C\\HA|?_PCdNCQA?pwpMBe@C@C\
+> db`CnOGCPHWCPHSPK_rCxRWs[IBc|PX[^MW_[GbeSFbd@`@CTHQwvQgkPHQwvQgGBBpOVF@w^Hb\
+> CsLR_xMcDARTHSTgCOCQTMbp{sMSHXdp{xTDe@CQTO_b_xRTeDB`CnMsA^MTPXVGGBD@w^HbCwM\
+> SDLSdXXVg_WFACaKrdTaP_XFAoxcPKnNx[^MTd[a?cKE@c[GQGfJBKxPTTaWwCOCQTCRd@YVWs[\
+> MSTRdp{xUTpdfbd@Tdd`fACrMUHeb`CnOC|^bp{sLRcyOddZVHCRJr|cfrdSUTp_b`CnOC|kcQ{\
+> oPca@CQTMSDtffBc|PTMPCqKnLhCRGAKiJr?uNs@EQCdcZfDsd@weMTd`_PCQHRpC`pogMSTF_P\
+> CdPCpPfA_jMSULFBdDSuaFFA_jMSTyfBc|PTLr]~");;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+63
+gap> M1 := [
+> [1, 76], [2, 56], [3, 95], [4, 57], [5, 22], [6, 60], [7, 30], [8, 125], 
+> [9, 52], [10, 100], [11, 28], [12, 89], [13, 40], [14, 105], [15, 37], 
+> [16, 67], [17, 91], [18, 58], [19, 120], [20, 73], [21, 87], [23, 63], 
+> [24, 85], [25, 99], [26, 45], [27, 46], [29, 90], [31, 78], [32, 98], 
+> [33, 74], [34, 108], [35, 86], [36, 117], [38, 48], [39, 119], [41, 84], 
+> [42, 75], [43, 71], [44, 123], [47, 88], [49, 114], [50, 83], [51, 68], 
+> [53, 92], [54, 59], [55, 64], [61, 77], [62, 116], [65, 118], [66, 107], 
+> [69, 104], [70, 103], [72, 121], [79, 115], [80, 113], [81, 94], [82, 122], 
+> [93, 110], [96, 109], [97, 112], [101, 111], [102, 106], [124, 126]];;
+gap> M = M1;
+true
+gap> D := DigraphFromDiSparse6String("\
+> .~?BG`WHawSbOT_wJbwYcOOcgCCS`d?SBkj?gedo_`sp?OOdSuCCC?o^bS[cwgdD?A[wdC}gofF\
+> [FGLJA_\\GhIi?uio_j?RF[bH|OaGyjgjjwOFdAHXYdhMbSQIDdE`KKTf?PalGh__jIKYHXPe@H\
+> gD]kLfdXcekPA`pmoSfslG[[n_CCGx_gpGd~CGdDhfic}IKBAhPbS@?XJJpnbogGHdg\\_kXslS\
+> aHeKJKaeXphhqk@pqOODABe[fKHgqoTfCKEPOrOSFxEHHqNQKr`qd@|cTc`YSqMb@G]CsRptl`h\
+> LSc@G`QrSZSS@?G~h`hPKD@X@GpTTLiMifSyjc@[NYUmq@PAOp[D?o]bG\\Gq[T|uiMvCq]Ryjv\
+> H^LUbchZKejUsoRC]mqga`}RaocpHH`wNczJ@WPY]hHPJ|DKa@OqHUK@DhMNYbij@axmQr@xCJ@\
+> KP@sVAcYAkA?wJboOcOOcgabSgBkjCsmCCMCkP_Sieo__cCb_ifWggGwdC}gofF[FGLJBhDHSMh\
+> oMi?uiONHSCH|U@w_fcocXNfhOaLBjwCAD`Dk~ILOkhKKTf?PSKThDLPbSoHKPGD]m@fkctaGUM\
+> LYmoSC{}LklG\\{CGxnw`K|SfsBAmCBp]L{gGHd_@BJ{jKDbg@bLSaHXKpgafS@BpijxpqOADAB\
+> eWycxHKHgNeUAmW@_qI@YhCSFxEHHqr`^MSgN@|cOokeSqMb@?WBoeaXHptl`hLSc@GdkRSZfxw\
+> pIc_gJGHEIiblHiMijc@CN[_OIGQCNOYJuWXBhERancXuuy^nSZCxis[VChZK`ddijvo]H@YLYV\
+> dPuaaohHKNCzJ@WKY]w`DOIH_GHDhzS\\TTlmQv");;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+96
+gap> D := DigraphFromDiSparse6String("\
+> .~?BZ_O?__B_SF?CE_kC_[A@[M@KP?sDACC@{M_OL`cJ`OV`GU`?T_{EA[DASCAKB_O]_GMBk?@\
+> g[b[JBSIBKHBCGA{FC{TCsDAcCAWc_WQ_OP_G`_?_`sL`_\\`W[D{IDsHBOl`?XDcFB?ja{U__g\
+> _WSC{AAWe_GQCgy_?PC_xa?w`waE{MCGuekKB{JBor`O\\ESH`?ZdxE_oXDpDb?lGcVD`B_WUDX\
+> A_OTDSSDH?_?RDCfFsPCo|cg{c_z`obFPR`gaFHQ`_wIK_ExO`O^H{HEhM`?\\Ecr_oZESDBOpH\
+> SCBGob?nHCVDpF_GUDhE_?TGh_a_jJ{idHAJkPD@@JcOCx?J[NCo~JSMFsLJCb`WaIsICGyIk_F\
+> HS`?wI[FBovL{uIKDB_tLkCBWsHxk_WYHpjhk@EHKLK?AwoHXgdxIK{THLdaWkGxcaOjK[PDPDK\
+> SODHCKKgGX_cxAJx}`geGL{`[ICXZ`GaJPx`?`NC_JC^FPVMsDBoxIpt__wIhs_W[ExrbWu_GY_\
+> ?XIKWEXOL{VEPNLqNaopHplPsTLaLa_nHaKaWmH[lHPhPSPPKODXfPCNDPFKshGpdOsgGhc`_fG\
+> aCgXaO[ICh`OScKCGCX?Jy?_waF{ECH\\NsDC?|J`|SCCBw{JX{R{BBozJQ]bhXNQ\\fHWNI[_?\
+> ZF@VNAZexUMyYbGuIhuRKWEhSMiWawsIXsQ{UIPrQsTEPPMQTa_pMIShyRaOnHpnaGmLqPdhKLi\
+> O`wkHXkP{MDXILYMU[LDPHLShHAp`WgGxgUCfPQn`GeGhePImchCPAlc`BKaFTcECXbOt@KQDTS\
+> CCH?KIhc?~KABTCAFp^OQf_G]Fh]Ss?Bg{OAdbacfPZNqbfHYNiajI`b@zSCVNREehUNI]WkTIh\
+> wWcSI`vRbBaWqIXuRZAaOpIPtRR@aGoIHsWCnI@rRA~dpNMQV`olHppQq|`gkHhoQi{`_jH`nV[\
+> JDPJLqRVSIDHILiQVKHD@HLcfQAvcpFPyu_pELIM_hDUfZ__B_o@_CE`WB_OJ_GI_CG_{EaWC_[\
+> A@k@@c?@[V`GUakFAcEaSCAKBACA@{@Bk?@g[`_Z`[I`GW`CFAof_oT_gd_cQC[AAGa_GOCK?@w\
+> _b{]`_\\ECJB_n`OZDsHBOl`?XDcFBCEAwi_gUDKTDCSf[@AOd_?Pa?bFCNCOvcGu`g_EkKBws`\
+> W]`O\\ESHB_pbWo_wYDxE_om_glGcCAwkG[BD[AAgiGK@GCRF{QFsPCsOCkNC_zfPR`gaFHQ`_`\
+> F@P`W_ExOepNbotHssHkFB`K_oqH\\IbHH_WWDxG_OVG{@Aold`DKCjGcRGX]aPAJkPGKOG@Z`w\
+> eF{MCg}JKLC_|JCKF`VcOz`O`FPT`G_IcGBww_wvIPn_o\\EpPLsDB`OLkZHxk_WrHpj_OXEPib\
+> C?H[UHSmKsSDhGKkRD`caPEaHDKSODHCKKND@BKCMNt]NkKCh?JkcFx[N[ICW}JXy`GaFhYNKGF\
+> `X_w_FXWM{EBwyIxu_g]FHUbhTMcBB_vI`r_OZEpRMS@BOtIPpbGsIHob?rI@nawqHxmaopHsTE\
+> @LLcSDxKLYKaXJLQJaOlHQIaGkHHgdXGK{NDQF`ohGqE`ggKaD`_fK[JCpa`OdGP`OSHC`@OKGJ\
+> {FCO~Jp~cG}Jh}fh[Ni___^JX{R{]FXYN[AFPX_G[FI[_?ZF@VR[YExUM{XEpTRKtIaWawsIYVa\
+> oragqQkpI@paWoHxoQ[QDxMLyQaGmHhmQKODhKLkND`JLaN`ojLYr`giHILUSKDHhPap`XFLAJ`\
+> OfGpfPQncpDKsGKiG_xBKaFTdAKYET[DCPa__`G@`Oah_W_KAg_O^JyAS{]Fi@Ss?F`\\OC[FX[\
+> NycbXZNqbbOxNkXF@{SKWExWSCuIxyR{UIpxWksIi\\WcrI`vRbBaXuRZAaPQMkPIIXa?nIAW`w\
+> mHxqQy}dhMMIUVkLD`LQkjH`nQdJQ[IDHlVKHD@HLaPVCGCxGL[FCpiUsEChELIMUkDC`DLALUf\
+> ");;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+109
+gap> D := DigraphFromDiSparse6String("\
+> .~?B]`?C`OFc?B`kbBcd@cf@si@sXeWDCswCczE{|A{~?wGgGRgWeF|E?tJBs_DtP??HC?le_xi\
+> `DipFj?kctZEozd\\LkGNGdbDT\\kxAh|BlWdlgHlwME[CapkcpAm_ompin?JeD{DD]ap[jeAAO\
+> kDpcOK@FX\\KxsN{SooKA}GE?zK[@G@Mp_@?x?fqA`?~GeO?gOA?kk{^B|CIMT?xWcpyP}ZE[TI\
+> [Ps@QNdyc@}R[He@^mLYh|xc`gNtpQ[XCgxGi^tgnNIgnMoBimbXHhYAep\\Lq\\uoYQ[YNUE_I\
+> YiDFf@zNsoG]~BPLc}EwW{OcSTUIoB@s|lV[NAG~skIFPA`PedGiIAOu[ByP[LyKpL\\lJGivJi\
+> xePSzJ{}H`zPAmuAoap]_HxYN]`gJbOTc?BcgKcKMbsjBKm?[r?kyDoqe{~?wG@|@A\\BF|KCCh\
+> iG?DlS?wXGlUAXF`czIDYBCzkGNGdbDT\\e\\fGTNlWdlgHgcA@omE[Yapkm_`mpi`wUnHHkD|J\
+> sUJeADpc_GWKxsN|XnCap?[E@H_MK?x?fpD`?fF{FB{DADfbw^geT?xNJEN`MXCU[AgUs@QOTyc\
+> AP`KoK\\_gdN_HxNLgmKXCgxGi^tgCJHxTEoBimhKDOSuJhmRk]M}uBPfQ[YNUE_IYvXFf@zNso\
+> G]~BPLc}ER|wocSPQiwq?x@lV[NAIrskyGQ|kshGhOxxFyHDNaTj`ny`\\lJGf@UcDVfX^fpKN\\
+> \qUD]nJP");;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+97
+gap> D := DigraphFromDiSparse6String("\
+> .~?B]_O?__B_S@`?E_kC_[A@[I_?H`CF_sD_cB@sA`c?@[IA{Y@CFAcE_gQ__Pc?A@{@BkLBcKB\
+> [J`SW`?VasEAge_gSCkC_WQC[AAGa_GOCK?CCp@g]eCJD{IBWm`Gl`?XDcwAwi_gUDKTDCBA_fa\
+> WeF[QCgy_?PCcOC[NCSMCK_`_^EcJBor`Oq`G[EKG_wn_om_gWDkCAwkG[BApA_OTDP@_GSDH?_\
+> ?RD?~cw}aGeFkO`wcF[MCWy`hQ`_w`W_E{IBxNbotHsGBhL_w[E[EBXJ_gYEHI__XECBB?nHCAA\
+> xFdhE_?TD`DKCSDXCJ{RDPBdHAJkPD@@JcOG@Z`{MCg}`gcFhW`_bF`V`WaF[y`KGBwwI[]ExQL\
+> {EBhPLsDEhO__ZE`NLcrHpj_OX_GWEHKLKVE@JLCnHPfdpHa_lH@dd`FKdbaGiKShG``dCMCxAJ\
+> {LCp|`_dJh{`W~J`z`ObFpZNSHCPx`?`F`X_w_J@vbwyIxuboxIptf@T_W[Exr_OZEpRMSYEhQM\
+> K?IHob?rI@nhyNhsoHhkPljPcmHXiP[QDhILIIaHHLAHhCiGxedHEKiE`ggGhcOlCKYCgXaO[IC\
+> hAKIA`GcKA@`?bG@^cP]_o`Fp\\_g|J`|SCCBw{JX{R{BNY]_O\\FPyRk@B_xNK?NAZbQYbKWEh\
+> SMkVE`RQ{UEXQQsqIHqQkSEHOMISaWoHxoQ[nHpnaHLLqPa?lHaO`xJLaNdXjPqr`hHLQLh@hPa\
+> p`WgLCICxfT{HGiHTsGChCKiGTkFC`BKak_obGPbT[aGHaOii__`G@`TKBC?~KABTC}JyAS{@Bo\
+> |Jq@_?{OAdb_zJ`~ScZFP}S[YFH|SSXF@XNa`exWNY_awuI{UIpxRrDe`TNBCa_rI`vRcRIXuRZ\
+> AaOpIPtWKPE@sRKODxOMYWV|NMQ}`olHqUVkkHhoQi{`_jH`nV[JDPJLsIDHlQQx`HHLaPVFWGx\
+> i_odGqMUkcLALUcbG`fPar_WaGXeURZgPdPQpZV]_O?__B_o@_CE_kK@[@@S?`CP?sDACC@{B@s\
+> A@k@@c?@[I`GU`?T_wS_oR_k^?WO_ONBs@@s?`cJBSIBKH`CFAof_oTCsDCkRCcBC[AAGa_K?@w\
+> _`o^bsKBgobcm`GY`?XDcFB?j_oVDSUDKCDCBC{AAWeF[@AOdFS?AGcFKOFCv`o`EsLC?t`_^Ec\
+> JE[\\b_p`?ZECYDxE_oXGkWDhC__kG[jGSAAgiGK@A_hGC?AWgaOffkOCg{c_zi[aFHQ`_`F@Pc\
+> @ObwuH{HBot`?sHlK_oZEPJbOpHTH_WnHCAAwm_GUDhEd`DKCSG`^dPBJsQDHAJkPD@@JcfG@Z`\
+> weFxY`odJKcFhW``V`WzIsICHT`G_FHS`?wI[FBovIPnbguIHmb_tLkCBWs_WYL[XEPLLS@B@KL\
+> K?AxJaonK{TKslKkRDcQDXEK[PDPDKSO`xBKCfGP^NsLCp@JsKG@\\NcJC_~J`z`ObFsHCO|JPx\
+> `?{JHw_w_F[EBxVMsDBoxIpt__\\IhsexSM\\R_GtISXE`oeXnawqHxmaopLiMahka_nH`jPcRH\
+> YJaOlPSPDcODXGKyG`wiGxeO{MGpdOtDKcKCxCOcJCpachAgH_OL^OCFCO~N{`Fp}_g_Fh|SCCF\
+> a^_W]FXYNY]bgyJLWRc?BWwIxwR[YExUMyYepTMqXb@SRCVE`RMcUIPrQsTEPPMSSe@NMARaPnQ\
+> SPDpLLqPdhKLiO`wkLcMHSLDPiUSKDHGPcJD@FLAJUCICxEKyIT{HCpeTsGChd_wcGYFTcEGPbO\
+> qj_gaGHaOii__`GACTKBC?~O[ABx^OS@Bp]OIe_?\\Ji?Sk[FX[NycbWyJ[YFHYNiaf@XNa`b?v\
+> JA_epVNQ^WstRrDagsIi\\WcrRbBePRMqZaOpRR@aHPMaXWCnMYWV{NDpNMQVVsMDhpVkLD`LMA\
+> TVcKHaSV[JDPmQYy`OhHPlVKHD@kQKGCxGLYOU{FCpFLQNUsEGphPsDC`DPkCKyKU[BPYqZ[ACH\
+> APRY");;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+111
 
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);

--- a/tst/standard/attr.tst
+++ b/tst/standard/attr.tst
@@ -2210,6 +2210,42 @@ gap> P := DigraphRemoveAllMultipleEdges(ReducedDigraph(OnDigraphs(D, proj[2])));
 gap> IsIsomorphicDigraph(H, P);
 true
 
+# DigraphMaximalMatching
+gap> D := RandomDigraph(100);;
+gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
+true
+gap> D := RandomDigraph(IsMutable, 100);;
+gap> M := DigraphMaximalMatching(D);; IsMaximalMatching(D, M);
+true
+gap> D := Digraph(IsMutable, [[2], [3], [4], [1]]);
+<mutable digraph with 4 vertices, 4 edges>
+gap> M := DigraphMaximalMatching(D);;
+gap> M = [[1, 2], [3, 4]] or M = [[2, 3], [4, 1]];
+true
+gap> D;
+<mutable digraph with 4 vertices, 4 edges>
+
+# DigraphMaximumMatching
+gap> D := RandomDigraph(100);;
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> D := DigraphFromDiSparse6String(".]cBn@kqAlt?EpclQp|M}bAgFjHkoDsIuACyCM_Hj");
+<immutable digraph with 30 vertices, 26 edges>
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+14
+gap> D := Digraph([[5, 6, 7, 8], [6, 7, 8], [7, 8], [8], [], [], [], []]);
+<immutable digraph with 8 vertices, 10 edges>
+gap> DigraphMaximumMatching(D);
+[ [ 1, 5 ], [ 2, 6 ], [ 3, 7 ], [ 4, 8 ] ]
+gap> D := Digraph(IsMutable, [[2, 3], [1, 4], [2, 4], [5], [3, 5]]);
+<mutable digraph with 5 vertices, 9 edges>
+gap> M := DigraphMaximumMatching(D);; IsMaximalMatching(D, M);
+true
+gap> Length(M);
+3
+
 #  DIGRAPHS_UnbindVariables
 gap> Unbind(adj);
 gap> Unbind(adj1);

--- a/tst/standard/oper.tst
+++ b/tst/standard/oper.tst
@@ -1739,6 +1739,16 @@ gap> edges := [[1, 1], [2, 3]];
 gap> IsMaximalMatching(gr, edges);
 true
 
+# IsMaximumMatching
+gap> D := Digraph([[1, 2], [1, 2], [2, 3, 4], [3, 5], [1]]);
+<immutable digraph with 5 vertices, 10 edges>
+gap> IsMaximumMatching(D, [[1, 2], [3, 3], [4, 5]]);
+false
+gap> IsMaximumMatching(D, [[1, 1], [2, 2], [3, 3], [4, 5]]);
+true
+gap> IsMaximumMatching(D, [[1, 1], [1, 2], [2, 2], [3, 3], [4, 5]]);
+false
+
 # DigraphShortestPath
 gap> gr := Digraph([[1], [3, 4], [5, 6], [4, 2, 3], [4, 5], [1]]);;
 gap> DigraphShortestPath(gr, 1, 6);


### PR DESCRIPTION
This PR adds the following attributes and property:  
* `DigraphMaximalMatching` - for a digraph, this attribute returns a maximal matching of the digraph.
* `DigraphMaximumMatching` - for a digraph, this attribute returns a maximum matching of the digraph.
* `IsMaximumMatching` - for a digraph, and list of pairs of vertices, returns true if the list is a valid maximum matching of the digraph and false otherwise.  

See issue #155.  

### Definitions:
A matching of a graph is a subset of the edges such that no pair of edges are incident at a vertex. A matching is *maximal* if it cannot be extended by adding an edge. A matching is *maximum* if it has maximum cardinality among all possible matchings. Note that the Digraphs package definition of matching allows the inclusion of loops in a matching.  

### Complexity: 
If what follows let `G` be a digraph with `n` vertices and `m`edges.  
`DigraphMaximalMatching` uses a greedy algorithm, which performs very fast in practice (about `O(n)`).   
`DigraphMaximumMatching`: 
* To handle loops we first matches all of the loop vertices to themselves (we can prove this is always optimal). Loops are then removed by looking at the subdigraph induced by the loopless vertices. This is done so that we could use existing algorithms for maximum matching.
* Since edge direction does not actually matter in a matching, we look at the symmetric closure of the induced graph. 
* We use a greedy matching algorithm to get an initial matching. This is a heuristic which improves most matching algorithms.
* If the induced graph is bipartite, we use the [Hopcroft-Karp algorithm](https://en.wikipedia.org/wiki/Hopcroft%E2%80%93Karp_algorithm) which runs in time `O(sqrt(n)*m)`
* Otherwise we use a general graph matching algorithm which is a derivative of the [one by Gabow](http://cobra.ee.ntu.edu.tw/~khr/khr/p221-gabow.pdf) [1]  and runs in about time `O(n*m*log(n))`, although I am not sure of the exact complexity.
* Afterwards we assemble all of the pieces together to get a final matching of the original graph, and convert it to the list of vertex pairs format that Digraphs uses.  

`IsMaximumMatching`: Here we simply compare the length of the given matching to the one given by `DigraphMaximumMatching`. So takes the same amount of time.

### Improvements:
There are many things that could be improved in the future, if the need arises, for example
#### Improving the general matching algorithm
The current general graph matching algorithm is not the best. In particular the algorithm of [Micali and Vazirani](https://ieeexplore.ieee.org/document/4567800) [2] runs in time `O(sqrt(n)*m)`, and is also faster in practice. The algorithm is also adaptive, and so would exhibit even better performance for graphs close to certain special classes of graphs, see [[3]](https://arxiv.org/pdf/1904.11244). However it is harder to implement. 
#### Improving the heuristics
Currently the only heuristic used is the greedy initial matching.  I implemented a different initial matching - the dynamic mindegree algorithm, however it has complexity `O(m)` (versus the about `O(n)` that the greedy matching does), and so only provides a performance benefit for `n>2500` or so, and makes the overall runtime slower for `n` less than that, so I decided not to include it in the final PR. Maybe worth looking into.

An outline for different heuristics is given in [[4]](https://core.ac.uk/download/pdf/84869336.pdf), [5] and [[6]](http://www.ii.uib.no/~fredrikm/fredrik/papers/JEA2010.pdf).
#### Implement the whole thing in C
The implementation doesn't really use any Gap-specific things, so implementing it in C would probably be possible and would probably make things faster.

#### Improve IsMaximumMatching
We dont actually need to compute the maximum matching of the graph to decide whether or not a given matching is maximum, we can also simply run a single phase of the algorithm to see if we could find an augmenting path. If not then the given matching is maximum, otherwise it is not. This was tricky to implement without duplicating code so I didnt.

### References:
[1] Harold N. Gabow. 1976. An Efficient Implementation of Edmonds’ Algorithm for Maximum Matching on Graphs. J. ACM 23, 2 (April 1976), 221–234. DOI: https://doi.org/10.1145/321941.321942
[2]  S. Micali and V. V. Vazirani, "An O(v|v| c |E|) algoithm for finding maximum matching in general graphs," 21st Annual Symposium on Foundations of Computer Science (sfcs 1980), Syracuse, NY, USA, 1980, pp. 17-27. doi: 10.1109/SFCS.1980.12
[3] Falko Hegerfeld, & Stefan Kratsch. (2019). On adaptive algorithms for maximum matching.  https://https://arxiv.org/abs/1904.11244
[4] Huang, M., & Stein, C. (2017). Extending Search Phases in the Micali-Vazirani Algorithm. SEA.
[5] Kececioglu, J.D., & Pecqueur, A.J. (1998). Computing Maximum-Cardinality Matchings in Sparse General Graphs. Algorithm Engineering.
[6] Johannes Langguth, Fredrik Manne, and Peter Sanders. 2010. Heuristic initialization for bipartite matching problems. J. Exp. Algorithmics 15, Article 1.3 (March 2010), 22 pages. DOI:https://doi.org/10.1145/1671970.1712656