### PR TITLE
Update Wilf's details in PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -203,15 +203,12 @@ Persons := [
 
   rec(
     LastName      := "Wilson",
-    FirstNames    := "Wilf",
+    FirstNames    := "Wilf A.",
     IsAuthor      := true,
     IsMaintainer  := true,
     Email         := "gap@wilf-wilson.net",
-    WWWHome       := "http://wilf.me",
-    PostalAddress := Concatenation(["Theodor-Lieser-Straße 5, ",
-                                    "06120 Halle (Saale), Germany"]),
-    Place         := "Halle (Saale), Germany",
-    Institution   := "University of Halle-Wittenberg")],
+    WWWHome       := "https://wilf.me",
+  )],
 
 Status := "deposited",
 


### PR DESCRIPTION
My location details were out of date. I prefer to leave them out now, rather than update them. I also prefer to be credited with my middle initial.