### PR TITLE
Don't say "strongly connected" in the ViewString of symmetric digraphs

### DIFF
--- a/gap/digraph.gi
+++ b/gap/digraph.gi
@@ -487,13 +487,15 @@ function(D)
       fi;
       if HasIsStronglyConnectedDigraph(D) and IsStronglyConnectedDigraph(D)
           and not (HasIsEulerianDigraph(D) and IsEulerianDigraph(D))
-          and not (HasIsHamiltonianDigraph(D) and IsHamiltonianDigraph(D)) then
+          and not (HasIsHamiltonianDigraph(D) and IsHamiltonianDigraph(D))
+          and not (HasIsSymmetricDigraph(D) and IsSymmetricDigraph(D)) then
         Append(str, "strongly connected ");
       fi;
       if HasIsBiconnectedDigraph(D) and IsBiconnectedDigraph(D) then
         Append(str, "biconnected ");
-      elif not (HasIsStronglyConnectedDigraph(D) and
-                IsStronglyConnectedDigraph(D))
+      elif ((HasIsSymmetricDigraph(D) and IsSymmetricDigraph(D))
+            or not (HasIsStronglyConnectedDigraph(D)
+                    and IsStronglyConnectedDigraph(D)))
           and not (HasIsTournament(D) and IsTournament(D))
           and HasIsConnectedDigraph(D) and IsConnectedDigraph(D) then
         Append(str, "connected ");

--- a/tst/standard/digraph.tst
+++ b/tst/standard/digraph.tst
@@ -1642,6 +1642,14 @@ gap> D := Digraph([[2], [1]]);;
 gap> IsHamiltonianDigraph(D);;
 gap> D;
 <immutable Hamiltonian digraph with 2 vertices, 2 edges>
+gap> D := Digraph([[2], [1, 3], [2]]);;
+gap> IsSymmetricDigraph(D);;
+gap> D;
+<immutable symmetric digraph with 3 vertices, 4 edges>
+gap> IsStronglyConnectedDigraph(D);
+true
+gap> D;
+<immutable connected symmetric digraph with 3 vertices, 4 edges>
 
 # String
 gap> D := CycleDigraph(3);


### PR DESCRIPTION
Since symmetric digraphs are connected if and only if they are strongly connected, saying 'strongly' is unnecessary. We may as well not be unnecessarily verbose if we can help it.