### PR TITLE
travis: fix NautyTracesInterface

### DIFF
--- a/scripts/travis-build-dependencies.sh
+++ b/scripts/travis-build-dependencies.sh
@@ -104,8 +104,10 @@ rm packages-required-master.tar.gz
 ################################################################################
 ## Install NautyTracesInterface in Travis
 if [ "$SETUP" == "travis" ] && [ "$NAUTY" != "no" ]; then
-  echo -e "\nGetting master version of NautyTracesInterface"
-  git clone -b master --depth=1 https://github.com/sebasguts/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
+  # echo -e "\nGetting master version of NautyTracesInterface"
+  # git clone -b master --depth=1 https://github.com/gap-packages/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
+  echo -e "\nGetting fixed version of NautyTracesInterface"
+  git clone -b fix-digraphs --depth=1 https://github.com/james-d-mitchell/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
   cd $GAPROOT/pkg/nautytraces/nauty2*r* && ./configure $PKG_FLAGS && make
   cd $GAPROOT/pkg/nautytraces && ./autogen.sh && ./configure $PKG_FLAGS && make
 fi


### PR DESCRIPTION
Use a temporary version of NautyTracesInterface because the upstream is currently broken. 
See: 

https://github.com/gap-packages/NautyTracesInterface/pull/34
https://github.com/gap-packages/Digraphs/pull/308
https://github.com/gap-packages/NautyTracesInterface/issues/33


