### PR TITLE
Update the URL for the main NautyTracesInterface repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,7 +460,7 @@ The principal change in Digraphs version 0.11.0 is the addition of
 support for computing automorphisms, canonical labellings, and isomorphisms of
 digraphs with [nauty](http://pallini.di.uniroma1.it/). This
 functionality requires the [NautyTracesInterface
-package](https://github.com/sebasguts/NautyTracesInterface) for GAP, version 0.2
+package](https://github.com/gap-packages/NautyTracesInterface) for GAP, version 0.2
 or newer. However, this is not a required package, and the default engine
 remains [bliss](http://www.tcs.hut.fi/Software/bliss/). It is possible to
 specify the engine that is used by Digraphs. These changes to Digraphs were made

--- a/scripts/travis-build-dependencies.sh
+++ b/scripts/travis-build-dependencies.sh
@@ -105,7 +105,7 @@ rm packages-required-master.tar.gz
 ## Install NautyTracesInterface in Travis
 if [ "$SETUP" == "travis" ] && [ "$NAUTY" != "no" ]; then
   echo -e "\nGetting master version of NautyTracesInterface"
-  git clone -b master --depth=1 https://github.com/sebasguts/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
+  git clone -b master --depth=1 https://github.com/gap-packages/NautyTracesInterface.git $GAPROOT/pkg/nautytraces
   cd $GAPROOT/pkg/nautytraces/nauty2*r* && ./configure $PKG_FLAGS && make
   cd $GAPROOT/pkg/nautytraces && ./autogen.sh && ./configure $PKG_FLAGS && make
 fi


### PR DESCRIPTION
Although the old link redirects to the current one, I think it makes sense to actually use the current one.