### PR TITLE
Change #include "src/compiled.h" to just "compiled.h"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ LT_INIT([disable-static dlopen win32-dll])
 dnl ##
 dnl ## Locate the GAP root dir
 dnl ##
-AC_FIND_GAP
+FIND_GAP
 
 dnl ##
 dnl ## Detect Windows resp. Cygwin

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -3,7 +3,7 @@
 # Can be configured using --with-gaproot=...
 #######################################################################
 
-AC_DEFUN([AC_FIND_GAP],
+AC_DEFUN([FIND_GAP],
 [
   AC_LANG_PUSH([C])
 
@@ -18,10 +18,9 @@ AC_DEFUN([AC_FIND_GAP],
   AC_MSG_CHECKING([for GAP root directory])
   GAPROOT="../.."
 
-  #Allow the user to specify the location of GAP
-  #
+  # Allow the user to specify the location of GAP
   AC_ARG_WITH(gaproot,
-    [AC_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
+    [AS_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
     [GAPROOT="$withval"])
 
   # Convert the path to absolute
@@ -72,65 +71,20 @@ AC_DEFUN([AC_FIND_GAP],
     AC_MSG_ERROR([Unable to find plausible GAParch information.])
   fi
 
-
-  AC_MSG_CHECKING([for GAP >= 4.9])
-  # test if this GAP >= 4.9
-  if test "x$GAP_CPPFLAGS" != x; then
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no])
-    #####################################
-    # Now check for the GAP header files
-
-    bad=0
-    AC_MSG_CHECKING([for GAP include files])
-    if test -r $GAPROOT/src/compiled.h; then
-      AC_MSG_RESULT([$GAPROOT/src/compiled.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-    AC_MSG_CHECKING([for GAP config.h])
-    if test -r $GAPROOT/bin/$GAPARCH/config.h; then
-      AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-
-    if test "x$bad" = "x1"; then
-      echo ""
-      echo "********************************************************************"
-      echo "  ERROR"
-      echo ""
-      echo "  Failed to find the GAP source header files in src/ and"
-      echo "  GAP's config.h in the architecture dependend directory"
-      echo ""
-      echo "  The kernel build process expects to find the normal GAP "
-      echo "  root directory structure as it is after building GAP itself, and"
-      echo "  in particular the files"
-      echo "      <gaproot>/sysinfo.gap"
-      echo "      <gaproot>/src/<includes>"
-      echo "  and <gaproot>/bin/<architecture>/bin/config.h."
-      echo "  Please make sure that your GAP root directory structure"
-      echo "  conforms to this layout, or give the correct GAP root using"
-      echo "  --with-gaproot=<path>"
-      echo "********************************************************************"
-      echo ""
-      AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
-    fi
-
-    ARCHPATH=$GAPROOT/bin/$GAPARCH
-    GAP_CPPFLAGS="-I$GAPROOT -iquote $GAPROOT/src -I$ARCHPATH"
-
-    AC_MSG_CHECKING([for GAP's gmp.h location])
-    if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
-      GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
-      AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
-    else
-      AC_MSG_RESULT([not found, GAP was compiled without its own GMP])
-    fi
+  # require GAP >= 4.9
+  if test "x$GAP_CPPFLAGS" = x; then
+    echo ""
+    echo "********************************************************************"
+    echo "  ERROR"
+    echo ""
+    echo "  This version of GAP is too old and not supported by this package."
+    echo "********************************************************************"
+    echo ""
+    AC_MSG_ERROR([No GAP_CPPFLAGS is given])
   fi
+
+  # compatibility with GAP 4.9 (not needed in GAP >= 4.10)
+  GAP_CPPFLAGS="$GAP_CPPFLAGS -I${GAP_LIB_DIR}/src"
 
   AC_SUBST(GAPARCH)
   AC_SUBST(GAPROOT)

--- a/scripts/travis-build-dependencies.sh
+++ b/scripts/travis-build-dependencies.sh
@@ -104,10 +104,8 @@ rm packages-required-master.tar.gz
 ################################################################################
 ## Install NautyTracesInterface in Travis
 if [ "$SETUP" == "travis" ] && [ "$NAUTY" != "no" ]; then
-  # echo -e "\nGetting master version of NautyTracesInterface"
-  # git clone -b master --depth=1 https://github.com/gap-packages/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
-  echo -e "\nGetting fixed version of NautyTracesInterface"
-  git clone -b fix-digraphs --depth=1 https://github.com/james-d-mitchell/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
+  echo -e "\nGetting master version of NautyTracesInterface"
+  git clone -b master --depth=1 https://github.com/sebasguts/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
   cd $GAPROOT/pkg/nautytraces/nauty2*r* && ./configure $PKG_FLAGS && make
   cd $GAPROOT/pkg/nautytraces && ./autogen.sh && ./configure $PKG_FLAGS && make
 fi

--- a/src/bitarray.c
+++ b/src/bitarray.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>  // for free, calloc, malloc
 
 // GAP headers
-#include "src/compiled.h"  // for Obj, ELM_LIST, ISB_LIST, Fail
+#include "compiled.h"  // for Obj, ELM_LIST, ISB_LIST, Fail
 
 // Digraphs headers
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT

--- a/src/bitarray.h
+++ b/src/bitarray.h
@@ -18,7 +18,7 @@
 #include <stdint.h>   // for uint16_t
 
 // GAP headers
-#include "src/compiled.h"  // for COUNT_TRUES_BLOCKS, Obj, . . .
+#include "compiled.h"  // for COUNT_TRUES_BLOCKS, Obj, . . .
 
 // Digraphs headers
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT

--- a/src/digraphs.h
+++ b/src/digraphs.h
@@ -16,7 +16,7 @@
 #define DIGRAPHS_SRC_DIGRAPHS_H_
 
 // GAP headers
-#include "src/compiled.h"  // for Obj, Int
+#include "compiled.h"  // for Obj, Int
 
 Int DigraphNrVertices(Obj D);
 Obj FuncOutNeighbours(Obj self, Obj D);

--- a/src/homos-graphs.c
+++ b/src/homos-graphs.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>  // for free, malloc, NULL
 
 // GAP headers
-#include "src/compiled.h"  // for Obj, Int
+#include "compiled.h"  // for Obj, Int
 
 // Digraphs headers
 #include "digraphs-config.h"  // for DIGRAPHS_WITH_INCLUDED_BLISS

--- a/src/homos.c
+++ b/src/homos.c
@@ -36,7 +36,7 @@
 #include <time.h>     // for time
 
 // GAP headers
-#include "src/compiled.h"
+#include "compiled.h"
 
 // Digraphs package headers
 #include "bitarray.h"         // for BitArray

--- a/src/homos.h
+++ b/src/homos.h
@@ -16,7 +16,7 @@
 #define MIN(a, b) (a < b ? a : b)
 
 // GAP headers
-#include "src/compiled.h"
+#include "compiled.h"
 
 Obj FuncHomomorphismDigraphsFinder(Obj self, Obj args);
 

--- a/src/perms.h
+++ b/src/perms.h
@@ -22,7 +22,7 @@
 #include "digraphs-debug.h"  // for DIGRAPHS_ASSERT
 
 // GAP headers
-#include "src/compiled.h"  // for Obj, Int
+#include "compiled.h"  // for Obj, Int
 #include "src/permutat.h"  // for ADDR_PERM, IS_PERM
 
 #define MAXVERTS 512

--- a/src/planar.h
+++ b/src/planar.h
@@ -13,7 +13,7 @@
 #define DIGRAPHS_SRC_PLANAR_H_
 
 // GAP headers
-#include "src/compiled.h"
+#include "compiled.h"
 
 Obj FuncIS_PLANAR(Obj self, Obj digraph);
 Obj FuncKURATOWSKI_PLANAR_SUBGRAPH(Obj self, Obj digraph);


### PR DESCRIPTION
This will allow future GAP versions to simplify their GAP_CPPFLAGS,
which currently need to contain `-I$(abs_srcdir)` just to support this
old use case. Also, this in turn makes it easier to have package
compatible with future installed version of GAP, which have headers in
PREFIX/include/gap/ so there is no `src` there (unless downstream
packagers jump through hoops to ensure that, e.g. by adding a special
symlink).

Note: we could also #include "gap_all.h" but that would require GAP >= 4.11.