### PR TITLE
Improve performance of CopyDigraph

### DIFF
--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -14,6 +14,7 @@ DeclareCategory("IsDigraphWithAdjacencyFunction", IsDigraph);
 DeclareCategory("IsCayleyDigraph", IsDigraph);
 DeclareCategory("IsImmutableDigraph", IsDigraph);
 DeclareSynonym("IsMutableDigraph", IsDigraph and IsMutable);
+DeclareFilter("IsNotDefaultEdgeLabelled", IsDigraph);
 
 DeclareAttribute("DigraphMutabilityFilter", IsDigraph);
 

--- a/gap/digraph.gd
+++ b/gap/digraph.gd
@@ -14,7 +14,6 @@ DeclareCategory("IsDigraphWithAdjacencyFunction", IsDigraph);
 DeclareCategory("IsCayleyDigraph", IsDigraph);
 DeclareCategory("IsImmutableDigraph", IsDigraph);
 DeclareSynonym("IsMutableDigraph", IsDigraph and IsMutable);
-DeclareFilter("IsNotDefaultEdgeLabelled", IsDigraph);
 
 DeclareAttribute("DigraphMutabilityFilter", IsDigraph);
 

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -137,7 +137,9 @@ function(D)
   local copy;
   copy := ConvertToMutableDigraphNC(OutNeighboursMutableCopy(D));
   SetDigraphVertexLabels(copy, StructuralCopy(DigraphVertexLabels(D)));
-  SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
+  if IsNotDefaultEdgeLabelled(D) = true then
+    SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
+  fi;
   return copy;
 end);
 
@@ -147,7 +149,9 @@ function(D)
   local copy;
   copy := ConvertToImmutableDigraphNC(OutNeighboursMutableCopy(D));
   SetDigraphVertexLabels(copy, StructuralCopy(DigraphVertexLabels(D)));
-  SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
+  if IsNotDefaultEdgeLabelled(D) = true then
+    SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
+  fi;
   return copy;
 end);
 

--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -137,7 +137,7 @@ function(D)
   local copy;
   copy := ConvertToMutableDigraphNC(OutNeighboursMutableCopy(D));
   SetDigraphVertexLabels(copy, StructuralCopy(DigraphVertexLabels(D)));
-  if IsNotDefaultEdgeLabelled(D) = true then
+  if HaveEdgeLabelsBeenAssigned(D) then
     SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
   fi;
   return copy;
@@ -149,7 +149,7 @@ function(D)
   local copy;
   copy := ConvertToImmutableDigraphNC(OutNeighboursMutableCopy(D));
   SetDigraphVertexLabels(copy, StructuralCopy(DigraphVertexLabels(D)));
-  if IsNotDefaultEdgeLabelled(D) = true then
+  if HaveEdgeLabelsBeenAssigned(D) then
     SetDigraphEdgeLabelsNC(copy, StructuralCopy(DigraphEdgeLabelsNC(D)));
   fi;
   return copy;

--- a/gap/labels.gd
+++ b/gap/labels.gd
@@ -29,6 +29,7 @@ DeclareOperation("ClearDigraphVertexLabels", [IsDigraph]);
 DeclareOperation("DigraphEdgeLabel", [IsDigraph, IsPosInt, IsPosInt]);
 DeclareOperation("DigraphEdgeLabels", [IsDigraph]);
 DeclareOperation("DigraphEdgeLabelsNC", [IsDigraph]);
+DeclareOperation("HaveEdgeLabelsBeenAssigned", [IsDigraph]);
 
 #  Set edge labels
 DeclareOperation("SetDigraphEdgeLabel",

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -189,7 +189,7 @@ end);
 InstallMethod(ClearDigraphEdgeLabels, "for a digraph", [IsDigraph],
 function(D)
   Unbind(D!.edgelabels);
-  end);
+end);
 
 InstallMethod(RemoveDigraphEdgeLabel,
 "for a digraph, positive integer, and positive integer",

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -75,6 +75,11 @@ function(D)
   Unbind(D!.vertexlabels);
 end);
 
+InstallMethod(HaveEdgeLabelsBeenAssigned, "for a digraph", [IsDigraph],
+function(D)
+  return IsBound(D!.edgelabels);
+end);
+
 InstallMethod(SetDigraphEdgeLabel,
 "for a digraph, a pos int, a pos int, and an object",
 [IsDigraph, IsPosInt, IsPosInt, IsObject],
@@ -96,7 +101,6 @@ function(D, v, w, label)
     D!.edgelabels[v] := ListWithIdenticalEntries(Length(list), 1);
   fi;
   D!.edgelabels[v][p] := ShallowCopy(label);
-  SetFilterObj(D, IsNotDefaultEdgeLabelled);
 end);
 
 InstallMethod(DigraphEdgeLabel, "for a digraph, a pos int, and a pos int",
@@ -162,8 +166,7 @@ function(D, labels)
                   "the digraph <D> that is the 1st argument,");
   fi;
   SetDigraphEdgeLabelsNC(D, labels);
