### PR TITLE
Travis: build all branches except release candidates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ compiler:
   gcc
 
 branches:
-  only:
-  - master
-  - /^stable-\d+\.\d+/
+  except:
+    - /^rc-v\d+\.\d+\.\d+/
 
 env:
   global:


### PR DESCRIPTION
In commit https://github.com/gap-packages/Digraphs/commit/8fba7f376f235c3b9f199aaeae4623bb277690cf, the `.travis.yml` file was changed so that Travis would build only [PRs, and] commits pushed to the `master` and `stable` branches of Digraphs. I would like the effect of this change to be reversed.

@james-d-mitchell Was the purpose of commit https://github.com/gap-packages/Digraphs/commit/8fba7f376f235c3b9f199aaeae4623bb277690cf was to stop the `rc-v1.2.0` (etc) branches from being built, thereby reducing the release process time? If so, the same effect can be achieved with this PR. If there are deeper reasons, let's discuss...

_(Explanation of my motivations:)_

I work on this package (and other packages) by creating named branches on my computer, and then pushing them to my own fork. I have my Travis account set up run jobs from my fork. Only when I am happy that something is suitable and in good enough shape do I make a PR to `gap-packages/Digraphs`. I think this is a good and normal way of working.

I find it really useful having Travis run jobs on my own fork whenever I push. This lets me:
* Run the full suite of tests on things that I am not ready to share, or never intend to share.
* Avoid cluttering the `gap-packages/Digraphs` PR list and the `gap-packages` Travis queue with my experimental stuff.
* Not have to wait in the long `gap-packages` queue of Travis jobs to get the test results.
  * Since an organisation can only have (at the last time I checked) 5 concurrent jobs, and since there are many repositories in `gap-packages` that are frequently doing tests, it can take a long time to get the Travis results of something pushed to `gap-packages/Digraphs`.

However, with commit https://github.com/gap-packages/Digraphs/commit/8fba7f376f235c3b9f199aaeae4623bb277690cf, my workflow no longer works automatically. I can work around this by removing:
```
branches:
  only:
  - master
  - /^stable-\d+\.\d+/
```
from `.travis.yml` every time I make a new branch, or by adding the name of my current branch to that list, and undoing that when I make the PR. (Or, give up on running jobs on my fork, and instead make PRs immediately.) But I don't think this should be necessary.