### PR TITLE
Remove two calls to RetypeBag from kernel extension

### DIFF
--- a/src/homos.c
+++ b/src/homos.c
@@ -260,10 +260,6 @@ homo_hook_collect(void* user_param, uint16_t const nr, uint16_t const* map) {
   Obj    t;
   UInt   i;
 
-  if (TNUM_OBJ((Obj) user_param) == T_PLIST_EMPTY) {
-    RetypeBag(user_param, T_PLIST);
-  }
-
   // copy map into new trans2
   t   = NEW_TRANS2(nr);
   ptr = ADDR_TRANS2(t);

--- a/src/planar.c
+++ b/src/planar.c
@@ -205,9 +205,6 @@ Obj boyers_planarity_check(Obj digraph, int flags, bool krtwsk) {
         }
         j = theGraph->E[j].link[1];
       }
-      if (nr == 0) {
-        RetypeBag(list, T_PLIST_EMPTY);
-      }
       SET_ELM_PLIST(subgraph, i, list);
       CHANGED_BAG(subgraph);
     }


### PR DESCRIPTION
Motivation: RetypeBag is a very low-level part of the GAP kernel, and kernel
extensions should ideally restrict use of it to what's really required. In
many cases, it is far better to avoid it, and instead use higher-level APIs
such as ASS_LIST to edit lists, instead of relying on the unsafe low-level API
SET_ELM_PLIST combined with RetypeBag.

However, in the two cases at hand, calling RetypeBag simply is unnecessary: In
the first one, the code actually uses ASS_LIST and as such any retyping is
automatically performed by the GAP kernel for us.

In the second case, an empty plist is marked as such explicitly by retyping it
to T_PLIST_EMPTY. But that's a purely optional optimization.