-  SetFilterObj(D, IsNotDefaultEdgeLabelled);
-end);
+  end);
 
 InstallMethod(SetDigraphEdgeLabels, "for a digraph, and a function",
 [IsDigraph, IsFunction],
@@ -181,14 +184,12 @@ function(D, f)
       D!.edgelabels[i][j] := f(i, adj[i][j]);
     od;
   od;
-  SetFilterObj(D, IsNotDefaultEdgeLabelled);
-end);
+  end);
 
 InstallMethod(ClearDigraphEdgeLabels, "for a digraph", [IsDigraph],
 function(D)
   Unbind(D!.edgelabels);
-  ResetFilterObj(D, IsNotDefaultEdgeLabelled);
-end);
+  end);
 
 InstallMethod(RemoveDigraphEdgeLabel,
 "for a digraph, positive integer, and positive integer",

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -166,7 +166,7 @@ function(D, labels)
                   "the digraph <D> that is the 1st argument,");
   fi;
   SetDigraphEdgeLabelsNC(D, labels);
-  end);
+end);
 
 InstallMethod(SetDigraphEdgeLabels, "for a digraph, and a function",
 [IsDigraph, IsFunction],

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -184,7 +184,7 @@ function(D, f)
       D!.edgelabels[i][j] := f(i, adj[i][j]);
     od;
   od;
-  end);
+end);
 
 InstallMethod(ClearDigraphEdgeLabels, "for a digraph", [IsDigraph],
 function(D)

--- a/gap/labels.gi
+++ b/gap/labels.gi
@@ -96,6 +96,7 @@ function(D, v, w, label)
     D!.edgelabels[v] := ListWithIdenticalEntries(Length(list), 1);
   fi;
   D!.edgelabels[v][p] := ShallowCopy(label);
+  SetFilterObj(D, IsNotDefaultEdgeLabelled);
 end);
 
 InstallMethod(DigraphEdgeLabel, "for a digraph, a pos int, and a pos int",
@@ -161,6 +162,7 @@ function(D, labels)
                   "the digraph <D> that is the 1st argument,");
   fi;
   SetDigraphEdgeLabelsNC(D, labels);
+  SetFilterObj(D, IsNotDefaultEdgeLabelled);
 end);
 
 InstallMethod(SetDigraphEdgeLabels, "for a digraph, and a function",
@@ -179,11 +181,13 @@ function(D, f)
       D!.edgelabels[i][j] := f(i, adj[i][j]);
     od;
   od;
+  SetFilterObj(D, IsNotDefaultEdgeLabelled);
 end);
 
 InstallMethod(ClearDigraphEdgeLabels, "for a digraph", [IsDigraph],
 function(D)
   Unbind(D!.edgelabels);
+  ResetFilterObj(D, IsNotDefaultEdgeLabelled);
 end);
 
 InstallMethod(RemoveDigraphEdgeLabel,

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1031,7 +1031,7 @@ gap> String(gr2);
 "Digraph([ ])"
 gap> PrintString(gr2);
 "Digraph([ ])"
-gap> D := CycleDigraph(10 * 10^5);
+gap> D := CycleDigraph(10 * 10 ^ 5);
 <immutable cycle digraph with 1000000 vertices>
 gap> D1 := DigraphCopy(D);
 <immutable digraph with 1000000 vertices, 1000000 edges>

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1031,6 +1031,13 @@ gap> String(gr2);
 "Digraph([ ])"
 gap> PrintString(gr2);
 "Digraph([ ])"
+gap> D := CycleDigraph(10 * 10^5);
+<immutable cycle digraph with 1000000 vertices>
+gap> D1 := DigraphCopy(D);
+<immutable digraph with 1000000 vertices, 1000000 edges>
+gap> DigraphEdgeLabels(D);;
+gap> D2 := DigraphCopy(D);
+<immutable digraph with 1000000 vertices, 1000000 edges>
 
 # Tests for DigraphCopy originally located in oper.tst
 gap> gr := Digraph([[6, 1, 2, 3], [6], [2, 2, 3], [1, 1], [6, 5],

--- a/tst/standard/labels.tst
+++ b/tst/standard/labels.tst
@@ -171,6 +171,17 @@ gap> RemoveDigraphEdgeLabel(gr, 6, 1);
 gap> ClearDigraphEdgeLabels(gr);
 gap> DigraphEdgeLabel(gr, 6, 1);
 1
+gap> gr := Digraph([[2, 3], [3], [1, 5], [], [4]]);
+<immutable digraph with 5 vertices, 6 edges>
+gap> HaveEdgeLabelsBeenAssigned(gr);
+false
+gap> DigraphEdgeLabels(gr);
+[ [ 1, 1 ], [ 1 ], [ 1, 1 ], [  ], [ 1 ] ]
+gap> HaveEdgeLabelsBeenAssigned(gr);
+true
+gap> ClearDigraphEdgeLabels(gr);
+gap> HaveEdgeLabelsBeenAssigned(gr);
+false
 
 # Test errors in DigraphEdgeLabel
 gap> gr := Digraph([[2, 2], []]);


### PR DESCRIPTION
We added a filter called `IsNotDefaultEdgeLabelled` that changes to true when we set edge labels and changes back into false when we clear them, so now when we copy digraphs edges are only copied if they are not the default ones, which improves efficiency.

This addresses issue #292.