### PR TITLE
Travis: skip extreme tests for job with external bliss/planarity and without intrinsics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
       - ABI=64
       - GAP=stable-4.11
       - PACKAGES=required
+      - EXTREME=no
       - EXTRA_PKG_FLAGS="--with-external-planarity --with-external-bliss --without-intrinsics"
       - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/miniconda3/lib
       - CFLAGS="$CFLAGS -I$HOME/miniconda3/include -O2 -g"
@@ -47,7 +48,7 @@ jobs:
       - ABI=64
       - GAP=required
       - PACKAGES=required
-    
+
     - env:
       - SUITE=test
       - ABI=32

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,6 @@ jobs:
     - env:
       - SUITE=test
       - ABI=64
-      - GAP=stable-4.11
-      - PACKAGES=required
-      - EXTREME=no
-      - EXTRA_PKG_FLAGS="--with-external-planarity --with-external-bliss --without-intrinsics"
-      - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/miniconda3/lib
-      - CFLAGS="$CFLAGS -I$HOME/miniconda3/include -O2 -g"
-      - LDFLAGS="$LDFLAGS -L$HOME/miniconda3/lib"
-
-    - env:
-      - SUITE=test
-      - ABI=64
       - GAP=required
       - PACKAGES=required
 
@@ -76,6 +65,17 @@ jobs:
       addons:
         apt_packages:
           - g++-multilib
+
+    - env:
+      - SUITE=test
+      - ABI=64
+      - GAP=stable-4.11
+      - PACKAGES=required
+      - EXTREME=no
+      - EXTRA_PKG_FLAGS="--with-external-planarity --with-external-bliss --without-intrinsics"
+      - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/miniconda3/lib
+      - CFLAGS="$CFLAGS -I$HOME/miniconda3/include -O2 -g"
+      - LDFLAGS="$LDFLAGS -L$HOME/miniconda3/lib"
 
     - env:
       - SUITE=test

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -47,9 +47,15 @@ elif [ "$SUITE" == "test" ]; then
   echo "Test(\"load-workspace.tst\"); DigraphsTestInstall(); quit; quit; quit;" |
     $GAPSH -L test-output.w -A -x 80 -r -m 768m -o $MEM -T 2>&1 | tee -a $TESTLOG
 
-  echo -e "\nRunning Digraphs package tests and manual examples..."
-  echo "LoadPackage(\"digraphs\"); DigraphsTestAll(); DigraphsTestExtreme();" |
+  echo -e "\nRunning Digraphs package standard tests and manual examples..."
+  echo "LoadPackage(\"digraphs\"); DigraphsTestAll();" |
     $GAPSH -A -x 80 -r -m 768m -o $MEM -T 2>&1 | tee -a $TESTLOG
+
+  if [ ! "$EXTREME" == "no" ]; then
+    echo -e "\nRunning Digraphs package extreme tests..."
+    echo "LoadPackage(\"digraphs\"); DigraphsTestExtreme();" |
+      $GAPSH -A -x 80 -r -m 768m -o $MEM -T 2>&1 | tee -a $TESTLOG
+  fi
 fi
 
 echo -e "\nSuite complete." # AppVeyor needs some extra command here (like this)


### PR DESCRIPTION
See #316. The job takes unreasonably long as-is. I think it's reasonable to just run the standard tests, since the main purpose of that job is to make sure that Digraphs actually runs with all of those options.

Fixes #316.