### PR TITLE
Without intrinsics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       - ABI=64
       - GAP=stable-4.11
       - PACKAGES=required
-      - EXTRA_PKG_FLAGS="--with-external-planarity --with-external-bliss"
+      - EXTRA_PKG_FLAGS="--with-external-planarity --with-external-bliss --without-intrinsics"
       - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/miniconda3/lib
       - CFLAGS="$CFLAGS -I$HOME/miniconda3/include -O2 -g"
       - LDFLAGS="$LDFLAGS -L$HOME/miniconda3/lib"
@@ -40,7 +40,7 @@ matrix:
       - ABI=64
       - GAP=required
       - PACKAGES=required
-
+    
     - env:
       - SUITE=test
       - ABI=32

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,14 +70,12 @@ endif
 digraphs_la_CPPFLAGS =  $(GAP_CPPFLAGS)
 digraphs_la_CPPFLAGS += $(CODE_COVERAGE_CPPFLAGS)
 
-digraphs_la_CXXFLAGS =  -O3 -march=native -mpopcnt
-digraphs_la_CXXFLAGS += $(PLANAR_INCLUDE) $(DIGRAPHS_INCLUDE) 
+digraphs_la_CXXFLAGS =  $(PLANAR_INCLUDE) $(DIGRAPHS_INCLUDE) 
 digraphs_la_CXXFLAGS += $(CODE_COVERAGE_CXXFLAGS)
 digraphs_la_CXXFLAGS += $(WARNING_CXXFLAGS)
 
-digraphs_la_CFLAGS   =  -O3 -march=native -mpopcnt
-digraphs_la_CFLAGS   += $(GAP_CFLAGS) $(PLANAR_INCLUDE) $(DIGRAPHS_INCLUDE)
-digraphs_la_CFLAGS   += $(CODE_COVERAGE_CFLAGS)
+digraphs_la_CFLAGS =  $(GAP_CFLAGS) $(PLANAR_INCLUDE) $(DIGRAPHS_INCLUDE)
+digraphs_la_CFLAGS += $(CODE_COVERAGE_CFLAGS)
 digraphs_la_CFLAGS += $(WARNING_CFLAGS)
 
 digraphs_la_LDFLAGS  =  $(GAP_LDFLAGS) -module -avoid-version

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,20 @@ fi
 
 AX_CHECK_BLISS()
 
+# Check whether to use -march=native -mpopcnt and __builtin_ctzl
+AC_ARG_WITH([intrinsics],
+            [AS_HELP_STRING([--without-intrinsics], 
+                            [do not use compiler intrinsics even if available])]
+           )
+
+AS_IF([test "x$with_intrinsics" == "xno" ],
+      [AC_MSG_NOTICE([compiler intrinsics will not be used even if available])])
+
+AS_IF([test "x$with_intrinsics" != "xno"],
+      [AX_CHECK_COMPILE_FLAG(-march=native, AX_APPEND_FLAG(-march=native))
+       AX_CHECK_COMPILE_FLAG(-mpopcnt, AX_APPEND_FLAG(-mpopcnt))
+      ])
+
 dnl compiler builtins
 AC_DEFUN([CHECK_COMPILER_BUILTIN],
 [AC_MSG_CHECKING([for $1])
@@ -140,7 +154,8 @@ AC_DEFUN([CHECK_COMPILER_BUILTIN],
             [Define to 1 if the system has the `]$1[' built-in function])], []
         )])
 
-CHECK_COMPILER_BUILTIN([__builtin_ctzll],[0]);
+AS_IF([test "x$with_intrinsics" != "xno"],
+      [CHECK_COMPILER_BUILTIN([__builtin_ctzll],[0])])
 
 dnl ##
 dnl ## Output everything


### PR DESCRIPTION
This should resolve Issue #293, @isuruf I added a single flag that disables `-mpopcnt`, `-march=native` and `__builtin_ctzll`. You didn't ask for the last one but I guess it's desirable to disable it too? 